### PR TITLE
bump Complementary Shaders - Unbound version

### DIFF
--- a/shaderpacks/complementary-unbound.pw.toml
+++ b/shaderpacks/complementary-unbound.pw.toml
@@ -1,13 +1,13 @@
 name = "Complementary Shaders - Unbound"
-filename = "ComplementaryUnbound_r5.6.1.zip"
+filename = "ComplementaryUnbound_r5.7.1.zip"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "db9d5d3fab53bb896e1d727661540ecf570059a9"
+hash = "95883b516298ff4cf1a67ff512086eb67aeedd98"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7090228
+file-id = 7574260
 project-id = 385587


### PR DESCRIPTION
必要性
如若不然，它无法被使用。
似乎是 patcher 的 latest 策略，你就从了吧。

<img width="1279" height="708" alt="2026-02-24_20-48" src="https://github.com/user-attachments/assets/5ea93e95-4d2c-460f-911d-c803d5f2b3df" />
<img width="1280" height="708" alt="2026-02-24_20-49" src="https://github.com/user-attachments/assets/4070071a-ff43-42bb-bb8b-46e08e04a1a4" />

要是不从的话，备选方案有断网或配置，以及把这个光影包删掉。


数据来源
我在 Prism Launcher 中选用 curseforge 源更新后，观察
minecraft/shaderpacks/complementary-unbound.pw.toml
的变更复制粘贴而来。

可靠性
更新完后试玩暂时未炸。

<img width="2558" height="907" alt="2026-02-24_20-57" src="https://github.com/user-attachments/assets/40dd1fa9-8882-4561-8723-40a2c33875ef" />


风险
主要考虑到没有 pipeline 输出成品包的原因，我没测试过。