### PR TITLE
[fix]配方修改

### DIFF
--- a/config/jei/blacklist.cfg
+++ b/config/jei/blacklist.cfg
@@ -75,3 +75,4 @@ fluid:createcafe:passionfruit_tea
 fluid:farmersrespite:strong_coffee
 fluid:ratatouille:compost_tea
 fluid:create_central_kitchen:chocolate_ice_cream
+fluid:create_fantasizing:powder_snow

--- a/kubejs/server_scripts/Create Fantasizing/recipe.js
+++ b/kubejs/server_scripts/Create Fantasizing/recipe.js
@@ -6,8 +6,14 @@ ServerEvents.recipes(e => {
         "create_fantasizing:compact_wind_engine",
         "create_fantasizing:sturdy_conduit",
         "create_fantasizing:sturdy_heavy_core",
-        "create_fantasizing:block_placer" //太卡了
+        "create_fantasizing:compacting/powder_snow_to_block",
+        "create_fantasizing:mixing/powder_snow",
+        "create_fantasizing:block_placer"//太卡了
     ])
+    create.emptying([Fluid.of("fluid:powder_snow"), "minecraft:bucket"], 
+        "minecraft:powder_snow_bucket")
+        .id("create:empty_minecraft_powder_snow_bucket_of_create_fantasizing_powder_snow")
+        //此处id是为了同名覆盖机械动力原版的硬编码id，后续维护namespace时不要动它
     kubejs.shaped("create_fantasizing:sturdy_conduit", [
         "A",
         "B",

--- a/kubejs/server_scripts/Create Fluid/recipe.js
+++ b/kubejs/server_scripts/Create Fluid/recipe.js
@@ -4,7 +4,8 @@ ServerEvents.recipes(e => {
     e.replaceInput({id: "fluid:mechanical_pipette"}, "create:precision_mechanism", "create_sa:hydraulic_engine")
     remove_recipes_id(e, [
         "fluid:mechanical_pipette",
-        "fluid:copper_tap"
+        "fluid:copper_tap",
+        "fluid:copper_sink"
     ])
     kubejs.shaped("2x fluid:copper_tap", [
         " A ",
@@ -27,4 +28,13 @@ ServerEvents.recipes(e => {
         D: "create_sa:hydraulic_engine",
         E: "create:brass_casing"
     }).id("createdelight:mechanical_pipette")
+    kubejs.shaped("fluid:copper_sink", [
+        " A ",
+        "BBB",
+        " A "
+    ], {
+        A: "create:copper_sheet",
+        B: "minecraft:water_bucket"
+    }).replaceIngredient("minecraft:water_bucket", "minecraft:bucket")
+    .id("createdelight:copper_sink")
 })

--- a/kubejs/server_scripts/Create Ore/recipes.js
+++ b/kubejs/server_scripts/Create Ore/recipes.js
@@ -37,7 +37,7 @@ ServerEvents.recipes(e => {
         D: "create:electron_tube",
         E: "create:spout",
         F: "create:brass_casing",
-        G: "create_sa:steam_engine",
+        G: "create_sa:heat_engine",
         H: "create:mechanical_drill",
         I: "create:sturdy_sheet",
         J: "create:brass_tunnel"

--- a/kubejs/server_scripts/Create/recipes.js
+++ b/kubejs/server_scripts/Create/recipes.js
@@ -22,6 +22,11 @@ ServerEvents.recipes(e => {
         "create:crafting/logistics/package_frogport",
         "create:crafting/materials/transmitter",
         "create:crafting/logistics/stock_link",
+        "create:sequenced_assembly/precision_mechanism",
+        "create_new_age:cutting/copper_wire",
+        "/^create:crushing\/raw_[A-Za-z0-9]+$/",
+        "create:compacting/blaze_cake",
+        "createutilities:sandpaper_polishing/polished_amethyst"
     ])
     remove_recipes_output(e, [
         "create:pulp",


### PR DESCRIPTION
- 将矿物钻井合成配方中的蒸汽引擎换为热力引擎，以实现[commit #1422](https://github.com/Jasons-impart/Create-Delight-Remake/commit/e795a8122fa2717e92df47005a4f57b2bb211992)的部分需求；
- 隐藏[又在幻想了](https://www.mcmod.cn/class/20562.html)的细雪流体，保留[流体](https://www.mcmod.cn/class/22109.html)的细雪
- 修改铜水槽的配方
- 移除一些模组的原版配方（如精密构件）及重复的配方（粗矿物的粉碎处理）