### PR TITLE
fix: 重新删除因为更改配方名导致删除失效的配方（进度约1/6）

### DIFF
--- a/kubejs/server_scripts/Alex's Cave/candy.js
+++ b/kubejs/server_scripts/Alex's Cave/candy.js
@@ -8,7 +8,13 @@ ServerEvents.recipes(e => {
    "create_oppenheimered:mixing/ice_cream_sweetberry",
    "alexscaves:caramel_apple",
    "alexscaves:purple_soda_bottle_rocket",
-   "alexscaves:frostmint"
+   "alexscaves:frostmint",
+   "alexscaves:block_of_vanilla_frosting",
+   "create_oppenheimered:mixing/purple_honey_soda",
+   "neapolitan:mint/mint_candies",
+   "create_oppenheimered:mixing/sweet_puff_spinning",
+   "alexscaves:block_of_frosting",
+   "alexscaves:cake_from_cake_layer",
   ])
   //焦糖苹果
   e.recipes.kubejs.shapeless(
@@ -89,7 +95,7 @@ ServerEvents.recipes(e => {
       Fluid.of("cosmopolitan:cream", 250),
       'create_deepfried:berliner'
     ]
-  ).id("createdelight:mixing/sweet_puff_spinning")
+  ).id("createdelight:filling/sweet_puff_spinning")
   //巧克力块系列
   e.recipes.create.compacting(
    'alexscaves:block_of_chocolate',

--- a/kubejs/server_scripts/Alex's Cave/magnetic_cave.js
+++ b/kubejs/server_scripts/Alex's Cave/magnetic_cave.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(e => {
     remove_recipes_id(e, [
-        
+        "alexscaves:seeking_arrow"
     ])
     //粉碎方铅岩获取铁粒和钒粒
     e.recipes.create.crushing([

--- a/kubejs/server_scripts/Alex's Mobs/recipe.js
+++ b/kubejs/server_scripts/Alex's Mobs/recipe.js
@@ -21,6 +21,8 @@ ServerEvents.recipes(e => {
   ).id("createdelight:kangaroo_burger")
   remove_recipes_id(e, [
     "alexsmobs:banana_crate",
-    "alexsmobs:bananas"
+    "alexsmobs:bananas",
+    "alexsmobs:mosquito_repellent_stew",
+    "alexsmobs:kangaroo_burger"
   ])
 })

--- a/kubejs/server_scripts/Bakeries/recipe.js
+++ b/kubejs/server_scripts/Bakeries/recipe.js
@@ -58,7 +58,8 @@ ServerEvents.recipes(e => {
         "bakeries:cream_pumpkin_pie_dough",
         "bakeries:integration/create/mixing/crispy_dough",
         "bakeries:integration/create/mixing/foamed_cream",
-        "bakeries:integration/create/mixing/butter_cube"
+        "bakeries:integration/create/mixing/butter_cube",
+        "bakeries:paper_cup"
     ])
     remove_recipes_output(e, [
         "vintagedelight:oat_dough",

--- a/kubejs/server_scripts/Butchercraft/bug_fix.js
+++ b/kubejs/server_scripts/Butchercraft/bug_fix.js
@@ -1,4 +1,7 @@
 ServerEvents.recipes(e => {
+    remove_recipes_id(e, [
+        "supplementaries:soap"
+    ])
     e.recipes.minecraft.crafting_shapeless(
         "supplementaries:soap",
         [

--- a/kubejs/server_scripts/Casualness Delight/recipes.js
+++ b/kubejs/server_scripts/Casualness Delight/recipes.js
@@ -1,4 +1,7 @@
 ServerEvents.recipes(e => {
+    remove_recipes_id(e, [
+        "casualness_delight:crafting_shaped/raw_spring_roll"
+    ])
     // 牛排配约克郡布丁
     e.recipes.kubejs.shapeless("createdelight:yorkshire_pudding_and_beef", [
         "#forge:cooked_beef",

--- a/kubejs/server_scripts/Collectors Reap/recipes.js
+++ b/kubejs/server_scripts/Collectors Reap/recipes.js
@@ -12,7 +12,15 @@ ServerEvents.recipes(e => {
         "collectorsreap:food/pomegranate_smoothie",
         "collectorsreap:food/uni_roll",
         "collectorsreap:food/clam_roll",
-        "collectorsreap:fermenting/cream_cheese_from_milk_and_salt"
+        "collectorsreap:fermenting/cream_cheese_from_milk_and_salt",
+        "collectorsreap:food/big_rice_ball",
+        "collectorsreap:food/lime_pie",
+        "collectorsreap:food/candied_lime",
+        "collectorsreap:food/portobello_quiche",
+        "collectorsreap:food/berry_limeade",
+        "collectorsreap:food/pink_limeade",
+        "collectorsreap:food/limeade",
+        "collectorsreap:food/mint_limeade",
     ])
     e.replaceInput({id: "collectorsreap:food/buttered_legs"}, "collectorsreap:chieftain_leg", "#forge:crab_leg")
     e.replaceInput({id: "collectorsreap:food/buttered_legs"}, "#forge:milk", "createdelight:butter")

--- a/kubejs/server_scripts/Cosmopolitan/recipe.js
+++ b/kubejs/server_scripts/Cosmopolitan/recipe.js
@@ -3,7 +3,11 @@ ServerEvents.recipes(e => {
         "cosmopolitan:create/pressing/wafer_cone",
         "cosmopolitan:farmersdelight/frying/potato_pancakes_from_deep_frying",
         "cosmopolitan:farmersdelight/cutting/fern",
-        "cosmopolitan:lush_confiture_bottle_from_glass_bottle"
+        "cosmopolitan:lush_confiture_bottle_from_glass_bottle",
+        "cosmopolitan:general/gulime",
+        "cosmopolitan:farmersdelight/jelly_roll",
+        "cosmopolitan:farmersdelight/chocolate_roll_from_chocolate",
+        "cosmopolitan:farmersdelight/ink_roll",
     ])
 
     const { kubejs, create, create_new_age, farmersdelight } = e.recipes

--- a/kubejs/server_scripts/Crabbers Delight/lobster&crab.js
+++ b/kubejs/server_scripts/Crabbers Delight/lobster&crab.js
@@ -49,7 +49,9 @@ ServerEvents.tags("item", e => {
 ServerEvents.recipes(e => {
     remove_recipes_id(e, [
         "alexsmobs:cooked_lobster_tail_campfire",
-        "alexsmobs:cooked_lobster_tail_smoke"
+        "alexsmobs:cooked_lobster_tail_smoke",
+        "farmersdelight:cooking/seafood_gumbo",
+        "alexsmobs:cooked_lobster_tail"
     ])
     e.replaceInput({ id: "farmersdelight:cooking/stuffed_nautilus_shell" }, "#forge:cooked_fishes", "#alexsmobs:shoebill_foodstuffs")
     e.replaceInput({ id: "farmersdelight:cooking/crab_cakes" }, "crabbersdelight:crab", "#crabbersdelight:crab")

--- a/kubejs/server_scripts/Create BitterBallen/recipe.js
+++ b/kubejs/server_scripts/Create BitterBallen/recipe.js
@@ -31,7 +31,24 @@ ServerEvents.recipes(e => {
         "create_deepfried:deep_frying/donut",
         "create_deepfried:compat/farmersdelight/deep_frying/arancini",
         "create_bic_bit:compat/farmersdelight/ketchup",
-        "create_bic_bit:mixing/frying_oil"
+        "create_bic_bit:mixing/frying_oil",
+        "create_bic_bit:filling/ketchup_bottle",
+        "create_bic_bit:emptying/ketchup",
+        "create_bic_bit:mixing/raw_churros",
+        "create_bic_bit:mixing/raw_cheese_souffle",
+        "create_bic_bit:filling/ketchup_kroket_sandwich",
+        "create_bic_bit:filling/mayonnaise_ketchup_kroket_sandwich",
+        "create_bic_bit:mixing/raw_eggball",
+        "create_bic_bit:mixing/raw_kroket",
+        "create_bic_bit:compat/farmersdelight/kroket",
+        "create_bic_bit:mixing/raw_eggball",
+        "create_bic_bit:mixing/raw_frikandel",
+        "create_bic_bit:compat/farmersdelight/frikandel",
+        "create_bic_bit:filling/ketchup_frikandel_sandwich",
+        "create_bic_bit:filling/mayonnaise_ketchup_frikandel_sandwich",
+        "create_bic_bit:filling/wrapped_ketchup_fries",
+        "create_bic_bit:filling/wrapped_mayonnaise_ketchup_fries",
+        "create_bic_bit:deep_frying/enderball"
     ])
     remove_recipes_output(e, [
         'create_bic_bit:cheese_souffle', 

--- a/kubejs/server_scripts/Create/recipes.js
+++ b/kubejs/server_scripts/Create/recipes.js
@@ -30,7 +30,8 @@ ServerEvents.recipes(e => {
         "create_new_age:mixing/thorium",
         "create_new_age:crushing/radioactive_thorium",
         "createaddition:crafting/large_connector_electrum",
-        "create_oppenheimered:filling/gingerbread_sweet_roll"
+        "create_oppenheimered:filling/gingerbread_sweet_roll",
+        "create:crafting/materials/electron_tube"
     ])
     remove_recipes_output(e, [
         "create:pulp",


### PR DESCRIPTION
根据#1417，检查到Create Cafe/recipe.js，预估剩余约5/6的改动未检查。