### PR TITLE
[fix]回滚初始窗口大小改动

### DIFF
--- a/config/fml.toml
+++ b/config/fml.toml
@@ -1,5 +1,5 @@
 #Early window height
-earlyWindowHeight = 1080
+earlyWindowHeight = 480
 #Enable forge global version checking
 versionCheck = false
 #Should we control the window. Disabling this disables new GL features and can be bad for mods that rely on them.
@@ -9,7 +9,7 @@ earlyWindowFBScale = 1
 #Early window provider
 earlyWindowProvider = "fmlearlywindow"
 #Early window width
-earlyWindowWidth = 1920
+earlyWindowWidth = 854
 #Early window starts maximized
 earlyWindowMaximized = false
 #Default config path for servers


### PR DESCRIPTION
这个改动会导致使用2K & 1080p双屏的玩家在2K的大屏上无法全屏窗口化。