### PR TITLE
[fix] 修复README开发者头像竖向排列问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ A Minecraft 1.20.1 Forge Create & Farmer's Delight modpack
     <img src="kubejs/assets/createdelight/textures/images_for_readme/title.png" alt="Logo" width="1013" height="174">
   </a>
   <br />
-  <a href="https://github.com/JasonQ1123"><img src="https://avatars.githubusercontent.com/u/154645632?v=4" alt="Logo" width="80" height="80"></a>
-  <a href="https://github.com/SSWTLZZ69"><img src="https://avatars.githubusercontent.com/u/191679837?v=4" alt="Logo" width="80" height="80"></a>
-  <a href="https://github.com/wanquanw"><img src="https://avatars.githubusercontent.com/u/54640492?v=4" alt="Logo" width="80" height="80"></a>
+  <a href="https://github.com/JasonQ1123"><img src="https://avatars.githubusercontent.com/u/154645632?v=4" alt="Logo" width="80" height="80"></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/SSWTLZZ69"><img src="https://avatars.githubusercontent.com/u/191679837?v=4" alt="Logo" width="80" height="80"></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/wanquanw"><img src="https://avatars.githubusercontent.com/u/54640492?v=4" alt="Logo" width="80" height="80"></a>
 
   <h3 align="center">大型深度魔改向1.20.1Forge机械动力整合包</h3>
   <p align="center">

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ A Minecraft 1.20.1 Forge Create & Farmer's Delight modpack
   </a>
 </p>
 
-<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
-  <td><a href="https://github.com/JasonQ1123"><img src="https://avatars.githubusercontent.com/u/154645632?v=4" alt="Logo" width="80" height="80"></a></td>
-  <td><a href="https://github.com/SSWTLZZ69"><img src="https://avatars.githubusercontent.com/u/191679837?v=4" alt="Logo" width="80" height="80"></a></td>
-  <td><a href="https://github.com/wanquanw"><img src="https://avatars.githubusercontent.com/u/54640492?v=4" alt="Logo" width="80" height="80"></a></td>
+<table align="center" style="border: none; border-collapse: collapse;"><tr style="border: none;">
+  <td style="border: none; padding: 0 8px;"><a href="https://github.com/JasonQ1123"><img src="https://avatars.githubusercontent.com/u/154645632?v=4" alt="Logo" width="80" height="80"></a></td>
+  <td style="border: none; padding: 0 8px;"><a href="https://github.com/SSWTLZZ69"><img src="https://avatars.githubusercontent.com/u/191679837?v=4" alt="Logo" width="80" height="80"></a></td>
+  <td style="border: none; padding: 0 8px;"><a href="https://github.com/wanquanw"><img src="https://avatars.githubusercontent.com/u/54640492?v=4" alt="Logo" width="80" height="80"></a></td>
 </tr></table>
 
 <h3 align="center">大型深度魔改向1.20.1Forge机械动力整合包</h3>

--- a/README.md
+++ b/README.md
@@ -17,14 +17,18 @@ A Minecraft 1.20.1 Forge Create & Farmer's Delight modpack
 <br />
 
 <p align="center">
-  
   <a href="https://www.curseforge.com/minecraft/modpacks/create-delight-remake">
     <img src="kubejs/assets/createdelight/textures/images_for_readme/title.png" alt="Logo" width="1013" height="174">
   </a>
-  <br />
-  <a href="https://github.com/JasonQ1123"><img src="https://avatars.githubusercontent.com/u/154645632?v=4" alt="Logo" width="80" height="80"></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/SSWTLZZ69"><img src="https://avatars.githubusercontent.com/u/191679837?v=4" alt="Logo" width="80" height="80"></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/wanquanw"><img src="https://avatars.githubusercontent.com/u/54640492?v=4" alt="Logo" width="80" height="80"></a>
+</p>
 
