### PR TITLE
[fix] 任务书的材料章节引用的已删除模组adastra的物品修正为北极星物品

### DIFF
--- a/config/ftbquests/quests/chapters/Materials.snbt
+++ b/config/ftbquests/quests/chapters/Materials.snbt
@@ -202,11 +202,7 @@
 			size: 1.0d
 			tasks: [{
 				id: "48B5B9F5166ABCFC"
-				item: {
-					Count: 1
-					id: "ad_astra:etrionic_capacitor"
-					tag: { }
-				}
+				item: "createaddition:capacitor"
 				type: "item"
 			}]
 			x: 13.0d
@@ -271,7 +267,7 @@
 			size: 1.0d
 			tasks: [{
 				id: "417975C36DDA120A"
-				item: "ad_astra:calorite_ingot"
+				item: "createdelightcore:molten_martian_steel_bucket"
 				type: "item"
 			}]
 			x: 9.5d


### PR DESCRIPTION
更新Materials章节任务物品ID：

1. \d_astra:etrionic_capacitor\ → \createaddition:capacitor\
2. \d_astra:calorite_ingot\ → \createdelightcore:molten_martian_steel_bucket\

同时PR到: release-v048x