### PR TITLE
[fix]将矿物钻井合成配方中的蒸汽引擎换为热力引擎

### DIFF
--- a/kubejs/server_scripts/Create Ore/recipes.js
+++ b/kubejs/server_scripts/Create Ore/recipes.js
@@ -37,7 +37,7 @@ ServerEvents.recipes(e => {
         D: "create:electron_tube",
         E: "create:spout",
         F: "create:brass_casing",
-        G: "create_sa:steam_engine",
+        G: "create_sa:heat_engine",
         H: "create:mechanical_drill",
         I: "create:sturdy_sheet",
         J: "create:brass_tunnel"


### PR DESCRIPTION
将矿物钻井合成配方中的蒸汽引擎换为热力引擎，以实现[commit #1422](https://github.com/Jasons-impart/Create-Delight-Remake/commit/e795a8122fa2717e92df47005a4f57b2bb211992)的部分需求