-  <h3 align="center">大型深度魔改向1.20.1Forge机械动力整合包</h3>
+<table align="center"><tr>
+  <td><a href="https://github.com/JasonQ1123"><img src="https://avatars.githubusercontent.com/u/154645632?v=4" alt="Logo" width="80" height="80"></a></td>
+  <td><a href="https://github.com/SSWTLZZ69"><img src="https://avatars.githubusercontent.com/u/191679837?v=4" alt="Logo" width="80" height="80"></a></td>
+  <td><a href="https://github.com/wanquanw"><img src="https://avatars.githubusercontent.com/u/54640492?v=4" alt="Logo" width="80" height="80"></a></td>
+</tr></table>
+
+<h3 align="center">大型深度魔改向1.20.1Forge机械动力整合包</h3>
   <p align="center">
     <br />
     <a href="https://github.com/Jasons-impart/Create-Delight-Remake/actions"><strong>在GitHub上下载整合包最新测试版 »</strong></a>
@@ -40,8 +44,6 @@ A Minecraft 1.20.1 Forge Create & Farmer's Delight modpack
     ·
     <a href="https://github.com/Jasons-impart/Create-Delight-Remake/issues">提出新特性</a>
   </p>
-
-</p>
 
 > [!IMPORTANT]
 > 整合包仍在**加急开发中**！如果你遇到任何问题，请为我们[反馈问题](https://xr5r5e86lk.feishu.cn/share/base/form/shrcnIDUxvX4oOvWSQaddJUht9b)！感激不尽！

--- a/README.md
+++ b/README.md
@@ -22,15 +22,9 @@ A Minecraft 1.20.1 Forge Create & Farmer's Delight modpack
     <img src="kubejs/assets/createdelight/textures/images_for_readme/title.png" alt="Logo" width="1013" height="174">
   </a>
   <br />
-  <a href="https://github.com/JasonQ1123">
-    <img src="https://avatars.githubusercontent.com/u/154645632?v=4" alt="Logo" width="80" height="80">
-  </a>
-  <a href="https://github.com/SSWTLZZ69">
-    <img src="https://avatars.githubusercontent.com/u/191679837?v=4" alt="Logo" width="80" height="80">
-  </a>
-  <a href="https://github.com/wanquanw">
-    <img src="https://avatars.githubusercontent.com/u/54640492?v=4" alt="Logo" width="80" height="80">
-  </a>
+  <a href="https://github.com/JasonQ1123"><img src="https://avatars.githubusercontent.com/u/154645632?v=4" alt="Logo" width="80" height="80"></a>
+  <a href="https://github.com/SSWTLZZ69"><img src="https://avatars.githubusercontent.com/u/191679837?v=4" alt="Logo" width="80" height="80"></a>
+  <a href="https://github.com/wanquanw"><img src="https://avatars.githubusercontent.com/u/54640492?v=4" alt="Logo" width="80" height="80"></a>
 
   <h3 align="center">大型深度魔改向1.20.1Forge机械动力整合包</h3>
   <p align="center">

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Minecraft 1.20.1 Forge Create & Farmer's Delight modpack
   </a>
 </p>
 
-<table align="center"><tr>
+<table align="center" border="0" cellpadding="0" cellspacing="0"><tr>
   <td><a href="https://github.com/JasonQ1123"><img src="https://avatars.githubusercontent.com/u/154645632?v=4" alt="Logo" width="80" height="80"></a></td>
   <td><a href="https://github.com/SSWTLZZ69"><img src="https://avatars.githubusercontent.com/u/191679837?v=4" alt="Logo" width="80" height="80"></a></td>
   <td><a href="https://github.com/wanquanw"><img src="https://avatars.githubusercontent.com/u/54640492?v=4" alt="Logo" width="80" height="80"></a></td>


### PR DESCRIPTION
## Summary
- 修复 README 开头的三个开发者头像在 GitHub 渲染时竖向排列而非横向排列的问题
- 原因：GitHub HTML sanitizer 将多行的 <a><img></a> 视为块级元素，导致每个头像独占一行
- 修复：将 <a> 和 <img> 合并到同一行，使 GitHub 将其视为内联元素横向排列