### PR TITLE
[fix]删除电气时代中钍的多余增值配方

### DIFF
--- a/kubejs/server_scripts/Create/recipes.js
+++ b/kubejs/server_scripts/Create/recipes.js
@@ -26,7 +26,8 @@ ServerEvents.recipes(e => {
         "create_new_age:cutting/copper_wire",
         "/^create:crushing\/raw_[A-Za-z0-9]+$/",
         "create:compacting/blaze_cake",
-        "createutilities:sandpaper_polishing/polished_amethyst"
+        "createutilities:sandpaper_polishing/polished_amethyst",
+        "create_new_age:mixing/thorium"
     ])
     remove_recipes_output(e, [
         "create:pulp",


### PR DESCRIPTION
删除了[电气时代](https://www.mcmod.cn/class/11918.html)中钍的增殖配方