### PR TITLE
[fix]修复使用安山桶/罐子向烈焰人燃烧室输入液体燃料时容器被吞的bug

### DIFF
--- a/kubejs/server_scripts/Create Fluid Stuffs/bug_fix.js
+++ b/kubejs/server_scripts/Create Fluid Stuffs/bug_fix.js
@@ -1,0 +1,6 @@
+BlockEvents.rightClicked("create:blaze_burner", e => {
+    const {player, item} = e;
+    if (player == null) return;
+    if ((Ingredient.of("createfluidstuffs:bucket").test(item) || Ingredient.of("createfluidstuffs:jar").test(item))
+      && !e.player.shiftKeyDown) e.cancel();
+})


### PR DESCRIPTION
见我打开的Issue #890 
之前的pull request文件放错位置了，请忽略