### PR TITLE
Fix tooltip value calculation NPE

### DIFF
--- a/kubejs/client_scripts/tool_tip.js
+++ b/kubejs/client_scripts/tool_tip.js
@@ -121,15 +121,15 @@ const $QualityConfig = Java.loadClass("de.cadentem.quality_food.config.QualityCo
 
 let difficultyLoots = global.difficultyLoots
 ItemEvents.tooltip(e => {
-    e.addAdvancedToAll((item, advanced, text) => {
+    e.addAdvancedToAll((itemStack, advanced, text) => {
         let value = 0
-        let Quality = $QualityUtils.getQuality(item)
+        let Quality = $QualityUtils.getQuality(itemStack)
         let Qlevel = Quality.level()
         let multiplier = Math.round(Math.sqrt(2 / (Qlevel != 0 ? $QualityConfig.getChance(Quality) : 1)))
 
-        let baseValue = OEV$ItemValueManager.getValue(item)
-        if (baseValue <= 0 && item.getFoodProperties(null) != null) {
-            baseValue = MoneyUtil.calculateFoodValue(item)
+        let baseValue = OEV$ItemValueManager.getValue(itemStack)
+        if (baseValue <= 0 && itemStack.getFoodProperties(null) != null) {
+            baseValue = MoneyUtil.calculateFoodValue(itemStack)
         }
 
         if (baseValue > 0) {
@@ -143,10 +143,10 @@ ItemEvents.tooltip(e => {
                     text.add(Component.translate("tooltip.createdelight.single_price", MoneyUtil.convertBaseValueToString(value)))
                 }
             } else {
-                if (value * item.count < 1) {
-                    text.add(Component.translate("tooltip.createdelight.total_price", (Math.round(value * item.count * 10) / 10).toString()).append(MoneyUtil.convertBaseValueToString(-1)))
+                if (value * itemStack.count < 1) {
+                    text.add(Component.translate("tooltip.createdelight.total_price", (Math.round(value * itemStack.count * 10) / 10).toString()).append(MoneyUtil.convertBaseValueToString(-1)))
                 } else {
-                    text.add(Component.translate("tooltip.createdelight.total_price", MoneyUtil.convertBaseValueToString(value * item.count)))
+                    text.add(Component.translate("tooltip.createdelight.total_price", MoneyUtil.convertBaseValueToString(value * itemStack.count)))
                 }
             }
         }


### PR DESCRIPTION
## 问题

在 v0.4.8.0 或者我自制的 nightly 中，在任意世界中游玩都存在日志快速膨胀的问题。

分析发现有大量的 ERROR LOG，典型内容为

```
[15:19:57] [Render thread/ERROR] [KubeJS Client/]: tool_tip.js#131: Error while gathering tooltip for 1 stone_pickaxe: Can't find method net.minecraftforge.common.extensions.IForgeItemStack.getFoodProperties().
[15:19:57] [Render thread/ERROR] [KubeJS Client/]: …rhino.EvaluatorException: Can't find method net.minecraftforge.common.extensions.IForgeItemStack.getFoodProperties(). (client_scripts:tool_tip.js#131)
```

抽样显示可以有每秒53次在该行报错。主要是污染日志，性能是次要问题。

## 原因

#1407 引入，开发者在调用 `item.getFoodProperties()` 时未作方法存在检验。

这里 item 的类型只能是 ItemStack，而且不能是 Item。（分析见  [commit 9e317098](https://github.com/Jasons-impart/Create-Delight-Remake/commit/9e317098475c3ad90384e94adaf602aec2385384) 的 commit message）前者没有后者现有的 getFoodProperties 无参函数签名。 

## 测试

git apply patch 后，游玩 10min 后在 Minecraft Log 中使用 tool_tip.js 作为关键字检索无 ERROR LOG。提示处理有效。

## 风险

我想不出会更糟糕的场合。

## 杂谈

主要是开 [ProbeJS](https://kubejs.com/wiki/addons/probejs) 比较熬人。

1. `/probejs dump` 的 IO 开销极大，在 Minecraft 中执行后感觉是把 X11打死了，切 TTY 重启后把 minecraft 移入 ramfs 后克服。
2. 已不在 1.20.1 上继续更新。All we have is as it is. 上游不维护老版本了难道要我来做？
3. 文件臃肿，对 JetBrains 系 IDE 的没那么友善，我只保留约 50 MiB 的 client 侧代码会好一些。在 `*.d.ts` 那里有红字，TS2307 但按住 Ctrl 能点开，感觉是`jsconfig.json` 等项目索引指示没做好。
4. 对 JetBrains 系 IDE 的没那么友善，我只保留约 50 MiB 的 client 侧代码会好一些。在 `*.d.ts` 那里有红字，TS2307 但按住 Ctrl 能点开，感觉是`jsconfig.json` 等项目索引指示没做好。我没修好放弃了。

Afrer vs Before

<img width="2562" height="1442" alt="screenshot" src="https://github.com/user-attachments/assets/0391ee1c-2366-4498-9892-28dca0ff03ef" />

但关键还是靠用名字找 Forge 和相关 mod 的 Java 代码来敲定的。

而且实际上 ProbeJS 还给了我 item type 是 Item 或 ItemStack 的提示，一开始也没考虑到当初可能是设计一致但实现出错的情况。所以创作并验证通过了

```javascript
        let one = item.getItem ? item.getItem() : item
        if (baseValue <= 0 && one.getFoodProperties() != null) {
            baseValue = MoneyUtil.calculateFoodValue(item);
        }
```

的补丁，但按照奥卡姆剃刀原则，只要明确类型单一，显然是现在的版本更好。