### PR TITLE
[dev] 打包action适配 #1664 改动；[dev] 补充agent知识库方便开发

### DIFF
--- a/.agents/skills/knowledge-check/SKILL.md
+++ b/.agents/skills/knowledge-check/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: knowledge-check
+description: Guides structured knowledge base updates after implementation work
+---
+
+# Knowledge Check Skill
+
+Guides the agent through structured knowledge base updates after completing implementation work.
+
+## When to Use
+
+Invoke this skill (via `/knowledge-check`) when:
+- You just completed a code change, bug fix, or configuration update
+- You discovered a non-obvious project pattern, pitfall, or constraint
+- You corrected a mistake that could recur in future sessions
+
+Do NOT invoke for:
+- Pure research/exploration tasks with no code changes
+- Trivial changes that follow well-documented patterns
+- General knowledge not specific to THIS project
+
+## Process
+
+### Step 1: Assess Significance
+
+Ask: "Did I learn anything new about THIS PROJECT that future sessions would benefit from?"
+
+Categories of worth-recording knowledge:
+- **Bug/pitfall discovered** → `lessons-learned.md`
+- **New convention or pattern** → Relevant `AGENTS.md` (root, `kubejs/`, or `CDC-mod-src/`)
+- **New utility function or API** → `kubejs/AGENTS.md` UNIQUE STYLES section
+- **Config change with side effects** → `lessons-learned.md` or relevant AGENTS.md
+
+### Step 2: Choose Target File
+
+| Knowledge Type | Target File | When |
+|---------------|-------------|------|
+| Cross-module convention | Root `AGENTS.md` | Applies to entire project |
+| KubeJS recipe/dev pattern | `kubejs/AGENTS.md` | KubeJS-specific |
+| Java mod pattern | `CDC-mod-src/AGENTS.md` | CDC-specific |
+| Bug fix / pitfall / history | `lessons-learned.md` | Preventive knowledge |
+| New utility function | `kubejs/AGENTS.md` UNIQUE STYLES | Developer reference |
+
+### Step 3: Write Update
+
+**Rules for updating knowledge base files**:
+
+1. **Be concise** - One sentence per fact. No prose.
+2. **Include the Why** - Non-obvious rules MUST explain the reason.
+3. **No duplication** - If information exists elsewhere, reference it, don't repeat it.
+4. **Keep AGENTS.md ≤150 lines** (root) or ≤80 lines (subdirectory). If over limit, prune stale entries.
+5. **Lessons-learned entries**: Include Problem, Fix/Lesson, and date.
+
+**ALLOWED actions** (knowledge update only):
+- ✅ Edit `AGENTS.md` files (root, `kubejs/`, `CDC-mod-src/`)
+- ✅ Edit `lessons-learned.md`
+- ✅ Edit `.agents/skills/` or `.opencode/plugins/`
+
+**NOT ALLOWED** (when invoked as knowledge check):
+- ❌ Modifying code, recipes, configs unrelated to knowledge files
+- ❌ Running build/test commands
+- ❌ Git operations
+
+### Step 4: Output Summary
+
+Output this block at the end:
+
+```
+📝 Knowledge Check
+- Learned: [1-3 items or "nothing significant"]
+- Updated: [file path or "no update needed"]
+- Reason: [one sentence]
+```
+
+If nothing significant was learned, output ONLY: `📝 Knowledge: no update needed`
+
+## Anti-Patterns
+
+- ❌ Recording general programming knowledge (not project-specific)
+- ❌ Duplicating information across multiple AGENTS.md files
+- ❌ Adding entries without pruning when files exceed line limits
+- ❌ Writing verbose prose instead of concise bullet points
+
+## Self-Check (MANDATORY before finalizing any knowledge update)
+
+Before saving any edit to AGENTS.md or lessons-learned.md, verify ALL of these:
+
+1. **Line count** — Root AGENTS.md ≤150? Subdirectory AGENTS.md ≤80? If over, prune FIRST.
+2. **No duplication** — Does this information already exist in another knowledge file? If yes, reference instead of repeating.
+3. **Concise** — Is each entry one sentence? Can any words be cut without losing meaning?
+4. **Why included** — For non-obvious rules, did I explain the failure mode/reason?
+5. **Stale check** — Am I adding to a file that contains outdated entries? Flag them for removal.
+6. **Right file** — Is this in the correct knowledge file per the routing table above? Cross-module → root, domain-specific → subdirectory, historical → lessons-learned.
+
+If any check fails, fix before saving. This self-check is the primary mechanism ensuring knowledge base quality over time.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: release
+description: Create-Delight Remake modpack release workflow - version bump, tag, artifacts download, and GitHub release creation
+license: MIT
+compatibility: opencode
+metadata:
+  audience: maintainers
+  workflow: github-actions
+  project: create-delight-remake
+---
+
+## What I do
+
+Automate the full release pipeline using two PowerShell scripts:
+1. **release-prepare.ps1** — Version bump + PR creation (pre-merge)
+2. **release-publish.ps1** — Tag + CI + Download + Release (post-merge)
+
+## When to use me
+
+- "发布版本" / "发布新版本" / "release"
+- Version-related tasks like bumping `pack.toml`
+- Creating GitHub releases
+
+## Agent Decision Points
+
+The agent only needs to make **5 decisions**; everything else is scripted:
+
+### Decision 0: Target Branch
+
+**Rules**:
+- If the version is a patch release on an existing release line (e.g. v0.4.7.15 on v0.4.7.x) → target the release branch (e.g. `release-v047x`)
+- If the version is a new sub-version's first release (e.g. first v0.4.9.x) → target `main`
+- If user specifies a branch → use specified branch
+
+**How to detect**: Check if a remote branch matching `release-v{major}{minor}x` exists for the version's prefix.
+
+### Decision 1: Version Number
+
+**Rules**:
+- User specifies → use specified version
+- User says "发布新版本" without specifying → auto-detect:
+  1. Check if `pack.toml` was modified in the latest commit (`git log -1 --name-only | grep pack.toml`)
+  2. If YES → the developer already bumped the version in pack.toml, use the current version from pack.toml
+  3. If NO → increment the last digit of the latest version (e.g. v0.4.7.14 → v0.4.7.15). Find the latest version from the most recent git tag matching `v*`.
+
+```bash
+git log -1 --name-only | grep pack.toml
+```
+
+### Decision 2: Release Type
+
+- 正式版 → 4 artifacts (Client + ClientPatch + Server + ServerPatch)
+- 测试版 → 2 artifacts (Client + Server only, no patches)
+
+### Decision 3: Announcement Content
+
+Summarize changes into **≤3 bullet points, each ≤20 characters**, separated by commas. Example:
+- "机械动力6.0升级,北极星太空探索,核反应堆实装"
+
+**Format**: announcement.md uses `### {版本}已发布` as the title line, followed by the bullet points.
+
+**For first stable of a sub-version**: Derive the 3 points from the update-summary file (`docs/update-summary-{Version}.md`), picking the 3 most impactful changes.
+
+**For other stable releases**: Extract from the latest git log or user input.
+
+If user doesn't specify, extract from latest git log.
+
+### Decision 4: Update Summary (First Stable Release Only)
+
+When the sub-version's **first stable release** is being published (e.g. v0.4.8.9 is the first stable of 0.4.8.x, after v0.4.8.0-v0.4.8.8 were all pre-releases), the agent must generate an update summary markdown file **before** running release-publish.ps1.
+
+**Detection**: release-publish.ps1 automatically detects this by checking if no prior stable (non-prerelease) GitHub release exists for the sub-version prefix.
+
+**Agent responsibility**: Before Phase 2 (publish), generate `docs/update-summary-{Version}.md` covering all changes from the previous sub-version to this one. The file must:
+- Use Chinese (简体中文)
+- Group changes into categories with emoji headers
+- Include PR numbers (e.g. #1234) for each change
+- Start with a brief one-line summary of the update scope
+- End with an "升级须知" section recommending new saves
+
+**Release notes behavior**: release-publish.ps1 will automatically prepend the summary file content to the GitHub release body (above the per-commit auto-generated notes) when it detects a first stable release.
+
+**Example**: For v0.4.8.9 (first stable of 0.4.8.x), generate `docs/update-summary-v0.4.8.9.md` summarizing all changes from v0.4.7.0 onward.
+
+## Release Workflow
+
+### Phase 1: Prepare (Pre-merge)
+
+```powershell
+.\.agents\skills\release\release-prepare.ps1 `
+    -Version "v0.4.7.15" `
+    -TargetBranch "release-v047x" `
+    -ReleaseType "正式" `
+    -Announcement "更新TrueUUID修复旁观穿墙,补充zstd联机教学视频" `
+    -Proxy "http://127.0.0.1:7890"
+```
+
+Output: PR URL
+
+### ⚠️ Human Gate: Merge the PR
+
+**Must wait for user to manually merge the PR.** Never auto-merge.
+
+### Phase 2: Publish (Post-merge)
+
+After user confirms PR is merged:
+
+```powershell
+.\.agents\skills\release\release-publish.ps1 `
+    -Version "v0.4.7.15" `
+    -TargetBranch "release-v047x" `
+    -ReleaseType "正式" `
+    -Proxy "http://127.0.0.1:7890"
+```
+
+Note: `-PreviousVersion` is now optional. It auto-detects from the previous git tag. Override manually if needed:
+
+```powershell
+.\.agents\skills\release\release-publish.ps1 `
+    -Version "v0.4.7.15" `
+    -TargetBranch "release-v047x" `
+    -PreviousVersion "v0.4.7.14" `
+    -ReleaseType "正式" `
+    -Proxy "http://127.0.0.1:7890"
+```
+
+Output: Release URL
+
+## Script Reference
+
+### release-prepare.ps1
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `-Version` | ✅ | New version string (e.g. "v0.4.7.15") |
+| `-TargetBranch` | ✅ | Base branch for PR (e.g. "release-v047x") |
+| `-ReleaseType` | ❌ | "正式" (default) or "测试" |
+| `-Announcement` | ❌ | Comma-separated bullet points, e.g. "修复BUG,新增物品,优化性能". Auto-generated from git log if omitted |
+| `-Proxy` | ❌ | HTTPS proxy (e.g. "http://127.0.0.1:7890") |
+
+**What it does**: Update pack.toml → Update announcement.md → Auto-stage update-summary files → Create branch → Commit → Push → Create PR → Restore original branch
+
+### release-publish.ps1
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `-Version` | ✅ | Version tag to create (e.g. "v0.4.7.15") |
+| `-TargetBranch` | ✅ | Branch to tag on (e.g. "release-v047x") |
+| `-PreviousVersion` | ❌ | Previous version for release notes and patch names (e.g. "v0.4.7.14"). Auto-detected via `git describe --tags --abbrev=0 HEAD^` if omitted |
+| `-ReleaseType` | ❌ | "正式" (default, 4 artifacts) or "测试" (2 artifacts, prerelease) |
+| `-Proxy` | ❌ | HTTPS proxy |
+| `-CIPollIntervalSeconds` | ❌ | CI poll interval (default: 30) |
+| `-CITimeoutMinutes` | ❌ | CI timeout (default: 15) |
+
+**What it does**: Tag+Push → Wait CI → Download artifacts → Compress → Generate notes (+ prepend update summary if first stable) → Create release → Verify → Announcement PR to main (stable only)
+
+## Script Safety Features
+
+Both scripts include:
+
+- **Pre-flight validation**: Checks prerequisites (pack.toml exists, version format, gh auth, TargetBranch exists on remote, no existing release) before any changes. Fails fast with clear error messages.
+- **Dry-run mode**: Pass `-WhatIf` to preview what the script would do without making any changes. Useful for validating parameters.
+- **Idempotency**: Scripts handle re-runs gracefully:
+  - Existing tags on the correct commit → skipped
+  - Existing branches → cleaned up and recreated
+  - Existing PRs → existing URL returned
+  - Existing releases → fail with clear message (cannot recreate)
+
+---
+
+## ⚠️ CDC Mod Release (Separate Workflow)
+
+The following is a **separate** workflow for the custom Java mod, NOT part of the main modpack release pipeline. Only use this when specifically asked to update the CDC mod.
+
+CDC mod in `CDC-mod-src/`, separate repo: `Jasons-impart/Create-Delight-Core`
+
+```bash
+cd CDC-mod-src
+git checkout 1.20.1 && git pull
+git checkout -b fix/xxx
+./gradlew build --no-daemon
+git add -A && git commit -m "[fix] 描述"
+git push -u origin fix/xxx
+gh pr create --base 1.20.1 --title "[fix] 描述" --body "..."
+```
+
+After merge, update CDR mods:
+```bash
+cd ..
+Remove-Item mods/Create-Delight-Core-*.jar
+Copy-Item CDC-mod-src/build/libs/CDC-mod-src-*.jar mods/
+```
+
+## Important Notes
+
+- **PR merge**: Must wait for user to manually merge, cannot auto-merge
+- **Release notes**: Auto-generated from commit messages, appended with `(AI自动生成)`. For the first stable release of a sub-version, the update summary file (`docs/update-summary-{Version}.md`) is automatically prepended.
+- **Announcement PR**: For stable releases, release-publish.ps1 automatically creates a PR to main with the updated `docs/announcement.md`. The agent only needs to inform the user about this PR — no need to wait for merge.
+- **`[]` in filenames**: Handled by release-publish.ps1 using `-LiteralPath` copy
+- **Proxy**: Pass `-Proxy` parameter if direct GitHub access is slow
+- **Temp directory**: release-publish.ps1 preserves temp dir at `$env:TEMP\opencode\<version>` for debugging
+
+## PowerShell + gh CLI Pitfalls
+
+These bugs were discovered during releases. DO NOT reintroduce them:
+
+1. **`-Announcement` is `[string]` not `[string[]]`** — bash→powershell comma-separated args become 1 string. Script splits on `,` internally.
+2. **Never use `Set-Content -Encoding utf8`** — PS5.x writes UTF-8 BOM which breaks TOML parsers. Use `[System.IO.File]::WriteAllText()` with `UTF8Encoding($false)`.
+3. **Never use `gh pr create --body $multiline`** — PowerShell truncates multiline args to external commands. Use `--body-file` with a temp file. Same applies to `gh release create --notes` — use `--notes-file` instead.
+4. **Never use `--jq` with double quotes** — PowerShell's string interpolation breaks `contains("...")` etc. Use PowerShell's `ConvertFrom-Json` + `Where-Object` instead.
+5. **Set proxy AFTER Test-Prerequisites** — Setting `$env:HTTPS_PROXY` before `gh auth status` breaks keyring authentication on Windows. Always run prerequisite checks (which include gh auth) WITHOUT proxy env vars, then set proxy afterwards for actual network operations.
+6. **Set ALL_PROXY alongside HTTPS_PROXY/HTTP_PROXY** — Some tools (git, gh) respect ALL_PROXY more reliably. When `-Proxy` is provided, set all three env vars.
+7. **Auto-stage update-summary files** — release-prepare.ps1 must auto-detect and `git add` any `docs/update-summary-*.md` files in the working directory. Otherwise, the agent must manually add them to the PR branch after the script runs (error-prone).

--- a/.agents/skills/release/release-prepare.ps1
+++ b/.agents/skills/release/release-prepare.ps1
@@ -1,0 +1,336 @@
+<#
+.SYNOPSIS
+    Create-Delight Remake modpack release prepare script (pre-merge phase).
+
+.DESCRIPTION
+    Updates pack.toml version, docs/announcement.md, creates a version-bump
+    branch, commits, pushes, and opens a PR to the target branch.
+
+.PARAMETER Version
+    The new version string, e.g. "v0.4.7.15".
+
+.PARAMETER TargetBranch
+    The base branch for the PR, e.g. "release-v047x" or "main".
+
+.PARAMETER Announcement
+    Comma-separated announcement bullet points, e.g. "修复BUG,新增物品,优化性能".
+    If omitted, generated from the latest git commit message.
+
+.PARAMETER Proxy
+    Optional HTTPS proxy, e.g. "http://127.0.0.1:7890".
+
+.PARAMETER ReleaseType
+    "正式" for full release, "测试" for prerelease. Default: "正式".
+
+.EXAMPLE
+    .\release-prepare.ps1 -Version "v0.4.7.16" -TargetBranch "main" -Announcement "修复BUG,新增物品,优化性能"
+
+.EXAMPLE
+    .\release-prepare.ps1 -Version "v0.4.7.16" -TargetBranch "release-v047x" -ReleaseType 测试 -Proxy "http://127.0.0.1:7890"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$TargetBranch,
+    [string]$Announcement,                                 # Comma-separated, e.g. "修复BUG,新增物品,优化性能"
+    [ValidateSet("正式","测试")][string]$ReleaseType = "正式",
+    [string]$Proxy = "",
+    [switch]$WhatIf
+)
+
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+# Non-interactive git environment
+$env:CI = 'true'
+$env:GIT_TERMINAL_PROMPT = '0'
+$env:GCM_INTERACTIVE = 'never'
+$env:GIT_EDITOR = ':'
+$env:EDITOR = ':'
+$env:GIT_PAGER = 'cat'
+
+# NOTE: Proxy is set AFTER Test-Prerequisites to avoid breaking gh auth keyring.
+# See SKILL.md "PowerShell + gh CLI Pitfalls" #5.
+
+$Stashed = $false
+$OriginalBranch = ""
+$script:PrepareSucceeded = $false
+
+function Restore-State {
+    # Clean up version-bump branch if script failed after creating it
+    $versionBranch = git branch --list "release/$Version" 2>$null
+    if ($versionBranch -and -not $script:PrepareSucceeded) {
+        Write-Host "📦 Cleaning up local branch release/$Version"
+        git checkout $OriginalBranch 2>$null | Out-Null
+        git branch -D "release/$Version" 2>$null | Out-Null
+    }
+    if ($OriginalBranch) {
+        Write-Host "📦 Restoring branch: $OriginalBranch"
+        git checkout $OriginalBranch 2>$null | Out-Null
+    }
+    if ($Stashed) {
+        Write-Host "📦 Unstashing changes"
+        git stash pop 2>$null | Out-Null
+    }
+}
+
+function Test-Prerequisites {
+    $errors = @()
+    
+    # Check pack.toml exists
+    if (-not (Test-Path "pack.toml")) {
+        $errors += "pack.toml not found in current directory"
+    }
+    
+    # Check Version format
+    if ($Version -notmatch '^v\d+\.\d+\.\d+\.\d+$') {
+        $errors += "Version format invalid: '$Version'. Expected format: v0.4.8.10"
+    }
+    
+    # Check gh CLI available
+    $ghAvailable = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $ghAvailable) {
+        $errors += "gh CLI not found. Install GitHub CLI first."
+    }
+    
+    # Check gh auth
+    if ($ghAvailable) {
+        gh auth status 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            $errors += "gh CLI not authenticated. Run 'gh auth login' first."
+        }
+    }
+    
+    # Check TargetBranch exists on remote
+    $remoteBranch = git ls-remote --heads origin $TargetBranch 2>$null
+    if (-not $remoteBranch) {
+        $errors += "Target branch '$TargetBranch' not found on remote"
+    }
+    
+    # Check no existing release for this version
+    if ($ghAvailable) {
+        $existingRelease = gh release view $Version --repo Jasons-impart/Create-Delight-Remake --json tagName 2>$null
+        if ($LASTEXITCODE -eq 0 -and $existingRelease) {
+            $errors += "Release '$Version' already exists on GitHub"
+        }
+    }
+    
+    if ($errors.Count -gt 0) {
+        Write-Host "❌ Pre-flight validation failed:"
+        foreach ($err in $errors) {
+            Write-Host "   - $err"
+        }
+        return $false
+    }
+    
+    Write-Host "✅ Pre-flight validation passed"
+    return $true
+}
+
+# Verify working directory and run pre-flight checks
+if (-not (Test-Prerequisites)) {
+    exit 1
+}
+
+if ($WhatIf) {
+    Write-Host "🔍 DRY RUN - No changes will be made"
+    Write-Host "   Version: $Version"
+    Write-Host "   TargetBranch: $TargetBranch"
+    Write-Host "   ReleaseType: $ReleaseType"
+    Write-Host "   Announcement: $Announcement"
+    Write-Host "   Proxy: $(if($Proxy){$Proxy}else{'(none)'})"
+    Write-Host ""
+    Write-Host "   Would:"
+    Write-Host "   1. Update pack.toml version to $Version"
+    Write-Host "   2. Update docs/announcement.md"
+    Write-Host "   3. Auto-stage update-summary file (if present)"
+    Write-Host "   4. Create branch release/$Version from $TargetBranch"
+    Write-Host "   5. Commit and push"
+    Write-Host "   6. Create PR to $TargetBranch"
+    exit 0
+}
+
+# Set proxy AFTER Test-Prerequisites (gh auth keyring fails with proxy env vars)
+if ($Proxy) {
+    $env:HTTPS_PROXY = $Proxy
+    $env:HTTP_PROXY = $Proxy
+    $env:ALL_PROXY = $Proxy
+    Write-Host "📦 Proxy set: $Proxy"
+}
+
+# Capture original branch
+$OriginalBranch = git rev-parse --abbrev-ref HEAD 2>$null
+if (-not $OriginalBranch) {
+    $OriginalBranch = git rev-parse HEAD 2>$null
+}
+Write-Host "📦 Current branch: $OriginalBranch"
+
+# Check for uncommitted changes
+$StatusOutput = git status --porcelain 2>$null
+if ($StatusOutput) {
+    Write-Host "📦 Stashing uncommitted changes"
+    git stash | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to stash changes"
+        exit 1
+    }
+    $Stashed = $true
+}
+
+# Update pack.toml
+Write-Host "📦 Updating pack.toml version to $Version"
+try {
+    $Content = Get-Content "pack.toml" -Raw
+    $NewContent = $Content -replace 'version = "v[\d.]+"', "version = `"$Version`""
+    if ($NewContent -eq $Content) {
+        Write-Error "Failed to update version in pack.toml - pattern not matched"
+        Restore-State
+        exit 1
+    }
+    [System.IO.File]::WriteAllText((Join-Path $PWD "pack.toml"), $NewContent, $utf8NoBom)
+    Write-Host "✅ pack.toml updated"
+} catch {
+    Write-Error "Failed to update pack.toml: $_"
+    Restore-State
+    exit 1
+}
+
+# Build announcement content
+Write-Host "📦 Building announcement"
+$AnnLines = @()
+if ($Announcement -and $Announcement.Trim()) {
+    # Split by comma (handles both "a,b,c" string and string[] array)
+    $Items = $Announcement -split ','
+    foreach ($Item in $Items) {
+        $Item = $Item.Trim()
+        if ($Item) {
+            $AnnLines += "- $Item"
+        }
+    }
+} else {
+    # Generate from git log
+    $LastMsg = git log -1 --pretty=format:'%s' 2>$null
+    if ($LastMsg) {
+        $AnnLines += "- $LastMsg"
+    }
+}
+
+$AnnContent = "### $Version 已发布"
+if ($AnnLines.Count -gt 0) {
+    $AnnContent += "`n" + ($AnnLines -join "`n")
+}
+
+# Write announcement.md (use WriteAllText to avoid BOM)
+$AnnPath = "docs/announcement.md"
+if (-not (Test-Path "docs")) {
+    New-Item -ItemType Directory -Path "docs" | Out-Null
+}
+[System.IO.File]::WriteAllText((Join-Path $PWD $AnnPath), $AnnContent, $utf8NoBom)
+Write-Host "✅ announcement.md updated"
+
+# Create version-bump branch
+Write-Host "📦 Fetching remote branches"
+git fetch origin 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "⚠️ git fetch failed, continuing anyway"
+}
+
+Write-Host "📦 Creating branch release/$Version from $TargetBranch"
+
+# Check if branch already exists locally
+$existingBranch = git branch --list "release/$Version" 2>$null
+if ($existingBranch) {
+    Write-Host "⚠️ Branch release/$Version already exists locally, deleting"
+    git branch -D "release/$Version" 2>$null | Out-Null
+}
+
+# Check if branch already exists remotely
+$existingRemoteBranch = git ls-remote --heads origin "release/$Version" 2>$null
+if ($existingRemoteBranch) {
+    Write-Host "⚠️ Branch release/$Version already exists remotely, deleting"
+    git push origin --delete "release/$Version" 2>$null | Out-Null
+}
+
+git checkout -b "release/$Version" $TargetBranch 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to create branch release/$Version"
+    Restore-State
+    exit 1
+}
+
+# Stage and commit
+Write-Host "📦 Staging and committing"
+git add pack.toml $AnnPath
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to stage files"
+    Restore-State
+    exit 1
+}
+
+# Auto-stage update-summary file if present (needed for first stable release)
+$summaryFiles = Get-ChildItem -Path "docs" -Filter "update-summary-*.md" -ErrorAction SilentlyContinue
+if ($summaryFiles) {
+    foreach ($sf in $summaryFiles) {
+        $relPath = "docs/$($sf.Name)"
+        Write-Host "📦 Auto-staging update summary: $relPath"
+        git add $relPath 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "✅ Staged $relPath"
+        }
+    }
+}
+
+git commit -m "[feat] $Version $(if($ReleaseType -eq '正式'){'正式版'}else{'测试版'})版本更新"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to commit"
+    Restore-State
+    exit 1
+}
+Write-Host "✅ Committed"
+
+# Push
+Write-Host "📦 Pushing to origin"
+git push -u origin "release/$Version" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to push branch release/$Version"
+    Restore-State
+    exit 1
+}
+Write-Host "✅ Pushed"
+
+# Create PR (use --body-file to handle multiline content)
+Write-Host "📦 Creating PR"
+
+# Check if PR already exists
+$existingPr = gh pr list --repo Jasons-impart/Create-Delight-Remake --head "release/$Version" --base $TargetBranch --json url --jq '.[0].url' 2>$null
+if ($LASTEXITCODE -eq 0 -and $existingPr) {
+    Write-Host "✅ PR already exists: $existingPr"
+    $script:PrepareSucceeded = $true
+    Restore-State
+    Write-Host "✅ Done! PR already exists: $existingPr"
+    Write-Output $existingPr
+    exit 0
+}
+
+$AnnText = $AnnLines -replace '^- ', ''
+$PrBody = "版本号更新: → $Version`n`n**更新内容**:`n- $($AnnText -join "`n- ")"
+$PrBodyFile = Join-Path $env:TEMP "opencode\pr-body-$Version.md"
+New-Item -ItemType Directory -Path (Split-Path $PrBodyFile) -Force | Out-Null
+[System.IO.File]::WriteAllText($PrBodyFile, $PrBody, $utf8NoBom)
+$PrUrl = gh pr create --base $TargetBranch --head "release/$Version" --title "[feat] $Version 版本更新" --body-file $PrBodyFile 2>$null
+Remove-Item $PrBodyFile -Force -ErrorAction SilentlyContinue
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to create PR"
+    Restore-State
+    exit 1
+}
+Write-Host "✅ PR created"
+
+# Restore original branch and unstash
+$script:PrepareSucceeded = $true
+Restore-State
+
+# Output PR URL
+Write-Host "✅ Done! PR URL: $PrUrl"
+Write-Output $PrUrl

