### PR TITLE
[config]调整石油区块生成比例

### DIFF
--- a/defaultconfigs/createdieselgenerators-server.toml
+++ b/defaultconfigs/createdieselgenerators-server.toml
@@ -27,7 +27,7 @@
 		"Normal oil chunks oil amount multiplier" = 1.0
 		"High oil chunks oil amount multiplier" = 3.0
 		"Max Oil Scanner Level" = 10000
-		"Infinite oil chunk threshold" = 2000000
-		"Oil chunk threshold" = 2000000
+		"Infinite oil chunk threshold" = 3000000
+		"Oil chunk threshold" = 3000000
 		"Oil chunk map scale" = 1.0
 

--- a/defaultconfigs/createdieselgenerators-server.toml
+++ b/defaultconfigs/createdieselgenerators-server.toml
@@ -2,16 +2,8 @@
 ["Server Configs"]
 	#Maximum width of Oil Barrels
 	"Max Oil Barrel Width" = 3
-	#Canister Capacity in mB
-	"Capacity of Canisters" = 4000
-	#Canister Capacity Enchantment Capacity Addition in mB
-	"Capacity Addition of Capacity Enchantment in Canisters" = 1000
 	#Canister can be filled by spouts
 	"Canister can be filled by spouts" = true
-	#Capacity of Tools requiring Fluids in mB
-	"Capacity of Tools requiring Fluids" = 200
-	#Tool Capacity Enchantment Capacity Addition in mB
-	"Capacity Addition of Tools with Capacity Enchantment" = 10
 	#Combustibles do boom boom when on fire
 	"Combustibles blow up" = true
 
@@ -27,28 +19,15 @@
 		#Whenever Huge Diesel Engines are enabled
 		"Huge Diesel Engines" = true
 		#Whenever Diesel Engines can be filled with an Item
-		"Engines can be filled with a bucket" = true
+		"Engines filled with a bucket" = false
+		#Whenever Diesel Engines can be disabled with redstone
+		"Engines disabled with redstone" = true
 
 	["Server Configs"."Oil Config"]
-		#Whenever crude oil deposits are infinite
-		"Infinite oil deposits" = true
-		#Normal oil chunks oil amount multiplier
 		"Normal oil chunks oil amount multiplier" = 1.0
-		#High oil chunks oil amount multiplier
 		"High oil chunks oil amount multiplier" = 3.0
-		#Max Oil Scanner Level
 		"Max Oil Scanner Level" = 10000
-		#Normal oil chunks percentage
-		#Range: 0.0 ~ 100.0
-		"Normal oil chunks percentage" = 30.0
-		#High oil chunks percentage
-		#Range: 0.0 ~ 100.0
-		"High oil chunks percentage" = 10.0
-
-		["Server Configs"."Oil Config".Distillation]
-			#Whenever wide Distillation Towers go faster than the thin ones
-			"Wide Distillation Tower Distill Faster" = true
-			#Height of Distillation Tower level
-			#Range: 1 ~ 3
-			"Height of Distillation Tower level" = 1
+		"Infinite oil chunk threshold" = 2000000
+		"Oil chunk threshold" = 2000000
+		"Oil chunk map scale" = 1.0
 


### PR DESCRIPTION
柴油动力mod修改了石油区块的生成方式，并删除了旧的石油区块配置项，导致更新mod版本后石油区块变得很少见&多为贫油。

先对齐最新配置文件，并修改配置项，让所有石油区块都是无限 & 提高石油区块比例。

柴油动力石油生成修改思路相关issue：https://github.com/george8188625/Create-Diesel-Generators/issues/86

柴油动力石油区块判断逻辑代码： https://github.com/george8188625/Create-Diesel-Generators/blob/1.20.1/src/main/java/com/jesz/createdieselgenerators/world/OilChunksSavedData.java#L136