### PR TITLE
[fix]暂时禁用懒惰刻分液池优化以修复分液基因种子的问题

### DIFF
--- a/config/createlazytick-common.toml
+++ b/config/createlazytick-common.toml
@@ -70,7 +70,8 @@
 	#
 	#--------------------------------------------------------------------------
 	#Whether to enable item drain lazy tick
-	enable_lazy_item_drain = true
+	#DISABLED by CDC fix - 基因种子跳级问题修复
+	enable_lazy_item_drain = false
 	#
 	#--------------------------------------------------------------------------
 	#max delay tick if something stuck on the item drain


### PR DESCRIPTION
[相关问题](https://github.com/duckgun13476/Create-LazyTick/issues/21)