### PR TITLE
[dev] CI: 添加tag触发CI构建支持

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - release*       # 匹配主发布分支
       - test-*         # 匹配所有 test- 开头的分支（通配符）
+    tags:
+      - 'v*'           # 匹配版本标签触发
 env:
   VERSION_FILE_PATH: config/fancymenu/assets/version.md
   PACKWIZ_DOWNLOAD_URL: https://github.com/Jasons-impart/packwiz/releases/latest/download/packwiz
@@ -56,7 +58,11 @@ jobs:
         id: generate_modpack_version
         run: |
           BRANCH_NAME="${{ github.ref_name }}"
-          if [[ "$BRANCH_NAME" == *test* ]]; then
+          if [[ "$BRANCH_NAME" == v* ]]; then
+            # Tag-triggered: use version from pack.toml directly
+            VERSION="${{ steps.read-version.outputs.value }}"
+            echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          elif [[ "$BRANCH_NAME" == *test* ]]; then
             VERSION="${{ steps.read-version.outputs.value }}-test-build-${{ github.run_number }}"
             echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           else
@@ -84,7 +90,8 @@ jobs:
       startsWith(github.ref_name, 'release') || 
       startsWith(github.ref_name, 'test-release') ||
       startsWith(github.ref_name, 'test-client') ||
-      startsWith(github.ref_name, 'test-patch')
+      startsWith(github.ref_name, 'test-patch') ||
+      startsWith(github.ref_name, 'v')
     steps:
       - name: 测试环境变量
         run: |
@@ -200,7 +207,8 @@ jobs:
     if: >
       startsWith(github.ref_name, 'release') || 
       startsWith(github.ref_name, 'test-release') ||
-      startsWith(github.ref_name, 'test-server')
+      startsWith(github.ref_name, 'test-server') ||
+      startsWith(github.ref_name, 'v')
     steps:
       - name: 检出代码
         uses: actions/checkout@v4
@@ -289,7 +297,8 @@ jobs:
     if: >
       startsWith(github.ref_name, 'release') || 
       startsWith(github.ref_name, 'test-release') ||
-      startsWith(github.ref_name, 'test-patch')
+      startsWith(github.ref_name, 'test-patch') ||
+      startsWith(github.ref_name, 'v')
     steps:
       - name: 测试环境变量
         run: |


### PR DESCRIPTION
## Summary
Cherry-pick 1f8186fe to main: 添加 `v*` tag 触发 CI 构建支持

### Changes
- release.yml 添加 `tags: - 'v*'` 触发器
- common-steps 添加 tag 触发时的版本号处理逻辑
- client-tasks, server-tasks, patch-tasks 添加 `v` 前缀分支匹配

This enables creating releases by pushing version tags directly, without needing a release branch push.