### PR TITLE
[fix] 解决玫瑰石英配方冲突

### DIFF
--- a/kubejs/server_scripts/Create/recipes.js
+++ b/kubejs/server_scripts/Create/recipes.js
@@ -187,15 +187,15 @@ ServerEvents.recipes(e => {
     e.remove({ type: 'minecraft:stonecutting', output: 'create:rose_quartz_block', input: 'create:rose_quartz' })
     e.remove({ type: 'minecraft:stonecutting', output: 'create:rose_quartz_tiles', input: 'create:polished_rose_quartz' })
     e.remove({ type: 'minecraft:stonecutting', output: 'create:small_rose_quartz_tiles', input: 'create:polished_rose_quartz' })
-    // 玫瑰石英块/砖 4合1配方
-    e.shaped('create:rose_quartz_block', [
+    // 玫瑰石英块/砖
+    e.shaped('8x create:rose_quartz_block', [
         'AA',
         'AA'
     ], {
         A: 'create:rose_quartz'
     }).id('create:crafting/rose_quartz_block')
     
-    e.shaped('create:rose_quartz_tiles', [
+    e.shaped('8x create:rose_quartz_tiles', [
         'AA',
         'AA'
     ], {


### PR DESCRIPTION
Added new recipes for rose quartz and removed conflicting stonecutting recipes.

整合包魔改：玫瑰石英可以使用切割机切割成1个磨制玫瑰石英

但问题在于，机械动力原版有一个切石配方 `1玫瑰石英->2玫瑰石英块` 切石机同时还会被注册到切割机，于是**发生冲突**，切割时会轮流使用配方，产出不稳定！

解决方案：

- 删除玫瑰石英切石配方
- 添加工作台配方 `4玫瑰石英->1玫瑰石英块` 

为了保证一致性（四合一）：

- 删除磨制玫瑰石英切石配方
- 添加工作台配方 `4磨制玫瑰石英->1磨制玫瑰石英砖块` 