--- a/.agents/skills/release/release-publish.ps1
+++ b/.agents/skills/release/release-publish.ps1
@@ -1,0 +1,819 @@
+<#
+.SYNOPSIS
+    Create-Delight Remake post-merge release workflow script.
+
+.DESCRIPTION
+    Handles the full release pipeline after PR merge:
+    - Tags the target branch and pushes the tag
+    - Waits for GitHub Actions CI to complete
+    - Downloads build artifacts (Client, Server, and optionally Patch)
+    - Re-compresses artifacts into zip files
+    - Copies to bracket-free paths (PowerShell [] glob workaround)
+    - Generates release notes from git log
+    - Creates GitHub Release with artifacts
+    - Verifies all assets uploaded
+
+.PARAMETER Version
+    The version tag to create (e.g. "v0.4.7.15").
+
+.PARAMETER TargetBranch
+    The branch to tag on (e.g. "release-v047x").
+
+.PARAMETER PreviousVersion
+    The previous version for release notes and patch artifact names (e.g. "v0.4.7.14").
+
+.PARAMETER ReleaseType
+    "正式" for full release, "测试" for prerelease. Default: "正式".
+
+.PARAMETER Proxy
+    Optional HTTP proxy (e.g. "http://127.0.0.1:7890").
+
+.PARAMETER CIPollIntervalSeconds
+    How often to poll CI status. Default: 30.
+
+.PARAMETER CITimeoutMinutes
+    Max wait for CI. Default: 15.
+
+.EXAMPLE
+    .\release-publish.ps1 -Version v0.4.7.15 -TargetBranch release-v047x
+
+.EXAMPLE
+    .\release-publish.ps1 -Version v0.4.7.15 -TargetBranch release-v047x -PreviousVersion v0.4.7.14 -ReleaseType 测试 -Proxy http://127.0.0.1:7890
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$TargetBranch,
+    [Parameter(Mandatory=$false)][string]$PreviousVersion = "",
+    [ValidateSet("正式","测试")][string]$ReleaseType = "正式",
+    [string]$Proxy = "",
+    [int]$CIPollIntervalSeconds = 30,
+    [int]$CITimeoutMinutes = 15,
+    [switch]$WhatIf
+)
+
+$ErrorActionPreference = "Stop"
+
+# --- State for cleanup ---
+$script:OriginalBranch = $null
+$script:Stashed = $false
+
+function Restore-State {
+    <# Restore original branch and unstash if needed #>
+    if ($script:OriginalBranch -and $script:OriginalBranch -ne $TargetBranch) {
+        Write-Host "🔄 Restoring original branch: $script:OriginalBranch"
+        git checkout $script:OriginalBranch 2>$null
+    }
+    if ($script:Stashed) {
+        Write-Host "🔄 Restoring stashed changes"
+        git stash pop 2>$null
+    }
+}
+
+function Fail {
+    param([string]$Message)
+    Write-Host "❌ $Message"
+    Restore-State
+    Write-Error $Message
+    exit 1
+}
+
+function Test-Prerequisites {
+    $errors = @()
+    
+    # Check Version format
+    if ($Version -notmatch '^v\d+\.\d+\.\d+\.\d+$') {
+        $errors += "Version format invalid: '$Version'. Expected format: v0.4.8.10"
+    }
+    
+    # Check pack.toml exists
+    if (-not (Test-Path "pack.toml")) {
+        $errors += "pack.toml not found in current directory"
+    }
+    
+    # Check gh CLI available
+    $ghAvailable = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $ghAvailable) {
+        $errors += "gh CLI not found. Install GitHub CLI first."
+    }
+    
+    # Check gh auth
+    if ($ghAvailable) {
+        try {
+            gh auth status 2>$null | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                $errors += "gh CLI not authenticated. Run 'gh auth login' first."
+            }
+        } catch {
+            $errors += "gh CLI not authenticated. Run 'gh auth login' first."
+        }
+    }
+    
+    # Check TargetBranch exists on remote
+    $remoteBranch = git ls-remote --heads origin $TargetBranch 2>$null
+    if (-not $remoteBranch) {
+        $errors += "Target branch '$TargetBranch' not found on remote"
+    }
+    
+    # Check no existing release for this version
+    if ($ghAvailable) {
+        try {
+            $existingRelease = gh release view $Version --repo Jasons-impart/Create-Delight-Remake --json tagName 2>$null
+            if ($LASTEXITCODE -eq 0 -and $existingRelease) {
+                $errors += "Release '$Version' already exists on GitHub. Cannot recreate a release."
+            }
+        } catch {
+            # gh release view returns error for non-existent releases, which is expected
+        }
+    }
+    
+    if ($errors.Count -gt 0) {
+        Write-Host "❌ Pre-flight validation failed:"
+        foreach ($err in $errors) {
+            Write-Host "   - $err"
+        }
+        return $false
+    }
+    
+    Write-Host "✅ Pre-flight validation passed"
+    return $true
+}
+
+if (-not (Test-Prerequisites)) {
+    exit 1
+}
+
+# Auto-detect PreviousVersion if not provided (matches CI's patch-tasks logic)
+if (-not $PreviousVersion) {
+    Write-Host "🔍 Auto-detecting PreviousVersion..."
+    # After checkout & pull in Phase A, HEAD will have the tag.
+    # Use same logic as CI: if HEAD has exact tag, look at HEAD^; otherwise HEAD.
+    # But we're running before Phase A checkout, so use remote tags.
+    $autoPrev = git describe --tags --abbrev=0 "$Version^" 2>$null
+    if ($LASTEXITCODE -eq 0 -and $autoPrev) {
+        $PreviousVersion = $autoPrev
+        Write-Host "   ✅ Auto-detected PreviousVersion: $PreviousVersion"
+    } else {
+        # Fallback: list tags and find the one before $Version
+        $allTags = git tag -l 'v*' --sort=-version:refname 2>$null
+        $found = $false
+        foreach ($tag in $allTags) {
+            if ($tag -eq $Version) { continue }
+            if ($tag -match '^v\d+\.\d+\.\d+\.\d+$') {
+                $PreviousVersion = $tag
+                $found = $true
+                Write-Host "   ✅ Auto-detected PreviousVersion from tag list: $PreviousVersion"
+                break
+            }
+        }
+        if (-not $found) {
+            Fail "Cannot auto-detect PreviousVersion. Please provide -PreviousVersion parameter."
+        }
+    }
+}
+
+# Validate PreviousVersion format (now that it may be auto-detected)
+if ($PreviousVersion -notmatch '^v\d+\.\d+\.\d+\.\d+$') {
+    Fail "PreviousVersion format invalid: '$PreviousVersion'. Expected format: v0.4.7.15"
+}
+
+# Verify PreviousVersion tag exists
+$prevTag = git tag -l $PreviousVersion 2>$null
+if (-not $prevTag) {
+    Fail "PreviousVersion tag '$PreviousVersion' not found locally. Available tags: $(git tag -l 'v*' | Select-Object -Last 5)"
+}
+
+if ($WhatIf) {
+    Write-Host ""
+    Write-Host "🔍 DRY RUN - No changes will be made"
+    Write-Host "   Version: $Version"
+    Write-Host "   TargetBranch: $TargetBranch"
+    Write-Host "   PreviousVersion: $PreviousVersion"
+    Write-Host "   ReleaseType: $ReleaseType"
+    Write-Host ""
+    Write-Host "   Would:"
+    Write-Host "   A. Create tag $Version on $TargetBranch and push"
+    Write-Host "   B. Wait for CI (timeout: $CITimeoutMinutes min)"
+    Write-Host "   C. Download artifacts (Client, Server$(if($ReleaseType -eq '正式'){', ClientPatch, ServerPatch'}))"
+    Write-Host "   D. Compress and prepare for upload"
+    Write-Host "   E. Generate release notes from $PreviousVersion..$Version"
+    Write-Host "   F. Create GitHub release as $(if($ReleaseType -eq '正式'){'stable'}else{'prerelease'})"
+    Write-Host "   G. Verify assets"
+    if ($ReleaseType -eq "正式") {
+        Write-Host "   H. Create announcement PR to main"
+    }
+    exit 0
+}
+
+# ============================================================
+# Phase A: Tag
+# ============================================================
+Write-Host "🏷️ Phase A: Creating and pushing tag $Version"
+
+# Set proxy AFTER Test-Prerequisites (gh auth keyring fails with proxy env vars)
+# See SKILL.md "PowerShell + gh CLI Pitfalls" #5.
+if ($Proxy) {
+    $env:HTTPS_PROXY = $Proxy
+    $env:HTTP_PROXY = $Proxy
+    $env:ALL_PROXY = $Proxy
+    Write-Host "🌐 Proxy set: $Proxy"
+}
+
+# Set git env vars for non-interactive operation
+$env:CI = 'true'
+$env:GIT_TERMINAL_PROMPT = '0'
+$env:GCM_INTERACTIVE = 'never'
+$env:GIT_EDITOR = ':'
+$env:EDITOR = ':'
+$env:GIT_PAGER = 'cat'
+
+# Record original branch
+$script:OriginalBranch = git branch --show-current
+if ($LASTEXITCODE -ne 0) { Fail "Cannot determine current branch" }
+
+# Stash uncommitted changes if any
+$dirty = git status --porcelain
+if ($dirty) {
+    Write-Host "📦 Stashing uncommitted changes"
+    git stash
+    if ($LASTEXITCODE -ne 0) { Fail "git stash failed" }
+    $script:Stashed = $true
+}
+
+# Checkout target branch
+git checkout $TargetBranch
+if ($LASTEXITCODE -ne 0) { Fail "Cannot checkout branch $TargetBranch" }
+
+# Pull latest
+git pull
+if ($LASTEXITCODE -ne 0) { Fail "git pull failed on $TargetBranch" }
+
+# Pop stash after pull to avoid conflicts with incoming changes
+if ($script:Stashed) {
+    git stash pop 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "⚠️ stash pop had conflicts, continuing anyway"
+    }
+    $script:Stashed = $false
+}
+
+# Record commit SHA for CI matching (before tagging, so it matches the commit CI will run on)
+$commitSha = git rev-parse HEAD
+if ($LASTEXITCODE -ne 0) { Fail "Cannot determine HEAD commit SHA" }
+Write-Host "   Commit SHA: $commitSha"
+
+# Create tag (idempotent: skip if already exists on correct commit)
+$existingTagCommit = git rev-list -n 1 $Version 2>$null
+if ($LASTEXITCODE -eq 0 -and $existingTagCommit) {
+    if ($existingTagCommit -eq $commitSha) {
+        Write-Host "   Tag $Version already exists on current commit, skipping tag creation"
+    } else {
+        Fail "Tag $Version already exists on different commit ($existingTagCommit). Current commit is $commitSha. Delete the tag first or use a different version."
+    }
+} else {
+    git tag $Version
+    if ($LASTEXITCODE -ne 0) { Fail "Cannot create tag $Version" }
+
+    git push origin $Version
+    if ($LASTEXITCODE -ne 0) { Fail "Cannot push tag $Version" }
+
+    Write-Host "✅ Tag $Version pushed"
+}
+
+# ============================================================
+# Phase B: Wait for CI
+# ============================================================
+Write-Host "⏳ Phase B: Waiting for GitHub Actions CI"
+
+$repo = "Jasons-impart/Create-Delight-Remake"
+$timeout = [TimeSpan]::FromMinutes($CITimeoutMinutes)
+$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+$RunId = $null
+
+# Wait for the workflow run triggered by our tag to appear.
+# Match by workflow name AND head_sha to avoid picking up a previous run.
+# Use single quotes for --jq to avoid PowerShell string interpolation issues.
+$workflowName = "发布版本"
+while ($stopwatch.Elapsed -lt $timeout) {
+    # First get all runs, then filter in PowerShell to avoid jq quoting hell
+    $allRuns = gh run list --repo $repo --limit 10 --json databaseId,status,conclusion,name,headSha 2>$null
+    if ($LASTEXITCODE -eq 0 -and $allRuns) {
+        $runs = $allRuns | ConvertFrom-Json -ErrorAction SilentlyContinue
+        $matchingRun = $runs | Where-Object { $_.name -eq $workflowName -and $_.headSha -eq $commitSha } | Select-Object -First 1
+        if ($matchingRun -and $matchingRun.databaseId) {
+            $RunId = $matchingRun.databaseId
+            break
+        }
+    }
+    Write-Host "   Waiting for workflow run (SHA $commitSha) to appear..."
+    Start-Sleep -Seconds $CIPollIntervalSeconds
+}
+
+if (-not $RunId) {
+    Fail "CI workflow run not found within $CITimeoutMinutes minutes"
+}
+
+Write-Host "   Found workflow run: $RunId"
+
+# Poll until completed
+$stopwatch.Restart()
+while ($stopwatch.Elapsed -lt $timeout) {
+    $statusJson = gh run view $RunId --repo $repo --json status,conclusion 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Fail "Cannot query CI run status"
+    }
+    $runStatus = $statusJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+    $status = $runStatus.status
+    $conclusion = $runStatus.conclusion
+
+    if ($status -eq "completed") {
+        if ($conclusion -eq "success") {
+            Write-Host "✅ CI completed successfully (run $RunId)"
+            break
+        } else {
+            $runUrl = "https://github.com/$repo/actions/runs/$RunId"
+            Fail "CI failed with conclusion: $conclusion. See: $runUrl"
+        }
+    }
+
+    Write-Host "   CI status: $status (elapsed: $($stopwatch.Elapsed.ToString('mm\:ss')))"
+    Start-Sleep -Seconds $CIPollIntervalSeconds
+}
+
+if ($stopwatch.Elapsed -ge $timeout) {
+    Fail "CI timed out after $CITimeoutMinutes minutes"
+}
+
+# ============================================================
+# Phase C: Download Artifacts
+# ============================================================
+Write-Host "📥 Phase C: Downloading artifacts"
+
+$tmpDir = Join-Path $env:TEMP "opencode\$Version"
+New-Item -ItemType Directory -Path "$tmpDir\client" -Force | Out-Null
+New-Item -ItemType Directory -Path "$tmpDir\clientpatch" -Force | Out-Null
+New-Item -ItemType Directory -Path "$tmpDir\server" -Force | Out-Null
+New-Item -ItemType Directory -Path "$tmpDir\serverpatch" -Force | Out-Null
+
+# Artifact name patterns
+$clientName = "[Client]Create-Delight-Remake-$Version"
+$clientPatchName = "[ClientPatch]Create-Delight-Remake-$PreviousVersion-to-$Version"
+$serverName = "Server-Create-Delight-Remake-$Version"
+$serverPatchName = "[ServerPatch]Create-Delight-Remake-$PreviousVersion-to-$Version"
+
+# List available artifacts and filter in PowerShell (avoids jq quoting issues)
+$artifactsResponse = gh api "repos/$repo/actions/runs/$RunId/artifacts" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Fail "Cannot list artifacts"
+}
+$artifactsObj = $artifactsResponse | ConvertFrom-Json -ErrorAction SilentlyContinue
+$artifacts = @()
+if ($artifactsObj -and $artifactsObj.artifacts) {
+    $artifacts = @($artifactsObj.artifacts | Where-Object { 
+        $_.name -notmatch 'ClickToUse' -and $_.name -notmatch 'manifest' 
+    })
+}
+
+# Download function with progress display
+function Download-Artifact {
+    param([string]$Name, [string]$DestDir)
+    $found = $artifacts | Where-Object { $_.name -eq $Name }
+    if (-not $found) {
+        Fail "Artifact not found: $Name. Available: $($artifacts.name -join ', ')"
+    }
+    $sizeInBytes = $found.size_in_bytes
+    $sizeMB = if ($sizeInBytes) { [math]::Round($sizeInBytes / 1MB, 1) } else { "?" }
+
+    Write-Host "   📥 Downloading $Name ($sizeMB MB) -> $DestDir"
+
+    # Download via gh api for progress, with fallback to gh run download
+    $artifactId = $found.id
+    $zipFile = Join-Path $env:TEMP "opencode\$Version\artifacts\$Name.zip"
+    New-Item -ItemType Directory -Path (Split-Path $zipFile) -Force | Out-Null
+
+    try {
+        # Use gh api to download the artifact zip directly
+        # This shows download progress via gh's built-in progress indicator
+        gh api "repos/$repo/actions/artifacts/$artifactId/zip" --output $zipFile 2>$null
+        if ($LASTEXITCODE -eq 0 -and (Test-Path $zipFile) -and ((Get-Item $zipFile).Length -gt 0)) {
+            # Extract the zip to destination
+            Expand-Archive -Path $zipFile -DestinationPath $DestDir -Force
+            Remove-Item $zipFile -Force -ErrorAction SilentlyContinue
+            Write-Host "   ✅ Downloaded $Name ($sizeMB MB)"
+        } else {
+            throw "gh api download returned empty or failed"
+        }
+    } catch {
+        # Fallback to gh run download (no size display but reliable)
+        Write-Host "   ⚠️ Direct download failed, falling back to gh run download..."
+        if (Test-Path $zipFile) { Remove-Item $zipFile -Force -ErrorAction SilentlyContinue }
+        gh run download $RunId --repo $repo -n $Name -D $DestDir
+        if ($LASTEXITCODE -ne 0) {
+            Fail "Failed to download artifact: $Name"
+        }
+        Write-Host "   ✅ Downloaded $Name (via gh run download)"
+    }
+}
+
+# Always download Client and Server
+Download-Artifact -Name $clientName -DestDir "$tmpDir\client"
+Download-Artifact -Name $serverName -DestDir "$tmpDir\server"
+
+# Only download patches for 正式版
+if ($ReleaseType -eq "正式") {
+    Download-Artifact -Name $clientPatchName -DestDir "$tmpDir\clientpatch"
+    Download-Artifact -Name $serverPatchName -DestDir "$tmpDir\serverpatch"
+}
+
+Write-Host "✅ All artifacts downloaded"
+
+# ============================================================
+# Phase D: Compress Artifacts
+# ============================================================
+Write-Host "📦 Phase D: Compressing artifacts"
+
+# Client
+$clientZip = "$tmpDir\$clientName.zip"
+Write-Host "   📦 Compressing client -> $clientZip"
+Compress-Archive -Path "$tmpDir\client\*" -DestinationPath $clientZip -Force
+
+# Server
+$serverZip = "$tmpDir\$serverName.zip"
+Write-Host "   📦 Compressing server -> $serverZip"
+Compress-Archive -Path "$tmpDir\server\*" -DestinationPath $serverZip -Force
+
+# Patches (正式版 only)
+if ($ReleaseType -eq "正式") {
+    $clientPatchZip = "$tmpDir\$clientPatchName.zip"
+    Write-Host "   📦 Compressing clientpatch -> $clientPatchZip"
+    Compress-Archive -Path "$tmpDir\clientpatch\*" -DestinationPath $clientPatchZip -Force
+
+    $serverPatchZip = "$tmpDir\$serverPatchName.zip"
+    Write-Host "   📦 Compressing serverpatch -> $serverPatchZip"
+    Compress-Archive -Path "$tmpDir\serverpatch\*" -DestinationPath $serverPatchZip -Force
+}
+
+Write-Host "✅ All artifacts compressed"
+
+# ============================================================
+# Phase E: Bracket-free copy
+# ============================================================
+Write-Host "📋 Phase E: Copying to bracket-free paths"
+
+$uploadDir = "$tmpDir\upload"
+New-Item -ItemType Directory -Path $uploadDir -Force | Out-Null
+
+# Client: [Client]xxx -> Client-xxx
+$uploadClient = "$uploadDir\Client-Create-Delight-Remake-$Version.zip"
+Copy-Item -LiteralPath $clientZip -Destination $uploadClient
+
+# Server: no brackets but copy for consistency
+$uploadServer = "$uploadDir\Server-Create-Delight-Remake-$Version.zip"
+Copy-Item -LiteralPath $serverZip -Destination $uploadServer
+
+if ($ReleaseType -eq "正式") {
+    # ClientPatch: [ClientPatch]xxx -> ClientPatch-xxx
+    $uploadClientPatch = "$uploadDir\ClientPatch-Create-Delight-Remake-$PreviousVersion-to-$Version.zip"
+    Copy-Item -LiteralPath $clientPatchZip -Destination $uploadClientPatch
+
+    # ServerPatch: [ServerPatch]xxx -> ServerPatch-xxx
+    $uploadServerPatch = "$uploadDir\ServerPatch-Create-Delight-Remake-$PreviousVersion-to-$Version.zip"
+    Copy-Item -LiteralPath $serverPatchZip -Destination $uploadServerPatch
+}
+
+Write-Host "✅ Bracket-free copies created in $uploadDir"
+
+# ============================================================
+# Phase F: Generate Release Notes
+# ============================================================
+Write-Host "📝 Phase F: Generating release notes"
+
+# --- Check if this is the first stable release of the sub-version ---
+# Extract sub-version prefix, e.g. "v0.4.8" from "v0.4.8.9"
+$subVersionPrefix = ""
+if ($Version -match '^(v\d+\.\d+\.\d+)') {
+    $subVersionPrefix = $Matches[1]
+}
+$isFirstStable = $false
+$summaryFilePath = ""
+
+if ($subVersionPrefix -and $ReleaseType -eq "正式") {
+    # Check if any existing tag with this sub-version prefix is a stable (non-prerelease) release
+    $existingTags = git tag -l "$subVersionPrefix*" 2>$null
+    $hasStableRelease = $false
+    foreach ($tag in $existingTags) {
+        if ($tag -eq $Version) { continue }  # Skip the tag we just created
+        $releaseInfo = gh release view $tag --repo $repo --json isPrerelease 2>$null
+        if ($LASTEXITCODE -eq 0 -and $releaseInfo) {
+            $relObj = $releaseInfo | ConvertFrom-Json -ErrorAction SilentlyContinue
+            if ($relObj -and -not $relObj.isPrerelease) {
+                $hasStableRelease = $true
+                Write-Host "   Found existing stable release: $tag"
+                break
+            }
+        }
+    }
+    if (-not $hasStableRelease) {
+        $isFirstStable = $true
+        Write-Host "   🎉 This is the first stable release of $subVersionPrefix"
+    }
+}
+
+# --- Prepend update summary if this is the first stable release ---
+$summaryContent = ""
+if ($isFirstStable) {
+    # Look for update summary file: docs/update-summary-{version}.md
+    $summaryFilePath = "docs/update-summary-$Version.md"
+    if (Test-Path $summaryFilePath) {
+        $summaryContent = Get-Content $summaryFilePath -Raw
+        Write-Host "   📄 Found update summary: $summaryFilePath"
+    } else {
+        # Try with sub-version prefix pattern: docs/update-summary-v0.4.8.*.md
+        $summaryCandidates = Get-ChildItem -Path "docs" -Filter "update-summary-$subVersionPrefix*.md" -ErrorAction SilentlyContinue
+        if ($summaryCandidates) {
+            $summaryFilePath = $summaryCandidates | Sort-Object Name -Descending | Select-Object -First 1
+            $summaryContent = Get-Content $summaryFilePath.FullName -Raw
+            Write-Host "   📄 Found update summary: $($summaryFilePath.FullName)"
+        } else {
+            Write-Host "   ⚠️ No update summary file found for $subVersionPrefix (expected docs/update-summary-$Version.md)"
+        }
+    }
+}
+
+# Get commits between versions
+$commits = git log "$PreviousVersion..$Version" --pretty=format:'%s' 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "   ⚠️ Cannot get git log, using empty release notes"
+    $commits = @()
+}
+
+# Filter out version bump commits - only filter the specific format used by prepare script
+$commits = $commits | Where-Object { $_ -notmatch '^\[feat\]\s*v\d[\d.]+\s+(正式版|测试版)版本更新$' }
+
+# Categorize
+$categories = [ordered]@{
+    '[mod]'   = "模组更新"
+    '[feat]'  = "新功能"
+    '[fix]'   = "Bug修复"
+    '[quest]' = "任务相关"
+    '[conf]'  = "配置调整"
+}
+$uncategorized = "其他"
+
+$grouped = @{}
+foreach ($key in $categories.Keys) { $grouped[$key] = @() }
+$grouped[$uncategorized] = @()
+
+foreach ($commit in $commits) {
+    $matched = $false
+    foreach ($prefix in $categories.Keys) {
+        $escaped = [regex]::Escape($prefix)
+        if ($commit -match "^$escaped") {
+            # Strip the [xxx] prefix
+            $msg = $commit -replace "^$escaped\s*", ""
+            $grouped[$prefix] += $msg
+            $matched = $true
+            break
+        }
+    }
+    if (-not $matched) {
+        $grouped[$uncategorized] += $commit
+    }
+}
+
+# Build markdown
+$sb = [System.Text.StringBuilder]::new()
+
+# Prepend update summary if available (before the per-commit notes)
+if ($summaryContent) {
+    [void]$sb.AppendLine($summaryContent.TrimEnd())
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("---")
+    [void]$sb.AppendLine("")
+}
+
+[void]$sb.AppendLine("## 更新内容 (AI自动生成)")
+[void]$sb.AppendLine("")
+
+foreach ($prefix in $categories.Keys) {
+    $items = $grouped[$prefix]
+    if ($items.Count -gt 0) {
+        [void]$sb.AppendLine("**$($categories[$prefix])**")
+        foreach ($item in $items) {
+            [void]$sb.AppendLine("- $item")
+        }
+        [void]$sb.AppendLine("")
+    }
+}
+
+# Uncategorized
+$uncatItems = $grouped[$uncategorized]
+if ($uncatItems.Count -gt 0) {
+    [void]$sb.AppendLine("**$uncategorized**")
+    foreach ($item in $uncatItems) {
+        [void]$sb.AppendLine("- $item")
+    }
+    [void]$sb.AppendLine("")
+}
+
+# For 测试版, add patch note
+if ($ReleaseType -eq "测试") {
+    [void]$sb.AppendLine("**增量更新**: 测试版不提供Patch文件，请下载完整包。")
+    [void]$sb.AppendLine("")
+}
+
+# For 正式版, add incremental update note
+if ($ReleaseType -eq "正式") {
+    [void]$sb.AppendLine("**增量更新**")
+    [void]$sb.AppendLine("从 $PreviousVersion 更新只需下载 ClientPatch 和 ServerPatch 文件。")
+    [void]$sb.AppendLine("")
+}
+
+# Add compare link
+[void]$sb.AppendLine("**详细更新**: https://github.com/$repo/compare/$PreviousVersion...$Version")
+
+$ReleaseNotes = $sb.ToString()
+Write-Host "📝 Release notes generated"
+
+# ============================================================
+# Phase G: Create Release
+# ============================================================
+Write-Host "🚀 Phase G: Creating GitHub Release"
+
+if ($ReleaseType -eq "正式") {
+    $title = "$Version 正式版"
+    $notesFile = Join-Path $env:TEMP "opencode\release-notes-$Version.md"
+    New-Item -ItemType Directory -Path (Split-Path $notesFile) -Force | Out-Null
+    [System.IO.File]::WriteAllText($notesFile, $ReleaseNotes, [System.Text.UTF8Encoding]::new($false))
+    gh release create $Version --repo $repo --title $title --notes-file $notesFile `
+        "$uploadClient" `
+        "$uploadClientPatch" `
+        "$uploadServer" `
+        "$uploadServerPatch"
+    Remove-Item $notesFile -Force -ErrorAction SilentlyContinue
+} else {
+    $title = "$Version 测试版"
+    $notesFile = Join-Path $env:TEMP "opencode\release-notes-$Version.md"
+    New-Item -ItemType Directory -Path (Split-Path $notesFile) -Force | Out-Null
+    [System.IO.File]::WriteAllText($notesFile, $ReleaseNotes, [System.Text.UTF8Encoding]::new($false))
+    gh release create $Version --repo $repo --title $title --prerelease --notes-file $notesFile `
+        "$uploadClient" `
+        "$uploadServer"
+    Remove-Item $notesFile -Force -ErrorAction SilentlyContinue
+}
+
+if ($LASTEXITCODE -ne 0) {
+    Fail "Failed to create GitHub release"
+}
+
+Write-Host "✅ Release created: $title"
+
+# ============================================================
+# Phase H: Verify
+# ============================================================
+Write-Host "🔍 Phase H: Verifying uploaded assets"
+
+$releaseViewJson = gh release view $Version --repo $repo --json assets 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Fail "Cannot verify release assets"
+}
+$releaseView = $releaseViewJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+$uploadedAssets = @()
+if ($releaseView -and $releaseView.assets) {
+    $uploadedAssets = @($releaseView.assets | ForEach-Object { $_.name })
+}
+$assetCount = @($uploadedAssets).Count
+
+$expectedCount = if ($ReleaseType -eq "正式") { 4 } else { 2 }
+
+Write-Host "   Uploaded assets ($assetCount/$expectedCount):"
+foreach ($a in $uploadedAssets) {
+    Write-Host "     - $a"
+}
+
+if ($assetCount -ne $expectedCount) {
+    # Build expected list
+    $expectedAssets = @(
+        "Client-Create-Delight-Remake-$Version.zip",
+        "Server-Create-Delight-Remake-$Version.zip"
+    )
+    if ($ReleaseType -eq "正式") {
+        $expectedAssets += @(
+            "ClientPatch-Create-Delight-Remake-$PreviousVersion-to-$Version.zip",
+            "ServerPatch-Create-Delight-Remake-$PreviousVersion-to-$Version.zip"
+        )
+    }
+    $missing = $expectedAssets | Where-Object { $uploadedAssets -notcontains $_ }
+    Fail "Asset count mismatch: expected $expectedCount, got $assetCount. Missing: $($missing -join ', ')"
+}
+
+Write-Host "✅ All $assetCount assets verified"
+
+# ============================================================
+# Phase I: Announcement PR to main
+# ============================================================
+# For stable releases, create a separate PR to main with docs/announcement.md update.
+# Best-effort: if this fails, the release is still complete.
+$announcementPrUrl = ""
+
+if ($ReleaseType -eq "正式") {
+    Write-Host "📢 Phase I: Creating announcement PR to main"
+
+    try {
+        # Read announcement.md content BEFORE any branch switching.
+        # The $Version tag is on $TargetBranch, not main, so we must read
+        # while still checked out on $TargetBranch. If we've drifted to
+        # another branch somehow, ensure we're back on $TargetBranch first.
+        $currentForAnn = git branch --show-current 2>$null
+        if ($currentForAnn -ne $TargetBranch) {
+            Write-Host "   Ensuring we're on $TargetBranch before reading announcement"
+            git checkout $TargetBranch 2>$null
+        }
+        $annFromTag = git show "$Version:docs/announcement.md" 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $annFromTag) {
+            Write-Host "   ⚠️ Cannot read docs/announcement.md from tag $Version, skipping announcement PR"
+        } else {
+            # Create a branch from main for the announcement update
+            $annBranch = "announcement/$Version"
+            git fetch origin main 2>$null
+            git checkout -b $annBranch origin/main 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "   ⚠️ Cannot create branch $annBranch from origin/main, skipping announcement PR"
+            } else {
+                # Ensure docs directory exists
+                if (-not (Test-Path "docs")) {
+                    New-Item -ItemType Directory -Path "docs" | Out-Null
+                }
+
+                # Write announcement.md (UTF-8 no BOM)
+                $annPath = "docs/announcement.md"
+                $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+                [System.IO.File]::WriteAllText((Join-Path $PWD $annPath), $annFromTag, $utf8NoBom)
+
+                # Stage, commit, push
+                git add $annPath
+                git commit -m "[docs] 更新公告至$Version版本" 2>$null
+                if ($LASTEXITCODE -eq 0) {
+                    git push -u origin $annBranch 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        # Create PR to main
+                        $prBody = "自动更新 docs/announcement.md 至 $Version 正式版。"
+                        $prBodyFile = Join-Path $env:TEMP "opencode\ann-pr-body-$Version.md"
+                        New-Item -ItemType Directory -Path (Split-Path $prBodyFile) -Force | Out-Null
+                        [System.IO.File]::WriteAllText($prBodyFile, $prBody, [System.Text.UTF8Encoding]::new($false))
+                        $announcementPrUrl = gh pr create --base main --head $annBranch --title "[docs] 更新公告至$Version版本" --body-file $prBodyFile 2>$null
+                        Remove-Item $prBodyFile -Force -ErrorAction SilentlyContinue
+                        if ($LASTEXITCODE -eq 0) {
+                            Write-Host "   ✅ Announcement PR created: $announcementPrUrl"
+                        } else {
+                            Write-Host "   ⚠️ Failed to create announcement PR (gh pr create failed)"
+                        }
+                    } else {
+                        Write-Host "   ⚠️ Failed to push announcement branch"
+                    }
+                } else {
+                    Write-Host "   ⚠️ No changes to commit (announcement.md may be unchanged on main)"
+                }
+
+                # Return to target branch
+                git checkout $TargetBranch 2>$null
+            }
+        }
+    } catch {
+        Write-Host "   ⚠️ Announcement PR failed: $_"
+    } finally {
+        # Always ensure we're back on the target branch after Phase I
+        $currentBranch = git branch --show-current 2>$null
+        if ($currentBranch -ne $TargetBranch) {
+            Write-Host "   Restoring branch to $TargetBranch"
+            git checkout $TargetBranch 2>$null
+        }
+    }
+} else {
+    Write-Host "📢 Phase I: Skipped (测试版 does not need announcement PR)"
+}
+
+# ============================================================
+# Phase J: Cleanup
+# ============================================================
+Write-Host "🧹 Phase J: Cleanup"
+
+Restore-State
+
+# Output release URL
+$releaseUrlJson = gh release view $Version --repo $repo --json url 2>$null
+if ($LASTEXITCODE -eq 0 -and $releaseUrlJson) {
+    $urlObj = $releaseUrlJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+    $releaseUrl = $urlObj.url
+}
+if (-not $releaseUrl) {
+    $releaseUrl = "https://github.com/$repo/releases/tag/$Version"
+}
+
+Write-Host ""
+Write-Host "🎉 Release published successfully!"
+Write-Host "🔗 $releaseUrl"
+if ($announcementPrUrl) {
+    Write-Host "📢 Announcement PR: $announcementPrUrl"
+}
+Write-Host "📁 Temp directory preserved: $tmpDir"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
           done
           # 5. 下载并运行 packwiz-installer-bootstrap（bootstrap会自动下载installer）
           curl -o packwiz-installer-bootstrap.jar -L $PACKWIZ_INSTALLER_BOOTSTRAP_URL
