### PR TITLE
[fix]暂时移除出生点平台的生成

### DIFF
--- a/kubejs/data/createdelight/functions/tick.mcfunction
+++ b/kubejs/data/createdelight/functions/tick.mcfunction
@@ -1,2 +1,2 @@
 # 初始平台
-execute as @p at @s unless data storage spawn_create spawnpoint_structure run function createdelight:set_spawn_platform
+# execute as @p at @s unless data storage spawn_create spawnpoint_structure run function createdelight:set_spawn_platform


### PR DESCRIPTION
服务器和客户端创建世界均存在生成出生点平台100%失败的反馈，暂时移除这个功能回炉