### PR TITLE
[fix]修改由原木生产木屑的粉碎配方

### DIFF
--- a/kubejs/server_scripts/Create Diesel Generators/recipes.js
+++ b/kubejs/server_scripts/Create Diesel Generators/recipes.js
@@ -30,7 +30,14 @@ ServerEvents.recipes(e => {
   create.crushing(["31x createdieselgenerators:wood_chip",
       Item.of("createdieselgenerators:wood_chip", 1).withChance(0.5),
       Item.of("farmersdelight:tree_bark", 1).withChance(0.75)],
-  "#minecraft:logs")
+  Ingredient.of(['#minecraft:logs', 
+      'iceandfire:dreadwood_log', 
+      'netherexp:cerebrage_claret_stem'])
+    .subtract(['/.*_wood.*/', 
+      '/.*stripped_.*/', 
+      '/.*_hyphae.*/', 
+      'cosmopolitan:sappy_birch_log', 
+      'vintagedelight:magic_vine_block']))
   .id("createdieselgenerators:crushing/wood_chip_logs/with_bark")
   e.replaceInput({ mod: "createdieselgenerators", not: "createdieselgenerators:crafting/basin_lid" }, "create:andesite_alloy", "#forge:ingots/steel")
   e.replaceInput({ id: "createdieselgenerators:crafting/basin_lid" }, "create:andesite_alloy", "createdeco:industrial_iron_ingot")


### PR DESCRIPTION
修改由原木生产木屑的粉碎配方，使作为原料的“原木”不包含[去皮原木](https://zh.minecraft.wiki/w/%E5%8E%BB%E7%9A%AE%E5%8E%9F%E6%9C%A8)、[木头](https://zh.minecraft.wiki/w/%E6%9C%A8%E5%A4%B4)等树皮产出数量不匹配的物品