### PR TITLE
[conf] 电力回收交易冷却时间从24小时改为2小时，Limit改为500

### DIFF
--- a/config/lightmanscurrency/PersistentTraders.json
+++ b/config/lightmanscurrency/PersistentTraders.json
@@ -3006,8 +3006,8 @@
       "OwnerName": "JSI宇宙第一无敌公司",
       "Rules": [
         {
-          "Limit": 1000,
-          "ForgetTime": 86400000,
+          "Limit": 500,
+          "ForgetTime": 7200000,
           "Type": "lightmanscurrency:player_trade_limit"
         }
       ],


### PR DESCRIPTION
## Summary
- 电力回收交易冷却时间从24小时改为2小时
- Limit从1000改为500

## Changes
| 参数 | 原值 | 新值 |
|------|------|------|
| ForgetTime | 86400000 (24h) | 7200000 (2h) |
| Limit | 1000 | 500 |

## Details
修改文件: config/lightmanscurrency/PersistentTraders.json

电力回收交易商 (electricity_trade) 的 player_trade_limit 规则:
- ForgetTime: 86400000 → 7200000 (毫秒)
- Limit: 1000 → 500

## Motivation
缩短冷却时间，降低交易次数上限，平衡电力回收收益。