### PR TITLE
[fix]修复部分无限流体标签

### DIFF
--- a/kubejs/server_scripts/Create/tags.js
+++ b/kubejs/server_scripts/Create/tags.js
@@ -14,13 +14,17 @@ ServerEvents.tags("minecraft:item", e => {
 })
 
 ServerEvents.tags("minecraft:fluid", e => {
+    e.remove("create:bottomless/deny", [
+        "/.*molten_.*/"
+    ])
     e.add("create:bottomless/allow", [
         "ratatouille:cocoa_liquor",
         "createdelight:egg_yolk",
         "create:honey",
         "createdelight:vinegar",
-        "#forge:molten_materials",
+        "/.*molten_.*/",
         "netherexp:ectoplasm",
-        "the_bumblezone:sugar_water_still"
+        "the_bumblezone:sugar_water_still",
+        "minecraft:lava"
     ])
 })


### PR DESCRIPTION
- 为熔岩重新添加#create:bottomless/allow标签
- 为各种熔融材料删去deny标签，加入allow标签