### PR TITLE
fix quality absorber no money return

### DIFF
--- a/kubejs/server_scripts/Quality Food/absorber.js
+++ b/kubejs/server_scripts/Quality Food/absorber.js
@@ -15,7 +15,7 @@ ItemEvents.rightClicked("createdelight:quality_absorber", e => {
     })
     if (amount == 0)
         return
-    let money = $CoinValue.fromNumber(COIN_CHAIN_MAIN_VALUE, amount)
+    let money = $CoinValue.fromNumber("main", amount)
     $MoneyAPI.getApi().GetPlayersMoneyHandler(player).insertMoney(money, false)
     player.tell(Component.of("将物品栏中的所有品质去除物品，并将其转化为了").append(money.getText()))
 


### PR DESCRIPTION
## The Problem This PR Would Solve

目前 createdelight:quality_absorber 的工作不符合预期，消除品质后不能返回金钱。

日志提示

> [00:25:28] [Server thread/ERROR] [KubeJS Server/]: Quality Food/absorber.js#18: Error in 'ItemEvents.rightClicked': ReferenceError: "COIN_CHAIN_MAIN_VALUE" is not defined.

## Why

Similar to that in #1480 chapter Question.

直接原因也是 #1467，
根本原因也可以归咎为一开始写的不好没有落实 Don't Repeat Yourself 原则。

我在那个 PR 的 FYI 章节中提过了。
现在我遇到了，没想到**还**是我修。

考虑问题的相似性，建议 @SSWTLZZ69 同人处理。

## Solution

Keep consistency, rename to inline `“main”`.

## Alternatives

### A

目前 `“main”` 在所有 js 中的指代都是 `COIN_CHAIN_MAIN_VALUE`，我认为尚可接受。

如果出现其他意向导致混淆，或者出现了需要变更 `COIN_CHAIN_MAIN_VALUE` 为 `“main”` 之外值的 case，
我会选择提供并转用工具函数来消除 magic number。这会统一目前
```js
$CoinValue.fromNumber("main", amount)
$CoinValue["fromNumber(java.lang.String,long)"]("main", values)
```
两种写法。

### B

在 startup_scripts 的合适位置
```js
global.MoneyUtil.COIN_CHAIN_MAIN_VALUE="main";
```
做 export，并统一转用**长的多**的全局名字。

## Test

经检验，apply patch 后表现符合预期，能返钱。

<img width="1281" height="708" alt="2026-04-04_00-42" src="https://github.com/user-attachments/assets/7542053d-214f-4c96-b4a1-ac82e89994ee" />