-          java -jar packwiz-installer-bootstrap.jar --bootstrap-no-update -g "http://127.0.0.1:$PORT/pack.toml"
+          java -jar packwiz-installer-bootstrap.jar -g "http://127.0.0.1:$PORT/pack.toml"
           # 6. 清理
           kill $SERVER_PID 2>/dev/null || true
           rm -rf "$PACK_DIR" packwiz-installer-bootstrap.jar
@@ -579,7 +579,7 @@ jobs:
             sleep 0.2
           done
           curl -o packwiz-installer-bootstrap.jar -L $PACKWIZ_INSTALLER_BOOTSTRAP_URL
-          java -jar packwiz-installer-bootstrap.jar --bootstrap-no-update -g "http://127.0.0.1:$PORT/pack.toml"
+          java -jar packwiz-installer-bootstrap.jar -g "http://127.0.0.1:$PORT/pack.toml"
           kill $SERVER_PID 2>/dev/null || true
           rm -rf "$PACK_DIR" packwiz-installer-bootstrap.jar
           # detect 生成 manifest.json（给客户端补丁用，CF mod 以引用形式记录）

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 env:
   VERSION_FILE_PATH: config/fancymenu/assets/version.md
   PACKWIZ_DOWNLOAD_URL: https://github.com/Jasons-impart/packwiz/releases/latest/download/packwiz
