### PR TITLE
[quest]任务书添加zstd压缩带宽说明，添加液态燃料不建议用机械手喂燃烧室的提醒，修正多流体储罐任务物品ID

### DIFF
--- a/config/ftbquests/quests/chapters/Alloy_Innovation.snbt
+++ b/config/ftbquests/quests/chapters/Alloy_Innovation.snbt
@@ -67,7 +67,11 @@
 				"1999728E6F67F8EF"
 			]
 			dependency_requirement: "one_completed"
-			description: ["可直接通入&e液体燃料&r来进行&4加热&r，&n无需使用吸管&r"]
+			description: [
+				"可直接通入&e液体燃料&r来进行&4加热&r，&n无需使用吸管&r"
+				""
+				"对于需要持续运行的产线，&n不建议&r使用机械手喂液体燃料桶，可能导致超级燃烧状态&4丢失&r。"
+			]
 			id: "467AE0EF8AF5ACAF"
 			rewards: [{
 				id: "3CF78ADD5C4D6540"
@@ -279,14 +283,14 @@
 		}
 		{
 			dependencies: ["4B6A896ECC72EA02"]
-			description: [""]
+			icon: "createfluidstuffs:multi_fluid_tank"
 			id: "043C01E333AD7139"
 			shape: "gear"
 			size: 2.0d
 			subtitle: "&4超级超级超级好用&r的多流体储存罐！（最多八种流体）"
 			tasks: [{
 				id: "3F3576DB3D33FC4B"
-				item: "fluidlogistics:multi_fluid_tank"
+				item: "createfluidstuffs:multi_fluid_tank"
 				type: "item"
 			}]
 			x: 10.0d

--- a/config/ftbquests/quests/chapters/Settings.snbt
+++ b/config/ftbquests/quests/chapters/Settings.snbt
@@ -103,24 +103,18 @@
 		}
 		{
 			description: [
-				"为使其他玩家能操作你认领区块里的方块和物品，需要使用FTB teams组队。"
-				""
-				"&e&l未开启离线模式&r&r联机的情况下，可直接通过物品栏界面左上角的组队图标进入相关组队配置。"
-				"&e&l离线模式&r&r时，需要使用指令："
-				"/ftbteams party invite <player> 邀请玩家xxx加入自己的队伍"
-				"/ftbteams party leave 离开当前队伍"
-				"/ftbteams party allies add  <player> 设置玩家xxx为盟友"
-				""
-				"更多内容请看FTB Teams的百科界面。"
+				"整合包安装了zstdnet来实现带宽压缩，官方服务器实测能将带宽-90%"
+				"为了使带宽压缩生效，你需要&e&l&n关闭正版验证&r&r&r"
+				"如果你需要阻止离线玩家登录你的服务器，可使用整合包内的TrueUUID。"
 			]
-			icon: "itemfilters:id_regex"
+			icon: "sophisticatedbackpacks:advanced_deposit_upgrade"
 			id: "52F8FFE2BB54EEB8"
 			shape: "square"
 			tasks: [{
 				id: "2E2A54AABF31A237"
 				type: "checkmark"
 			}]
-			title: "组队"
+			title: "带宽消耗太快？开启zstd压缩"
 			x: 1.5d
 			y: 1.5d
 		}
@@ -206,7 +200,7 @@
 				type: "checkmark"
 			}]
 			title: "地图"
-			x: 0.75d
+			x: 0.0d
 			y: 3.0d
 		}
 		{
@@ -222,7 +216,30 @@
 				id: "266A26FD317370C8"
 				type: "checkmark"
 			}]
-			x: 2.5d
+			x: 3.0d
+			y: 3.0d
+		}
+		{
+			description: [
+				"为使其他玩家能操作你认领区块里的方块和物品，需要使用FTB teams组队。"
+				""
+				"&e&l未开启离线模式&r&r联机的情况下，可直接通过物品栏界面左上角的组队图标进入相关组队配置。"
+				"&e&l离线模式&r&r时，需要使用指令："
+				"/ftbteams party invite <player> 邀请玩家xxx加入自己的队伍"
+				"/ftbteams party leave 离开当前队伍"
+				"/ftbteams party allies add  <player> 设置玩家xxx为盟友"
+				""
+				"更多内容请看FTB Teams的百科界面。"
+			]
+			icon: "itemfilters:id_regex"
+			id: "682E85347D06AFF2"
+			shape: "square"
+			tasks: [{
+				id: "57C82F42E2039DDD"
+				type: "checkmark"
+			}]
+			title: "组队"
+			x: 1.5d
 			y: 3.0d
 		}
 	]


### PR DESCRIPTION
## Summary
- 修正合金创新章节中多流体储罐任务的物品ID：fluidlogistics:multi_fluid_tank → createfluidstuffs:multi_fluid_tank
- 添加多流体储罐任务的图标
- 添加燃烧器液体燃料加热的提示说明（警告机械手喂燃料可能导致超级燃烧状态丢失）
- 新增设置章节中关于zstd带宽压缩的说明任务
- 调整组队任务位置布局