### PR TITLE
[recipe]更新配方和jei黑名单，移除冗余配方

### DIFF
--- a/config/jei/blacklist.cfg
+++ b/config/jei/blacklist.cfg
@@ -76,3 +76,7 @@ fluid:farmersrespite:strong_coffee
 fluid:ratatouille:compost_tea
 fluid:create_central_kitchen:chocolate_ice_cream
 fluid:create_fantasizing:powder_snow
+northstar:brine_bucket
+fluid:northstar:brine
+northstar:sulfuric_acid_bucket
+fluid:northstar:sulfuric_acid

--- a/kubejs/server_scripts/Create Metallurgy/recipe.js
+++ b/kubejs/server_scripts/Create Metallurgy/recipe.js
@@ -5,6 +5,7 @@ ServerEvents.recipes(e => {
         "createmetallurgy:sequenced_assembly/industrial_crucible"
     ])
     e.replaceInput({id: "createmetallurgy:crafting/materials/tungsten_wire_spool"}, "minecraft:stick", "createaddition:spool")
+    e.replaceInput({id: "createmetallurgy:crafting/materials/graphite" }, "minecraft:coal", "#minecraft:coals")
     const { createmetallurgy, create, minecraft, vintageimprovements, kubejs } = e.recipes
     kubejs.shaped(
         'createmetallurgy:sandpaper_belt',

--- a/kubejs/server_scripts/Create New Age/energising.js
+++ b/kubejs/server_scripts/Create New Age/energising.js
@@ -79,9 +79,4 @@ ServerEvents.recipes(e => {
         .loops(1)
         .id("createdelight:shaped/reinforced_energiser")
         .transitionalItem(iner)
-    e.recipes.create_new_age.energising(
-        'createdelight:mmd_diamond',
-        'create_new_age:overcharged_diamond',
-        10000
-    ).id("createdelight:energising/mmd_diamond")
 })

--- a/kubejs/server_scripts/Create/recipes.js
+++ b/kubejs/server_scripts/Create/recipes.js
@@ -27,7 +27,8 @@ ServerEvents.recipes(e => {
         "/^create:crushing\/raw_[A-Za-z0-9]+$/",
         "create:compacting/blaze_cake",
         "createutilities:sandpaper_polishing/polished_amethyst",
-        "create_new_age:mixing/thorium"
+        "create_new_age:mixing/thorium",
+        "createaddition:crafting/large_connector_electrum"
     ])
     remove_recipes_output(e, [
         "create:pulp",


### PR DESCRIPTION
- 将石墨合成配方中的“煤炭”换为“#minecraft:coals”，以适配木炭、化石燃料等
- 在jei中隐藏北极星的硫酸、盐水及其桶
- 移除大型连接器的合成及人工钻石的充能中重复/冗余的配方