+  PACKWIZ_INSTALLER_URL: https://github.com/packwiz/packwiz-installer/releases/latest/download/packwiz-installer.jar
+  PACKWIZ_FILES_RAW_PREFIX: https://raw.githubusercontent.com/Jasons-impart/Create-Delight-Remake/main/packwiz-files/
   HMCL_DOWNLOAD_URL: https://github.com/HMCL-dev/HMCL/releases/download/release-3.7.3/HMCL-3.7.3.jar
   JAVA_DOWNLOAD_URL: https://download.oracle.com/java/17/archive/jdk-17.0.12_windows-x64_bin.msi
   FORGE_DOWNLOAD_URL_PREFIX: https://maven.minecraftforge.net/net/minecraftforge/forge
@@ -214,23 +216,59 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1 # 只取最新提交，加速
-      - name: 删除与服务端无关的文件
+      - name: 安装 Packwiz
         run: |
-            # mapfile -t prefixes < .packwizignore
-            # for prefix in "${prefixes[@]}"; do
-            #   echo "Deleting files with prefix: $prefix"
-            #   find ${{ github.workspace }} -name "${prefix}*" -exec rm {} +
-            # done
-            rm -rf resourcepacks
-            rm -rf shaderpacks
-            rm -f ModList0.4a.md
-            rm -f README.md
-            rm -f TODOlist.md
-            rm -f KubeJSStyleGuide.md
-            rm -f DevGuide.md
-            rm -f pack.toml
-            rm -f index.toml
-            rm -f client_jvm_args.example.txt
+          curl -o packwiz -L $PACKWIZ_DOWNLOAD_URL
+          chmod +x ./packwiz
+      - name: 更新文件索引
+        run: |
+          ./packwiz refresh
+      - name: 下载所有mod本体（packwiz-installer）
+        run: |
+          set -euo pipefail
+          # 参考脚本: scripts/sync-packwiz-assets.ps1
+          # 1. 创建临时 pack 目录，复制元数据和 packwiz-files/
+          PACK_DIR=$(mktemp -d)
+          cp pack.toml "$PACK_DIR/"
+          cp .packwizignore "$PACK_DIR/" 2>/dev/null || true
+          touch "$PACK_DIR/index.toml"
+          # 复制 .pw.toml 元数据
+          find mods resourcepacks shaderpacks -name '*.pw.toml' 2>/dev/null | while read -r f; do
+            mkdir -p "$PACK_DIR/$(dirname "$f")"
+            cp "$f" "$PACK_DIR/$f"
+          done
+          # 复制 packwiz-files/（CF受限 mod/资源包/光影包本体）
+          if [ -d "packwiz-files" ]; then
+            cp -r packwiz-files "$PACK_DIR/"
+          fi
+          # 2. 将 .pw.toml 中的 GitHub raw URL 替换为 localhost
+          PORT=8080
+          LOCAL_PREFIX="http://127.0.0.1:$PORT/packwiz-files/"
+          find "$PACK_DIR" -name '*.pw.toml' -exec sed -i "s|${PACKWIZ_FILES_RAW_PREFIX}|${LOCAL_PREFIX}|g" {} +
+          # 3. 在临时目录中 refresh 生成索引
+          (cd "$PACK_DIR" && "$OLDPWD/packwiz" refresh)
+          # 4. 启动 Python 静态服务器
+          python3 -m http.server $PORT --directory "$PACK_DIR" &
+          SERVER_PID=$!
+          # 等待服务器就绪
+          for i in $(seq 1 25); do
+            if curl -s -o /dev/null "http://127.0.0.1:$PORT/pack.toml"; then break; fi
+            sleep 0.2
+          done
+          # 5. 下载并运行 packwiz-installer
+          curl -o packwiz-installer.jar -L $PACKWIZ_INSTALLER_URL
+          java -jar packwiz-installer.jar --bootstrap-no-update -g "http://127.0.0.1:$PORT/pack.toml"
+          # 6. 清理
+          kill $SERVER_PID 2>/dev/null || true
+          rm -rf "$PACK_DIR" packwiz-installer.jar
+      - name: 删除客户端only模组
+        run: |
+            mapfile -t prefixes < .clientonlymodlist
+            for prefix in "${prefixes[@]}"; do
+              echo "Deleting files with prefix: $prefix"
+              find mods -name "${prefix}*" -exec rm {} +
+              find packwiz-files/mods -name "${prefix}*" -exec rm {} +
+            done
       - name: 安装服务端only模组
         run: |
             # 从.serveronlymodlist中读取模组URL
