### PR TITLE
[conf] 电力回收交易次数限制从100提升至1000

### DIFF
--- a/config/lightmanscurrency/PersistentTraders.json
+++ b/config/lightmanscurrency/PersistentTraders.json
@@ -3006,7 +3006,7 @@
       "OwnerName": "JSI宇宙第一无敌公司",
       "Rules": [
         {
-          "Limit": 100,
+          "Limit": 1000,
           "ForgetTime": 86400000,
           "Type": "lightmanscurrency:player_trade_limit"
         }


### PR DESCRIPTION
## Summary
- 将电力回收交易的每日交易次数限制从100提升至1000

## Changes
| 参数 | 原值 | 新值 |
|------|------|------|
| Limit | 100 | 1000 |

## Details
修改文件: config/lightmanscurrency/PersistentTraders.json

电力回收交易商 (electricity_trade) 的 player_trade_limit 规则中 Limit 字段从 100 改为 1000，ForgetTime 保持 24小时不变。

## Motivation
提升玩家每日可进行的电力回收交易次数，减少交易限制带来的不便。