### PR TITLE
fix: 修复 recipe_card 序列组装配方冲突问题

### DIFF
--- a/kubejs/server_scripts/Create vintage improvements/recipes.js
+++ b/kubejs/server_scripts/Create vintage improvements/recipes.js
@@ -14,7 +14,9 @@ ServerEvents.recipes(e => {
         "vintageimprovements:crushing/scoria",
         "vintageimprovements:pressurizing/sulfur_dioxide",
         "vintageimprovements:craft/spring_coiling_machine",
-        "vintageimprovements:grinder_polishing/rose_quartz"
+        "vintageimprovements:grinder_polishing/rose_quartz",
+        "vintageimprovements:sequenced_assembly/recipe_card",
+        "vintageimprovements:pressurizing/sulfur_trioxide_alt"
     ])
     vintageimprovements.pressurizing(
         Fluid.of("vintageimprovements:sulfur_trioxide", 500),


### PR DESCRIPTION
和vintage improvement原配方冲突，之前是通过同配方id覆盖的方式，前序commit修改配方id为统一格式后覆盖失效，因此现在显式删除。