@@ -238,13 +276,21 @@ jobs:
             for url in "${urls[@]}"; do
               curl -O -L "$url" --output-dir "mods"
             done
-      - name: 删除客户端only模组
+      - name: 删除与服务端无关的文件
         run: |
-            mapfile -t prefixes < .clientonlymodlist
-            for prefix in "${prefixes[@]}"; do
-              echo "Deleting files with prefix: $prefix"
-              find mods -name "${prefix}*" -exec rm {} +
-            done
+            # packwiz-installer 已将所有 mod JAR 下载到 mods/，packwiz-files/ 不再需要
+            rm -rf resourcepacks
+            rm -rf shaderpacks
+            rm -rf packwiz-files
+            rm -f ModList0.4a.md
+            rm -f README.md
+            rm -f TODOlist.md
+            rm -f KubeJSStyleGuide.md
+            rm -f DevGuide.md
+            rm -f client_jvm_args.example.txt
+            # 清理 packwiz 元数据
+            find mods -name "*.pw.toml" -exec rm {} +
+            rm -f pack.toml index.toml .packwizignore packwiz
       - name: 根据pack.toml的整合包版本替换更好地兼容检测配置
         run: |
           sed -i "s/modpackName =.*/modpackName=\"$MODPACK_NAME\"/" config/bcc-common.toml
@@ -374,11 +420,28 @@ jobs:
             if [ -d "patch/mods" ]; then
               find patch/mods -name "${prefix}*" -exec rm {} +
             fi
+            if [ -d "patch/packwiz-files/mods" ]; then
+              find patch/packwiz-files/mods -name "${prefix}*" -exec rm {} +
+            fi
           done
 
           rm -f patch/ModList0.4a.md patch/README.md patch/TODOlist.md \
                 patch/KubeJSStyleGuide.md patch/DevGuide.md patch/pack.toml \
                 patch/index.toml patch/client_jvm_args.example.txt
+
+          # 将 patch/packwiz-files/ 中的文件移到标准目录，然后删除 packwiz-files
+          if [ -d "patch/packwiz-files/mods" ]; then
+            mv patch/packwiz-files/mods/*.jar patch/mods/ 2>/dev/null || true
+          fi
+          if [ -d "patch/packwiz-files/resourcepacks" ]; then
+            mkdir -p patch/resourcepacks
+            mv patch/packwiz-files/resourcepacks/*.zip patch/resourcepacks/ 2>/dev/null || true
+          fi
+          if [ -d "patch/packwiz-files/shaderpacks" ]; then
+            mkdir -p patch/shaderpacks
+            mv patch/packwiz-files/shaderpacks/*.zip patch/shaderpacks/ 2>/dev/null || true
+          fi
+          rm -rf patch/packwiz-files
       - name: 更新配置文件
         run: |
           set -euo pipefail
@@ -491,11 +554,36 @@ jobs:
             deploy-patch.sh
             deploy-patch.bat
             patch/
-      - name: 检测并生成mods meta信息（packwiz将会自动移除cf可下载mod）
+      - name: 下载所有mod本体（packwiz-installer）& 生成manifest
         run: |
+          set -euo pipefail
+          PACK_DIR=$(mktemp -d)
+          cp pack.toml "$PACK_DIR/"
+          cp .packwizignore "$PACK_DIR/" 2>/dev/null || true
+          touch "$PACK_DIR/index.toml"
+          find mods resourcepacks shaderpacks -name '*.pw.toml' 2>/dev/null | while read -r f; do
+            mkdir -p "$PACK_DIR/$(dirname "$f")"
+            cp "$f" "$PACK_DIR/$f"
+          done
+          if [ -d "packwiz-files" ]; then
+            cp -r packwiz-files "$PACK_DIR/"
+          fi
+          PORT=8081
+          LOCAL_PREFIX="http://127.0.0.1:$PORT/packwiz-files/"
+          find "$PACK_DIR" -name '*.pw.toml' -exec sed -i "s|${PACKWIZ_FILES_RAW_PREFIX}|${LOCAL_PREFIX}|g" {} +
+          (cd "$PACK_DIR" && "$OLDPWD/packwiz" refresh)
+          python3 -m http.server $PORT --directory "$PACK_DIR" &
+          SERVER_PID=$!
+          for i in $(seq 1 25); do
+            if curl -s -o /dev/null "http://127.0.0.1:$PORT/pack.toml"; then break; fi
+            sleep 0.2
+          done
+          curl -o packwiz-installer.jar -L $PACKWIZ_INSTALLER_URL
+          java -jar packwiz-installer.jar --bootstrap-no-update -g "http://127.0.0.1:$PORT/pack.toml"
+          kill $SERVER_PID 2>/dev/null || true
+          rm -rf "$PACK_DIR" packwiz-installer.jar
+          # detect 生成 manifest.json（给客户端补丁用，CF mod 以引用形式记录）
           ./packwiz curseforge detect
-      - name: 更新index
-        run: |
           ./packwiz refresh
       - name: 下载manifest.json
         uses: actions/download-artifact@v4
@@ -506,6 +594,17 @@ jobs:
           rm -rf patch/mods
           mv mods patch
           rm -rf patch/mods/*.pw.toml
+          # packwiz-installer 已将 resourcepacks/shaderpacks 下载到标准目录
+          if [ -d "resourcepacks" ]; then
+            mkdir -p patch/resourcepacks
+            mv resourcepacks/*.zip patch/resourcepacks/ 2>/dev/null || true
+          fi
+          if [ -d "shaderpacks" ]; then
+            mkdir -p patch/shaderpacks
+            mv shaderpacks/*.zip patch/shaderpacks/ 2>/dev/null || true
+          fi
+          # 删除残留的 packwiz-files（JAR 已通过 installer 下载到标准目录）
+          rm -rf patch/packwiz-files
           mv manifest.json patch
       - name: 上传客户端补丁
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 env:
   VERSION_FILE_PATH: config/fancymenu/assets/version.md
   PACKWIZ_DOWNLOAD_URL: https://github.com/Jasons-impart/packwiz/releases/latest/download/packwiz
-  PACKWIZ_INSTALLER_URL: https://github.com/packwiz/packwiz-installer/releases/latest/download/packwiz-installer.jar
+  PACKWIZ_INSTALLER_BOOTSTRAP_URL: https://github.com/packwiz/packwiz-installer-bootstrap/releases/latest/download/packwiz-installer-bootstrap.jar
   PACKWIZ_FILES_RAW_PREFIX: https://raw.githubusercontent.com/Jasons-impart/Create-Delight-Remake/main/packwiz-files/
   HMCL_DOWNLOAD_URL: https://github.com/HMCL-dev/HMCL/releases/download/release-3.7.3/HMCL-3.7.3.jar
   JAVA_DOWNLOAD_URL: https://download.oracle.com/java/17/archive/jdk-17.0.12_windows-x64_bin.msi
@@ -176,7 +176,7 @@ jobs:
         run: |
           ./packwiz curseforge export
           mv *.zip ../lite-release.zip
-          unzip ../lite-release.zip -d ../lite-release
+          unzip -o ../lite-release.zip -d ../lite-release
           ls ..
       - name: Workaround actions/upload-artifact#176
         run: |
@@ -255,12 +255,12 @@ jobs:
             if curl -s -o /dev/null "http://127.0.0.1:$PORT/pack.toml"; then break; fi
             sleep 0.2
           done
-          # 5. 下载并运行 packwiz-installer
-          curl -o packwiz-installer.jar -L $PACKWIZ_INSTALLER_URL
-          java -jar packwiz-installer.jar --bootstrap-no-update -g "http://127.0.0.1:$PORT/pack.toml"
+          # 5. 下载并运行 packwiz-installer-bootstrap（bootstrap会自动下载installer）
+          curl -o packwiz-installer-bootstrap.jar -L $PACKWIZ_INSTALLER_BOOTSTRAP_URL
+          java -jar packwiz-installer-bootstrap.jar --bootstrap-no-update -g "http://127.0.0.1:$PORT/pack.toml"
           # 6. 清理
           kill $SERVER_PID 2>/dev/null || true
-          rm -rf "$PACK_DIR" packwiz-installer.jar
+          rm -rf "$PACK_DIR" packwiz-installer-bootstrap.jar
       - name: 删除客户端only模组
         run: |
             mapfile -t prefixes < .clientonlymodlist
@@ -578,10 +578,10 @@ jobs:
             if curl -s -o /dev/null "http://127.0.0.1:$PORT/pack.toml"; then break; fi
             sleep 0.2
           done
-          curl -o packwiz-installer.jar -L $PACKWIZ_INSTALLER_URL
-          java -jar packwiz-installer.jar --bootstrap-no-update -g "http://127.0.0.1:$PORT/pack.toml"
+          curl -o packwiz-installer-bootstrap.jar -L $PACKWIZ_INSTALLER_BOOTSTRAP_URL
+          java -jar packwiz-installer-bootstrap.jar --bootstrap-no-update -g "http://127.0.0.1:$PORT/pack.toml"
           kill $SERVER_PID 2>/dev/null || true
-          rm -rf "$PACK_DIR" packwiz-installer.jar
+          rm -rf "$PACK_DIR" packwiz-installer-bootstrap.jar
           # detect 生成 manifest.json（给客户端补丁用，CF mod 以引用形式记录）
           ./packwiz curseforge detect
           ./packwiz refresh

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 !/variables.nix.txt
 
 # Root directories that manage their own allowlists.
+!/.agents/
 !/.github/
 !/PCL/
 !/config/
@@ -41,3 +42,7 @@
 !/scripts/
 !/shaderpacks/
 !/tacz/
+
+# Agent knowledge base (compatible with OpenCode + Codex)
+!/AGENTS.md
+!/lessons-learned.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+# PROJECT KNOWLEDGE BASE
+
+Create-Delight Remake (齿轮盛宴) - A deep-modded Minecraft 1.20.1 Forge modpack focused on Create + Farmer's Delight with 5000+ custom recipes via KubeJS.
+
+**Core Stack**: Minecraft 1.20.1 | Forge 47.4.10 | KubeJS | Packwiz
+
+> Module-specific details: `kubejs/AGENTS.md`, `CDC-mod-src/AGENTS.md`
+> Historical lessons: `lessons-learned.md`
+> Skills: `.agents/skills/` (OpenCode + Codex compatible)
+
+## STRUCTURE
+
+```
+CD-master-dev/
+├── kubejs/           # KubeJS scripts - MAIN DEV AREA (see kubejs/AGENTS.md)
+├── CDC-mod-src/      # Custom Java mod (see CDC-mod-src/AGENTS.md)
+├── config/           # 50+ mod configs
+├── defaultconfigs/   # First-run defaults copied to config/
+├── tacz/             # TACZ gun data: armorer packs & gun config
+├── hotai/            # HotAI mod data
+├── mods/             # Packwiz metadata (*.pw.toml), NOT mod JARs
+├── packwiz-files/    # Manually-managed mod JARs (CF-restricted, custom)
+├── scripts/          # Utility scripts (sync, update-packwiz-meta)
+├── .github/          # CI/CD workflows
+└── pack.toml         # Pack metadata (ONLY version source)
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|------|----------|-------|
+| Modify recipes | `kubejs/server_scripts/{Mod}/` | 90+ mod folders, `/kubejs reload` |
+| Register items/fluids | `kubejs/startup_scripts/` | Requires game restart |
+| Custom textures/models | `kubejs/assets/createdelight/` | Resource pack overlay |
+| Custom lang/translations | `kubejs/assets/{namespace}/lang/zh_cn.json` | biome key: `biome.{namespace}.xxx` |
+| Custom loot/functions | `kubejs/data/` | Datapack overlay |
+| Mod configs | `config/{mod-name}.toml` | 50+ files |
+| FTB Quests | `config/ftbquests/quests/` | .snbt format |
+| Java mod dev | `CDC-mod-src/src/main/java/` | Forge mod project |
+| Version info | `pack.toml` | ONLY source - don't duplicate |
+
+## GLOSSARY
+
+| Term | Meaning |
+|------|--------|
+| **CD** | Create-Delight 整合包简称 |
+| **CDC** | Create Delight Core (custom Java mod) |
+| **SNBT** | FTB 任务配置格式 |
+| **分液池** | `create:item_drain` (ItemDrainBlockEntity) |
+| **AE2** | Applied Energistics 2 |
+| **BCC** | Better Compatibility Checker |
+| **OEI** | One Enough Item (config: `kubejs/data/oei/replacements/`) |
+| **DH** | Distant Horizons |
+
+## CONVENTIONS
+
+**Git Workflow**:
+- Branch from `main`: `git checkout main && git pull && git checkout -b feat/xxx`
+- Commit format: `[类型] 描述 (#PR号)` - types: `fix`, `feat`, `mod`, `dev`, `conf`
+- ❌ Never commit on merged feature branches
+- ❌ Never force push to main
+
+**Version Management**:
+- Version ONLY in `pack.toml` - CI auto-updates other configs
+- Test builds: `test-*` branches → version appended with `-test-build-{n}`
+- Releases: `release*` branches
+
+**Mod Management (Packwiz)**:
+- `mods/`, `resourcepacks/`, `shaderpacks/` contain only `.pw.toml` metadata, NOT JARs/zip
+- CF-restricted/custom JARs/zip live in `packwiz-files/{mods,resourcepacks,shaderpacks}/`
+- `.pw.toml` for packwiz-files assets reference GitHub raw URLs pointing to `packwiz-files/`
+- To add/update/remove mods: use `scripts/update-packwiz-meta.ps1` (NOT manual JAR placement)
+- To sync all mod JARs locally for development: use `scripts/sync-packwiz-assets.ps1`
+
+## ANTI-PATTERNS
+
+- ❌ `rm -rf`, `del /S /Q` on config/, kubejs/, mods/, hotai/, PCL/
+- ❌ Batch delete `*.json`, `*.snbt` in core dirs
+- ❌ Overwrite `index.toml`, `ModList*.md`
+- ❌ `e.remove()` or `e.removeById()` - use `remove_recipes_id(e, [...])`
+- ❌ Duplicate version in other files
+
+## COMMANDS
+
+```bash
+# Packwiz
+packwiz refresh                 # Update index
+packwiz curseforge export       # Build modpack
+
+# Update packwiz metadata after manually changing mod JARs
+./update-packwiz-meta.bat       # Windows wrapper
+./scripts/update-packwiz-meta.ps1 -Proxy "http://127.0.0.1:7890"  # Direct PS1
+
+# Sync all mod JARs locally for development
+./scripts/sync-packwiz-assets.ps1
+
+# KubeJS hot reload (in-game)
+/kubejs reload server_scripts
+/reload                         # Reload tags/loot
+
+# CDC mod build
+cd CDC-mod-src && ./gradlew build --no-daemon
+# Output: build/libs/CDC-mod-src-*.jar (use non-all version)
+```
+
+**发布流程**: Use `/release` skill for version bump, tag, and GitHub release workflow.
+
+## KNOWLEDGE BASE MAINTENANCE
+
+These rules ensure this knowledge base stays effective. Violating them degrades agent performance.
+
+- **Root AGENTS.md ≤150 lines** — If over limit, prune stale entries or move content to subdirectory files
+- **Subdirectory AGENTS.md ≤80 lines** — Keep focused on that domain only
+- **No duplication** — Each fact exists in exactly ONE file. Others reference it. Duplicate information = conflicting information
+- **Concise > verbose** — One sentence per fact. No prose. Agents ignore buried instructions
+- **Include the Why** — Non-obvious rules must explain the reason (agents follow rules better when they understand the failure mode)
+- **Stale > harmful** — Outdated instructions are worse than no instructions. Update when architecture changes, prune aggressively
+- **Iterate, don't upfront** — Add rules only when agent makes a repeated mistake. Remove rules agent always follows correctly
+- **Lessons go to `lessons-learned.md`** — Never inline long historical entries in AGENTS.md
+- **After fixing a non-obvious bug** — Add entry to `lessons-learned.md` (use `/knowledge-check` skill for guidance)
+
+## NOTES
+
+- **AGENTS.md 是本地开发知识库，已加入 .gitignore，不需要推送到远程仓库**
+- **`.agents/skills/` 存放技能文件，OpenCode 和 Codex 都能自动发现**
+- `pack.toml` is the ONLY version source - CI auto-updates other configs
+- Client-only mods → add to `.clientonlymodlist` (server startup required)
+- Server-only mods → add to `.serveronlymodlist`
+- Language files validated by `.vscode/probe.lang-schema.json`

--- a/lessons-learned.md
+++ b/lessons-learned.md
@@ -1,0 +1,122 @@
+# Lessons Learned
+
+## 多分支 PR 时必须基于各自目标分支创建特性分支
+
+**日期**: 2026-05-18
+**场景**: 将 `Introduction.snbt` 的改动同时 PR 到 `main` 和 `release-v048x`
+
+### 错误做法
+
+从一个分支（如 `main`）创建特性分支，然后用同一分支向两个目标分支发起 PR：
+
+```
+main ──→ feat/branch ──PR──→ main       ✅ 只有1个commit
+                      ──PR──→ release-v048x  ❌ 包含main比048x多的14个commit
+```
+
+**原因**: PR 包含的是特性分支与目标分支之间的全部差异。如果特性分支基于 `main`，而 `main` 比 `release-v048x` 多了 N 个 commit，PR 到 048x 时就会带上这 N 个无关 commit。
+
+### 正确做法
+
+**方案一（推荐）: 从各目标分支分别创建特性分支，cherry-pick 同一个 commit**
+
+```
+main ──→ feat/branch-main ──PR──→ main         ✅ 1 commit
+release-v048x ──→ feat/branch-048x ──PR──→ release-v048x  ✅ 1 commit
+# 两个分支各自 cherry-pick 同一个 commit
+```
+
+**方案二: 从一个分支创建，另一个用 cherry-pick 分支补充**
+
+先从 `main` 创建分支 PR 到 `main`，再从 `release-v048x` 创建新分支 cherry-pick 同一 commit PR 到 048x。
+
+### 规则
+
+> **向多个分支发 PR 时，每个目标分支必须有独立的、基于该目标分支创建的特性分支。** 绝不能复用同一个特性分支。
+
+## PowerShell 中反引号 `` ` `` 是转义字符，不能直接用于 Markdown 行内代码
+
+**日期**: 2026-05-19
+**场景**: 用 `gh pr create --body "..."` 创建 PR 时，PR 正文中 `ad_astra` 的 `a` 变成未知字符
+
+### 根因
+
+PowerShell 双引号字符串中，反引号 `` ` `` 是转义前缀（等价于 bash 的 `\`）：
+
+| 转义序列 | 含义 |
+|----------|------|
+| `` `a `` | BEL（响铃，0x07） |
+| `` `n `` | 换行 |
+| `` `t `` | 制表符 |
+| `` `" `` | 转义双引号 |
+| `` `` `` | 转义反引号本身 |
+
+所以 Markdown 行内代码写法 `` `ad_astra` `` 在双引号字符串中，`` `a `` 被解析为 BEL 字符（不可见），导致 `ad_astra` 显示为乱码。
+
+### 错误做法
+
+```powershell
+# ❌ 反引号 + a 被解析为 BEL
+gh pr create --body "... `ad_astra:xxx` ..."
+```
+
+### 正确做法
+
+**方案一（推荐）：用 `--body-file` 从文件读取 body，避免 PowerShell 字符串解析**
+
+```powershell
+# 写入临时文件，内容无需转义
+Set-Content -Path $tmpFile -Value "更新: ``ad_astra:xxx`` → ``yyy``"
+gh pr create --body-file $tmpFile
+```
+
+**方案二：双引号字符串中用双反引号 `` `` `` 转义**
+
+```powershell
+# ✅ ``  表示字面反引号
+gh pr create --body "... ``ad_astra:xxx`` ..."
+```
+
+**方案三：使用单引号字符串（无插值，反引号无需转义）**
+
+```powershell
+# ✅ 单引号内反引号是字面量，但无法插入变量
+gh pr create --body '... `ad_astra:xxx` ...'
+```
+
+### 规则
+
+> **在 PowerShell 双引号字符串中使用 Markdown 反引号语法时，必须转义为双反引号 `` `` ``，或改用 `--body-file` / 单引号避免转义问题。**
+
+## Packwiz 在 CI 中获取 mod JAR 的正确方式
+
+**日期**: 2026-05-20
+**场景**: Packwiz 迁移后，release.yml 的 server-tasks 和 patch-tasks 无法获取 CF 可下载的 mod JAR
+
+### 关键行为（容易被误解）
+
+| 命令 | 实际行为 | 常见误解 |
+|------|---------|---------|
+| `packwiz curseforge detect` | 只修改 `.pw.toml` 的 `mode` 为 `metadata:curseforge`，**不下载 JAR** | ❌ 以为会下载 JAR 到 `mods/` |
+| `packwiz curseforge export` | CF 可下载 mod 只在 `manifest.json` 中记录 project-id/file-id，**JAR 不在 zip 中**；非 CF mod（有 `url`）的 JAR 在 `overrides/` | ❌ 以为所有 JAR 都在 zip 中 |
+
+### 迁移前 vs 迁移后
+
+- **迁移前**: `mods/` 中既有 `.pw.toml` 又有 JAR（git 跟踪），`detect` 只是标记哪些可从 CF 下载
+- **迁移后**: `mods/` 中只有 `.pw.toml`，JAR 不在仓库中。CF mod 的 JAR 必须通过其他方式获取
+
+### 正确做法：packwiz-installer + 本地静态服务器
+
+参考 `scripts/sync-packwiz-assets.ps1` 的流程：
+
+1. 创建临时 pack 目录，复制 `.pw.toml` 元数据 + `packwiz-files/`
+2. 将 `.pw.toml` 中的 GitHub raw URL 替换为 `http://127.0.0.1:{PORT}/packwiz-files/`
+3. 在临时目录中 `packwiz refresh`
+4. 启动 Python 静态服务器：`python3 -m http.server $PORT --directory "$PACK_DIR" &`
+5. 运行 `packwiz-installer`：`java -jar packwiz-installer.jar --bootstrap-no-update -g http://127.0.0.1:$PORT/pack.toml`
+6. installer 会将所有 mod JAR 下载到 `mods/`，资源包到 `resourcepacks/`，光影到 `shaderpacks/`
+7. 清理：kill server，删除临时目录
+
+### 规则
+
+> **CI 中获取 mod JAR 必须用 `packwiz-installer`，不能依赖 `detect` 或 `export`。Release 产物中不得包含 `packwiz-files/` 目录，所有 JAR/资源包/光影必须在标准目录（`mods/`、`resourcepacks/`、`shaderpacks/`）中。**


### PR DESCRIPTION
## 改动概述

- release.yml 适配 packwiz 迁移后的 mod 下载流程，使用 packwiz-installer-bootstrap 替代直接下载 mod JAR。
- 补充agents.md以及skills等信息，共享agent知识库。

## 改动内容

### release.yml
- **新增 packwiz-installer-bootstrap 流程**：server-tasks 和 patch-tasks 中通过本地 HTTP 服务器 + packwiz-installer-bootstrap 下载所有 mod 本体（包括 CF 受限 mod）
- **修复 packwiz-files 处理**：客户端 only mod 删除时同时搜索 \packwiz-files/mods/\；patch-tasks 中将 packwiz-files 内容移到标准目录后清理
- **修复 unzip 交互问题**：添加 \-o\ 标志避免 CI 中重复文件覆写确认失败
- **清理 packwiz 元数据**：服务端包中删除 \.pw.toml\、\pack.toml\、\index.toml\ 等 packwiz 元数据文件

### .gitignore
- 添加 \.agents/\、\AGENTS.md\、\lessons-learned.md\ 到版本控制白名单

## CI 测试结果

通过 \	est-release\ 分支推送触发，[run 26171374542](https://github.com/Jasons-impart/Create-Delight-Remake/actions/runs/26171374542) 全部通过：

- ✓ common-steps (9s)
- ✓ client-tasks (42s)
- ✓ server-tasks (2m6s)
- ✓ patch-tasks (1m51s)

7 个 artifacts 全部正常生成，mods 目录下有 150+ 实际 JAR 文件，无 \.pw.toml\ 残留。