### PR TITLE
[dev] 重构release.yml：提取composite actions和shell脚本消除重复代码

### DIFF
--- a/.github/actions/remove-client-only-mods/action.yml
+++ b/.github/actions/remove-client-only-mods/action.yml
@@ -1,0 +1,26 @@
+name: 'Remove Client-Only Mods'
+description: 'Read .clientonlymodlist and delete matching mod files from the specified base directory'
+
+inputs:
+  base_dir:
+    description: 'Base directory to search for mod files (default: .)'
+    required: false
+    default: '.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Remove client-only mods
+      shell: bash
+      run: |
+        set -euo pipefail
+        mapfile -t prefixes < .clientonlymodlist
+        for prefix in "${prefixes[@]}"; do
+          echo "Deleting files with prefix: $prefix"
+          if [ -d "${{ inputs.base_dir }}/mods" ]; then
+            find ${{ inputs.base_dir }}/mods -name "${prefix}*" -exec rm {} +
+          fi
+          if [ -d "${{ inputs.base_dir }}/packwiz-files/mods" ]; then
+            find ${{ inputs.base_dir }}/packwiz-files/mods -name "${prefix}*" -exec rm {} +
+          fi
+        done

--- a/.github/actions/setup-packwiz/action.yml
+++ b/.github/actions/setup-packwiz/action.yml
@@ -1,0 +1,11 @@
+name: 'Setup Packwiz'
+description: 'Download and install Packwiz from GitHub releases'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Packwiz
+      shell: bash
+      run: |
+        curl -o packwiz -L ${{ env.PACKWIZ_DOWNLOAD_URL }}
+        chmod +x ./packwiz

--- a/.github/actions/update-modpack-config/action.yml
+++ b/.github/actions/update-modpack-config/action.yml
@@ -1,0 +1,50 @@
+name: 'Update Modpack Config'
+description: 'Update BCC config, client properties, feedback config, and version file with modpack version info'
+
+inputs:
+  modpack_name:
+    description: 'Modpack name (e.g. Create-Delight-Remake)'
+    required: true
+  modpack_version:
+    description: 'Modpack version string (e.g. v0.4.8.8)'
+    required: true
+  mode:
+    description: 'Config update mode: client, server, or patch'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Update BCC compatibility config
+      shell: bash
+      run: |
+        sed -i "s/modpackName =.*/modpackName=\"${{ inputs.modpack_name }}\"/" config/bcc-common.toml
+        sed -i "s/modpackVersion =.*/modpackVersion=\"${{ inputs.modpack_version }}\"/" config/bcc-common.toml
+        grep 'modpack' config/bcc-common.toml
+
+    - name: Update client display config
+      if: inputs.mode == 'client' || inputs.mode == 'patch'
+      shell: bash
+      run: |
+        if [ "${{ inputs.mode }}" = "patch" ]; then
+          sed -i "s/^title=\(.*\)/title=\1 | 版本${{ inputs.modpack_version }} (patch)/" kubejs/config/client.properties
+        else
+          sed -i "s/^title=\(.*\)/title=\1 | 版本${{ inputs.modpack_version }}/" kubejs/config/client.properties
+        fi
+        jq --arg v "${{ inputs.modpack_version }}" '.placeholder = "\n§l§4§n(勿删本行) 版本: " + $v' config/GeneralFeedback/default.json > default.json.tmp
+        mv default.json.tmp config/GeneralFeedback/default.json
+        grep 'title' kubejs/config/client.properties
+        grep 'placeholder' config/GeneralFeedback/default.json
+
+    - name: Write fancymenu version file
+      if: inputs.mode == 'client'
+      shell: bash
+      run: |
+        set -euo pipefail
+        cat << EOF > "${{ env.VERSION_FILE_PATH }}"
+        |||
+        ${{ inputs.modpack_name }} ${{ inputs.modpack_version }}
+        MIT License Copyright (c) 2025 JSI Production Team
+        |||
+        EOF
+        cat "${{ env.VERSION_FILE_PATH }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,21 +123,23 @@ jobs:
           mv *.zip ../lite-release.zip
           unzip -o ../lite-release.zip -d ../lite-release
           ls ..
+      - name: Workaround actions/upload-artifact#176
+        run: echo "artifacts_path=$(realpath ..)" >> $GITHUB_ENV
       - name: 上传懒人包
         uses: actions/upload-artifact@v4
         with:
           name: "[Client][ClickToUse]-${{ env.MODPACK_NAME }}-${{ env.MODPACK_VERSION }}"
-          path: ../click_to_run_release/
+          path: ${{ env.artifacts_path }}/click_to_run_release/
       - name: 上传不带mod包
         uses: actions/upload-artifact@v4
         with:
           name: "[Client]${{ env.MODPACK_NAME }}-${{ env.MODPACK_VERSION }}"
-          path: ../lite-release/
+          path: ${{ env.artifacts_path }}/lite-release/
       - name: 上传manifest.json用于客户端补丁
         uses: actions/upload-artifact@v4
         with:
           name: "[Dev]${{ env.MODPACK_NAME }}-${{ env.MODPACK_VERSION }}-manifest"
-          path: ../lite-release/manifest.json
+          path: ${{ env.artifacts_path }}/lite-release/manifest.json
 
   # 服务端相关任务（并行执行）
   server-tasks:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,24 +103,17 @@ jobs:
           python .github/workflows/scripts/update_credits.py --mode real --download-images
       - name: 更新文件索引并生成带mod本体的包
         run: |
-          ./packwiz refresh
-          ./packwiz curseforge export
           mkdir ../click_to_run_release
-          mv *.zip ../click_to_run_release/modpack.zip
+          bash .github/workflows/scripts/export_curseforge_pack.sh ../click_to_run_release/modpack.zip 8082
       - name: 下载HMCL启动器与jdk环境
         run: |
           curl -o HMCL.jar -L $HMCL_DOWNLOAD_URL
           curl -o jdk17.msi -L $JAVA_DOWNLOAD_URL
           mv HMCL.jar ../click_to_run_release
           mv jdk17.msi ../click_to_run_release
-      - name: 检测mods meta并更新索引
-        run: |
-          ./packwiz curseforge detect
-          ./packwiz refresh
       - name: 生成不带mod本体的包
         run: |
-          ./packwiz curseforge export
-          mv *.zip ../lite-release.zip
+          bash .github/workflows/scripts/export_curseforge_pack.sh ../lite-release.zip 8083
           unzip -o ../lite-release.zip -d ../lite-release
           ls ..
       - name: Workaround actions/upload-artifact#176
@@ -310,6 +303,12 @@ jobs:
         run: |
           cp .github/workflows/scripts/deploy-patch.sh deploy-patch.sh
           cp .github/workflows/scripts/deploy-patch.bat deploy-patch.bat
+      - name: 净化补丁用 CurseForge 元数据
+        run: |
+          bash .github/workflows/scripts/download_mods.sh 8081
+          ./packwiz -y curseforge detect
+          ./packwiz refresh
+          bash .github/workflows/scripts/remove_curseforge_payloads_from_patch.sh patch
       - name: 上传服务器补丁
         uses: actions/upload-artifact@v4
         with:
@@ -319,28 +318,13 @@ jobs:
             deploy-patch.sh
             deploy-patch.bat
             patch/
-      - name: 下载所有mod本体（packwiz-installer）& 生成manifest
-        run: |
-          bash .github/workflows/scripts/download_mods.sh 8081
-          ./packwiz curseforge detect
-          ./packwiz refresh
       - name: 下载manifest.json
         uses: actions/download-artifact@v4
         with:
           name: "[Dev]${{ env.MODPACK_NAME }}-${{ env.MODPACK_VERSION }}-manifest"
       - name: 更新patch中的mod，并加入manifest.json
         run: |
-          rm -rf patch/mods
-          mv mods patch
-          rm -rf patch/mods/*.pw.toml
-          if [ -d "resourcepacks" ]; then
-            mkdir -p patch/resourcepacks
-            mv resourcepacks/*.zip patch/resourcepacks/ 2>/dev/null || true
-          fi
-          if [ -d "shaderpacks" ]; then
-            mkdir -p patch/shaderpacks
-            mv shaderpacks/*.zip patch/shaderpacks/ 2>/dev/null || true
-          fi
+          bash .github/workflows/scripts/copy_non_curseforge_payloads.sh patch
           rm -rf patch/packwiz-files
           mv manifest.json patch
       - name: 上传客户端补丁

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,34 +56,20 @@ jobs:
         with:
           file: pack.toml
           field: 'versions.forge'
-      - name: 生成整合包带测试后缀版本号
+      - name: 生成整合包版本号
         id: generate_modpack_version
         run: |
-          BRANCH_NAME="${{ github.ref_name }}"
-          if [[ "$BRANCH_NAME" == v* ]]; then
-            # Tag-triggered: use version from pack.toml directly
-            VERSION="${{ steps.read-version.outputs.value }}"
-            echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          elif [[ "$BRANCH_NAME" == *test* ]]; then
-            VERSION="${{ steps.read-version.outputs.value }}-test-build-${{ github.run_number }}"
-            echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          else
-            VERSION="${{ steps.read-version.outputs.value }}"
-            echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          VERSION="${{ steps.read-version.outputs.value }}"
+          if [[ "${{ github.ref_name }}" == *test* ]]; then
+            VERSION="$VERSION-test-build-${{ github.run_number }}"
           fi
-      - name: 输出读取的变量用作验证
-        run: |
-          echo "Modpack Name: ${{ steps.read-modpackname.outputs.value }}"
-          echo "Modpack Version: ${{ steps.read-version.outputs.value }}"
-          echo "Modpack Full Version: ${{ steps.generate_modpack_version.outputs.VERSION }}"
-          echo "Minecraft Version: ${{ steps.read-minecraft.outputs.value }}"
-          echo "Forge Version: ${{ steps.read-forge.outputs.value }}"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
   # 客户端相关任务（并行执行）
   client-tasks:
-    needs: common-steps       # 依赖公共步骤完成
+    needs: common-steps
     runs-on: ubuntu-latest
-    env:  # Job 级环境变量（简化读取变量）
+    env:
       MODPACK_NAME: ${{ needs.common-steps.outputs.modpack_name }}
       MODPACK_VERSION: ${{ needs.common-steps.outputs.modpack_ver }}
       MC_VERSION: ${{ needs.common-steps.outputs.mc_version }}
@@ -95,68 +81,29 @@ jobs:
       startsWith(github.ref_name, 'test-patch') ||
       startsWith(github.ref_name, 'v')
     steps:
-      - name: 测试环境变量
-        run: |
-          echo "Modpack Name: $MODPACK_NAME"
-          echo "Modpack Version: $MODPACK_VERSION"
-          echo "Minecraft Version: $MC_VERSION"
-          echo "Forge Version: $FORGE_VERSION"
-          echo "Version File Path: $VERSION_FILE_PATH"
       - name: 检出代码
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1 # 只取最新提交，加速
-      - name: 安装 Packwiz 打包软件
-        run: |
-          curl -o packwiz -L $PACKWIZ_DOWNLOAD_URL
-          chmod +x ./packwiz
+          fetch-depth: 1
+      - name: 安装 Packwiz
+        uses: ./.github/actions/setup-packwiz
       - name: 重命名HMCL配置和options
         run: |
           mv .hmclversion.cfg hmclversion.cfg
           mv .options.txt options.txt
-      - name: 【版本】根据pack.toml的整合包和forge版本替换 游戏标题名称 & 更好地兼容检测配置文件 & 反馈配置 & 启动脚本
-        run: |
-          sed -i "s/modpackName =.*/modpackName=\"$MODPACK_NAME\"/" config/bcc-common.toml
-          sed -i "s/modpackVersion =.*/modpackVersion=\"$MODPACK_VERSION\"/" config/bcc-common.toml
-          sed -i "s/^title=\(.*\)/title=\1 | 版本$MODPACK_VERSION/" kubejs/config/client.properties
-
-          jq --arg v "$MODPACK_VERSION" '.placeholder = "\n§l§4§n(勿删本行) 版本: " + $v' config/GeneralFeedback/default.json > default.json.tmp
-          mv default.json.tmp config/GeneralFeedback/default.json
-          
-          grep 'modpack' config/bcc-common.toml
-          grep 'title' kubejs/config/client.properties
-          grep 'placeholder' config/GeneralFeedback/default.json
-      - name: 【版本】写版本号 供fancymenu展现在游戏首页 & 游戏标题画面
-        # fancymenu格式如下，为此需要用 > 覆盖写第一行，用 >> 追加写后续行
-        # |||
-        # Create-Delight-Remake x.x.x.x xxxx
-        # MIT License Copyright (c) 2025 JSI Production Team
-        # |||
-        run: |
-          set -euo pipefail
-          cat << EOF > "$VERSION_FILE_PATH"
-          |||
-          $MODPACK_NAME $MODPACK_VERSION
-          MIT License Copyright (c) 2025 JSI Production Team
-          |||
-          EOF
-          cat "$VERSION_FILE_PATH"
+      - name: 更新整合包配置与版本信息
+        uses: ./.github/actions/update-modpack-config
+        with:
+          modpack_name: ${{ env.MODPACK_NAME }}
+          modpack_version: ${{ env.MODPACK_VERSION }}
+          mode: client
       - name: 【鸣谢】更新鸣谢名单及头像
         run: |
           pip install requests
           python .github/workflows/scripts/update_credits.py --mode real --download-images
-      # - name: 删除仅服务端模组
-      #   run: |
-      #       mapfile -t prefixes < .serveronlymodlist
-      #       for prefix in "${prefixes[@]}"; do
-      #         echo "Deleting files with prefix: $prefix"
-      #         find mods -name "${prefix}*" -exec rm {} +
-      #       done
-      - name: 更新文件索引
+      - name: 更新文件索引并生成带mod本体的包
         run: |
           ./packwiz refresh
-      - name: 生成带mod本体的包 移动到workspace文件夹
-        run: |
           ./packwiz curseforge export
           mkdir ../click_to_run_release
           mv *.zip ../click_to_run_release/modpack.zip
@@ -166,11 +113,9 @@ jobs:
           curl -o jdk17.msi -L $JAVA_DOWNLOAD_URL
           mv HMCL.jar ../click_to_run_release
           mv jdk17.msi ../click_to_run_release
-      - name: 检测并生成mods meta信息
+      - name: 检测mods meta并更新索引
         run: |
           ./packwiz curseforge detect
-      - name: 更新index
-        run: |
           ./packwiz refresh
       - name: 生成不带mod本体的包
         run: |
@@ -178,30 +123,27 @@ jobs:
           mv *.zip ../lite-release.zip
           unzip -o ../lite-release.zip -d ../lite-release
           ls ..
-      - name: Workaround actions/upload-artifact#176
-        run: |
-          echo "artifacts_path=$(realpath ..)" >> $GITHUB_ENV
       - name: 上传懒人包
         uses: actions/upload-artifact@v4
         with:
           name: "[Client][ClickToUse]-${{ env.MODPACK_NAME }}-${{ env.MODPACK_VERSION }}"
-          path: ${{ env.artifacts_path }}/click_to_run_release/
+          path: ../click_to_run_release/
       - name: 上传不带mod包
         uses: actions/upload-artifact@v4
         with:
           name: "[Client]${{ env.MODPACK_NAME }}-${{ env.MODPACK_VERSION }}"
-          path: ${{ env.artifacts_path }}/lite-release/
+          path: ../lite-release/
       - name: 上传manifest.json用于客户端补丁
         uses: actions/upload-artifact@v4
         with:
           name: "[Dev]${{ env.MODPACK_NAME }}-${{ env.MODPACK_VERSION }}-manifest"
-          path: ${{ env.artifacts_path }}/lite-release/manifest.json
+          path: ../lite-release/manifest.json
 
   # 服务端相关任务（并行执行）
   server-tasks:
     needs: common-steps
     runs-on: ubuntu-latest
-    env:  # Job 级环境变量（简化读取变量）
+    env:
       MODPACK_NAME: ${{ needs.common-steps.outputs.modpack_name }}
       MODPACK_VERSION: ${{ needs.common-steps.outputs.modpack_ver }}
       MC_VERSION: ${{ needs.common-steps.outputs.mc_version }}
@@ -215,88 +157,37 @@ jobs:
       - name: 检出代码
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1 # 只取最新提交，加速
+          fetch-depth: 1
       - name: 安装 Packwiz
-        run: |
-          curl -o packwiz -L $PACKWIZ_DOWNLOAD_URL
-          chmod +x ./packwiz
+        uses: ./.github/actions/setup-packwiz
       - name: 更新文件索引
         run: |
           ./packwiz refresh
       - name: 下载所有mod本体（packwiz-installer）
-        run: |
-          set -euo pipefail
-          # 参考脚本: scripts/sync-packwiz-assets.ps1
-          # 1. 创建临时 pack 目录，复制元数据和 packwiz-files/
-          PACK_DIR=$(mktemp -d)
-          cp pack.toml "$PACK_DIR/"
-          cp .packwizignore "$PACK_DIR/" 2>/dev/null || true
-          touch "$PACK_DIR/index.toml"
-          # 复制 .pw.toml 元数据
-          find mods resourcepacks shaderpacks -name '*.pw.toml' 2>/dev/null | while read -r f; do
-            mkdir -p "$PACK_DIR/$(dirname "$f")"
-            cp "$f" "$PACK_DIR/$f"
-          done
-          # 复制 packwiz-files/（CF受限 mod/资源包/光影包本体）
-          if [ -d "packwiz-files" ]; then
-            cp -r packwiz-files "$PACK_DIR/"
-          fi
-          # 2. 将 .pw.toml 中的 GitHub raw URL 替换为 localhost
-          PORT=8080
-          LOCAL_PREFIX="http://127.0.0.1:$PORT/packwiz-files/"
-          find "$PACK_DIR" -name '*.pw.toml' -exec sed -i "s|${PACKWIZ_FILES_RAW_PREFIX}|${LOCAL_PREFIX}|g" {} +
-          # 3. 在临时目录中 refresh 生成索引
-          (cd "$PACK_DIR" && "$OLDPWD/packwiz" refresh)
-          # 4. 启动 Python 静态服务器
-          python3 -m http.server $PORT --directory "$PACK_DIR" &
-          SERVER_PID=$!
-          # 等待服务器就绪
-          for i in $(seq 1 25); do
-            if curl -s -o /dev/null "http://127.0.0.1:$PORT/pack.toml"; then break; fi
-            sleep 0.2
-          done
-          # 5. 下载并运行 packwiz-installer-bootstrap（bootstrap会自动下载installer）
-          curl -o packwiz-installer-bootstrap.jar -L $PACKWIZ_INSTALLER_BOOTSTRAP_URL
-          java -jar packwiz-installer-bootstrap.jar -g "http://127.0.0.1:$PORT/pack.toml"
-          # 6. 清理
-          kill $SERVER_PID 2>/dev/null || true
-          rm -rf "$PACK_DIR" packwiz-installer-bootstrap.jar
+        run: bash .github/workflows/scripts/download_mods.sh 8080
       - name: 删除客户端only模组
-        run: |
-            mapfile -t prefixes < .clientonlymodlist
-            for prefix in "${prefixes[@]}"; do
-              echo "Deleting files with prefix: $prefix"
-              find mods -name "${prefix}*" -exec rm {} +
-              find packwiz-files/mods -name "${prefix}*" -exec rm {} +
-            done
+        uses: ./.github/actions/remove-client-only-mods
+        with:
+          base_dir: .
       - name: 安装服务端only模组
         run: |
-            # 从.serveronlymodlist中读取模组URL
             mapfile -t urls < .serveronlymodlist
             for url in "${urls[@]}"; do
               curl -O -L "$url" --output-dir "mods"
             done
       - name: 删除与服务端无关的文件
         run: |
-            # packwiz-installer 已将所有 mod JAR 下载到 mods/，packwiz-files/ 不再需要
-            rm -rf resourcepacks
-            rm -rf shaderpacks
-            rm -rf packwiz-files
-            rm -f ModList0.4a.md
-            rm -f README.md
-            rm -f TODOlist.md
-            rm -f KubeJSStyleGuide.md
-            rm -f DevGuide.md
-            rm -f client_jvm_args.example.txt
-            # 清理 packwiz 元数据
+            rm -rf resourcepacks shaderpacks packwiz-files
+            rm -f ModList0.4a.md README.md TODOlist.md KubeJSStyleGuide.md DevGuide.md client_jvm_args.example.txt
             find mods -name "*.pw.toml" -exec rm {} +
             rm -f pack.toml index.toml .packwizignore packwiz
-      - name: 根据pack.toml的整合包版本替换更好地兼容检测配置
-        run: |
-          sed -i "s/modpackName =.*/modpackName=\"$MODPACK_NAME\"/" config/bcc-common.toml
-          sed -i "s/modpackVersion =.*/modpackVersion=\"$MODPACK_VERSION\"/" config/bcc-common.toml
-          grep 'modpack' config/bcc-common.toml
-      - name: 下载forge与ServerStarterJar
+      - name: 更新整合包配置与版本信息
+        uses: ./.github/actions/update-modpack-config
+        with:
+          modpack_name: ${{ env.MODPACK_NAME }}
+          modpack_version: ${{ env.MODPACK_VERSION }}
+          mode: server
+      - name: 下载forge安装器
         run: |
           set -euo pipefail
           FORGE_URL="${{ env.FORGE_DOWNLOAD_URL_PREFIX }}/${MC_VERSION}-${FORGE_VERSION}/forge-${MC_VERSION}-${FORGE_VERSION}-installer.jar"
@@ -313,10 +204,6 @@ jobs:
           unix2dos "start.bat"
           sed -i "s|!MC_VERSION!|${MC_VERSION}|" "start.bat"
           sed -i "s|!FORGE_VERSION!|${FORGE_VERSION}|" "start.bat"
-      - name: list remained files & mods
-        run: |
-          ls ${{ github.workspace }}
-          ls mods
       - name: 上传带mod包
         uses: actions/upload-artifact@v4
         with:
@@ -335,7 +222,7 @@ jobs:
   patch-tasks:
     needs: [common-steps, client-tasks]
     runs-on: ubuntu-latest
-    env:  # Job 级环境变量（简化读取变量）
+    env:
       MODPACK_NAME: ${{ needs.common-steps.outputs.modpack_name }}
       MODPACK_VERSION: ${{ needs.common-steps.outputs.modpack_ver }}
       MC_VERSION: ${{ needs.common-steps.outputs.mc_version }}
@@ -346,26 +233,16 @@ jobs:
       startsWith(github.ref_name, 'test-patch') ||
       startsWith(github.ref_name, 'v')
     steps:
-      - name: 测试环境变量
-        run: |
-          echo "Modpack Name: $MODPACK_NAME"
-          echo "Modpack Version: $MODPACK_VERSION"
-          echo "Minecraft Version: $MC_VERSION"
-          echo "Forge Version: $FORGE_VERSION"
-          echo "Version File Path: $VERSION_FILE_PATH"
       - name: 检出代码
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
-      - name: 安装 Packwiz 打包软件
-        run: |
-          curl -o packwiz -L $PACKWIZ_DOWNLOAD_URL
-          chmod +x ./packwiz
+      - name: 安装 Packwiz
+        uses: ./.github/actions/setup-packwiz
       - name: 获取最近的tag并配置环境变量
         run: |
           set -euo pipefail
-          # 若 HEAD 有 tag，则取上一提交的最近 tag；否则取 HEAD 的最近 tag
           if git describe --tags --exact-match >/dev/null 2>&1; then
             latest_tag=$(git describe --tags --abbrev=0 HEAD^)
           else
@@ -373,43 +250,14 @@ jobs:
           fi
           echo "最近的tag是: $latest_tag"
           echo "LATEST_TAG=$latest_tag" >> $GITHUB_ENV
-      - name: 【版本】根据pack.toml的整合包版本替换标题 和 更好地兼容检测配置 和 反馈配置
-        run: |
-          sed -i "s/modpackName =.*/modpackName=\"$MODPACK_NAME\"/" config/bcc-common.toml
-          sed -i "s/modpackVersion =.*/modpackVersion=\"$MODPACK_VERSION\"/" config/bcc-common.toml
-          sed -i "s/^title=\(.*\)/title=\1 | 版本$MODPACK_VERSION (patch)/" kubejs/config/client.properties
-          jq --arg v "$MODPACK_VERSION" '.placeholder = "\n§l§4§n(勿删本行) 版本: " + $v' config/GeneralFeedback/default.json > default.json.tmp
-          mv default.json.tmp config/GeneralFeedback/default.json
-          grep 'modpack' config/bcc-common.toml
-          grep 'title' kubejs/config/client.properties
-          grep 'placeholder' config/GeneralFeedback/default.json
-
+      - name: 更新整合包配置与版本信息
+        uses: ./.github/actions/update-modpack-config
+        with:
+          modpack_name: ${{ env.MODPACK_NAME }}
+          modpack_version: ${{ env.MODPACK_VERSION }}
+          mode: patch
       - name: 准备补丁文件
-        run: |
-          set -euo pipefail
-          git diff --name-status "${{ env.LATEST_TAG }}" HEAD > diff_report.txt
-          cat diff_report.txt
-          
-          # 解析差异报告
-          grep -E '^D' diff_report.txt | cut -f2 > deleted_files.txt || true
-          grep -E '^R' diff_report.txt | cut -f2 >> deleted_files.txt || true
-          grep -E '^[AM]' diff_report.txt | cut -f2 > added_files.txt || true
-          grep -E '^R' diff_report.txt | cut -f3 >> added_files.txt || true
-          grep -E '^C' diff_report.txt | cut -f3 >> added_files.txt || true
-
-          # 创建补丁目录
-          mkdir -p patch
-
-          # 复制新增/修改文件
-          while IFS= read -r file; do
-            [ -z "$file" ] && continue
-            if [ -f "$file" ]; then
-              mkdir -p "patch/$(dirname "$file")"
-              cp "$file" "patch/$file"
-            else
-              echo "Warn: $file not found at HEAD" >&2
-            fi
-          done < added_files.txt
+        run: bash .github/workflows/scripts/prepare_patch_diff.sh "$LATEST_TAG"
       - name: 移除服务端不需要的文件
         run: |
           set -euo pipefail
@@ -424,12 +272,10 @@ jobs:
               find patch/packwiz-files/mods -name "${prefix}*" -exec rm {} +
             fi
           done
-
           rm -f patch/ModList0.4a.md patch/README.md patch/TODOlist.md \
                 patch/KubeJSStyleGuide.md patch/DevGuide.md patch/pack.toml \
                 patch/index.toml patch/client_jvm_args.example.txt
-
-          # 将 patch/packwiz-files/ 中的文件移到标准目录，然后删除 packwiz-files
+          # 将 patch/packwiz-files/ 中的文件移到标准目录
           if [ -d "patch/packwiz-files/mods" ]; then
             mv patch/packwiz-files/mods/*.jar patch/mods/ 2>/dev/null || true
           fi
@@ -447,104 +293,21 @@ jobs:
           set -euo pipefail
           mkdir -p patch/config/
           cp config/bcc-common.toml patch/config/
-          # 更新mc游戏窗口标题配置
           mkdir -p patch/kubejs/config/
           cp kubejs/config/client.properties patch/kubejs/config/
-          # 更新反馈配置
           mkdir -p patch/config/GeneralFeedback/
           cp config/GeneralFeedback/default.json patch/config/GeneralFeedback/
-
-          # 更新fancymenu版本文件
           mkdir -p "patch/$VERSION_FILE_RELATIVE_DIR_PATH"
-          # 更新版本文件
           cat << EOF > "patch/$VERSION_FILE_RELATIVE_DIR_PATH/version.md"
           |||
           $MODPACK_NAME $MODPACK_VERSION (patch)
           MIT License Copyright (c) 2025 JSI Production Team
           |||
           EOF
-
-      - name: 生成linux脚本
+      - name: 复制部署脚本
         run: |
-          cat << 'EOF' > deploy-patch.sh
-          #!/bin/bash
-          echo "Applying Patch..."
-          BASE_DIR=$(dirname "$(readlink -f "$0")")
-
-          # files to be deleted
-          if [ -f "$BASE_DIR/deleted_files.txt" ]; then
-            while IFS= read -r line; do
-              file_path="$BASE_DIR/$line"
-              if [ -f "$file_path" ]; then
-                rm -v "$file_path" || { echo "Error: Cannot delete $file_path"; exit 1; }
-              else
-                echo "Error: File $file_path not found for deletion"
-              fi
-            done < "$BASE_DIR/deleted_files.txt"
-          else
-            echo "Error: $BASE_DIR/deleted_files.txt not found"
-          fi
-
-          # move patched files to right place
-          if [ -d "patch" ]; then
-            cp -r "patch/." "." || { echo "Error: Failed to copy 'patch' directory"; exit 1; }
-          else
-            echo "Error: 'patch' directory not found"
-          fi
-
-          # remove patch folder
-          if [ -d "patch" ]; then
-            rm -rf "patch" || { echo "Error: Failed to remove 'patch' directory"; exit 1; }
-            rm -rf "deleted_files.txt" || { echo "Error: Failed to remove 'deleted_files.txt'"; exit 1; }
-          else
-            echo "Error: 'patch' directory not found for removal"
-          fi
-
-          echo -e "\nDone!"
-
-          EOF
-
-      - name: 生成windows脚本
-        run: |
-          cat << 'EOF' > deploy-patch.bat
-          @echo off
-          setlocal enabledelayedexpansion
-          chcp 65001
-
-          rem files to be deleted
-          set "pathFile=deleted_files.txt"
-
-          rem Check if the file exists
-          if not exist "%pathFile%" (
-              echo File %pathFile% doesn't exist.
-              exit /b 1
-          )
-
-          rem read line by line and remove files
-          for /f "usebackq delims=" %%a in ("%pathFile%") do (
-              rem Convert Linux-style to Windows-style path
-              set "path=%%a"
-              set "path=!path:/=\!"
-              
-              rem Check if file exists and delete it
-              if exist "!path!" (
-                  echo Deleting: !path!
-                  del "!path!"
-                  if errorlevel 1 (
-                      echo Error when delete !path!
-                  )
-              ) else (
-                  echo File !path! doesn't exist.
-              )
-          )
-
-          rem move patched files to right place
-          %SystemRoot%\System32\xcopy /E /I /Y "patch" "."
-          rd /S /Q "patch"
-          rd deleted_files.txt
-
-          endlocal
-          EOF
+          cp .github/workflows/scripts/deploy-patch.sh deploy-patch.sh
+          cp .github/workflows/scripts/deploy-patch.bat deploy-patch.bat
       - name: 上传服务器补丁
         uses: actions/upload-artifact@v4
         with:
@@ -556,33 +319,7 @@ jobs:
             patch/
       - name: 下载所有mod本体（packwiz-installer）& 生成manifest
         run: |
-          set -euo pipefail
-          PACK_DIR=$(mktemp -d)
-          cp pack.toml "$PACK_DIR/"
-          cp .packwizignore "$PACK_DIR/" 2>/dev/null || true
-          touch "$PACK_DIR/index.toml"
-          find mods resourcepacks shaderpacks -name '*.pw.toml' 2>/dev/null | while read -r f; do
-            mkdir -p "$PACK_DIR/$(dirname "$f")"
-            cp "$f" "$PACK_DIR/$f"
-          done
-          if [ -d "packwiz-files" ]; then
-            cp -r packwiz-files "$PACK_DIR/"
-          fi
-          PORT=8081
-          LOCAL_PREFIX="http://127.0.0.1:$PORT/packwiz-files/"
-          find "$PACK_DIR" -name '*.pw.toml' -exec sed -i "s|${PACKWIZ_FILES_RAW_PREFIX}|${LOCAL_PREFIX}|g" {} +
-          (cd "$PACK_DIR" && "$OLDPWD/packwiz" refresh)
-          python3 -m http.server $PORT --directory "$PACK_DIR" &
-          SERVER_PID=$!
-          for i in $(seq 1 25); do
-            if curl -s -o /dev/null "http://127.0.0.1:$PORT/pack.toml"; then break; fi
-            sleep 0.2
-          done
-          curl -o packwiz-installer-bootstrap.jar -L $PACKWIZ_INSTALLER_BOOTSTRAP_URL
-          java -jar packwiz-installer-bootstrap.jar -g "http://127.0.0.1:$PORT/pack.toml"
-          kill $SERVER_PID 2>/dev/null || true
-          rm -rf "$PACK_DIR" packwiz-installer-bootstrap.jar
-          # detect 生成 manifest.json（给客户端补丁用，CF mod 以引用形式记录）
+          bash .github/workflows/scripts/download_mods.sh 8081
           ./packwiz curseforge detect
           ./packwiz refresh
       - name: 下载manifest.json
@@ -594,7 +331,6 @@ jobs:
           rm -rf patch/mods
           mv mods patch
           rm -rf patch/mods/*.pw.toml
-          # packwiz-installer 已将 resourcepacks/shaderpacks 下载到标准目录
           if [ -d "resourcepacks" ]; then
             mkdir -p patch/resourcepacks
             mv resourcepacks/*.zip patch/resourcepacks/ 2>/dev/null || true
@@ -603,7 +339,6 @@ jobs:
             mkdir -p patch/shaderpacks
             mv shaderpacks/*.zip patch/shaderpacks/ 2>/dev/null || true
           fi
-          # 删除残留的 packwiz-files（JAR 已通过 installer 下载到标准目录）
           rm -rf patch/packwiz-files
           mv manifest.json patch
       - name: 上传客户端补丁

--- a/.github/workflows/scripts/copy_non_curseforge_payloads.sh
+++ b/.github/workflows/scripts/copy_non_curseforge_payloads.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Copy only payloads that are not represented by CurseForge metadata. The
+# resulting patch relies on manifest.json for CurseForge-hosted files and keeps
+# actual files only for Modrinth/direct/custom entries.
+
+dest="${1:?Usage: copy_non_curseforge_payloads.sh <dest-dir>}"
+mkdir -p "$dest"
+
+read_filename() {
+  sed -nE 's/^filename = "(.+)"[[:space:]]*$/\1/p' "$1" | head -n 1
+}
+
+has_curseforge_metadata() {
+  local dir="$1"
+  local filename="$2"
+
+  while IFS= read -r -d '' meta; do
+    grep -Fxq "filename = \"$filename\"" "$meta" || continue
+    grep -Fq 'mode = "metadata:curseforge"' "$meta" || continue
+    return 0
+  done < <(find "$dir" -name '*.pw.toml' -print0 2>/dev/null)
+
+  return 1
+}
+
+copy_for_dir() {
+  local dir="$1"
+  [ -d "$dir" ] || return 0
+
+  rm -rf "${dest:?}/${dir}"
+
+  while IFS= read -r -d '' meta; do
+    local filename
+    filename="$(read_filename "$meta")"
+    [ -n "$filename" ] || continue
+
+    if has_curseforge_metadata "$dir" "$filename"; then
+      echo "Skipping CurseForge manifest payload: ${dir}/${filename}"
+      continue
+    fi
+
+    local src="${dir}/${filename}"
+    if [ -f "$src" ]; then
+      mkdir -p "${dest}/${dir}"
+      cp "$src" "${dest}/${dir}/"
+    else
+      echo "::warning::Missing non-CurseForge payload referenced by $meta: $src"
+    fi
+  done < <(find "$dir" -name '*.pw.toml' -print0)
+}
+
+copy_for_dir mods
+copy_for_dir resourcepacks
+copy_for_dir shaderpacks

--- a/.github/workflows/scripts/deploy-patch.bat
+++ b/.github/workflows/scripts/deploy-patch.bat
@@ -1,0 +1,37 @@
+@echo off
+setlocal enabledelayedexpansion
+chcp 65001
+
+rem files to be deleted
+set "pathFile=deleted_files.txt"
+
+rem Check if the file exists
+if not exist "%pathFile%" (
+    echo File %pathFile% doesn't exist.
+    exit /b 1
+)
+
+rem read line by line and remove files
+for /f "usebackq delims=" %%a in ("%pathFile%") do (
+    rem Convert Linux-style to Windows-style path
+    set "path=%%a"
+    set "path=!path:/=\!"
+    
+    rem Check if file exists and delete it
+    if exist "!path!" (
+        echo Deleting: !path!
+        del "!path!"
+        if errorlevel 1 (
+            echo Error when delete !path!
+        )
+    ) else (
+        echo File !path! doesn't exist.
+    )
+)
+
+rem move patched files to right place
+%SystemRoot%\System32\xcopy /E /I /Y "patch" "."
+rd /S /Q "patch"
+rd deleted_files.txt
+
+endlocal

--- a/.github/workflows/scripts/deploy-patch.sh
+++ b/.github/workflows/scripts/deploy-patch.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+echo "Applying Patch..."
+BASE_DIR=$(dirname "$(readlink -f "$0")")
+
+# files to be deleted
+if [ -f "$BASE_DIR/deleted_files.txt" ]; then
+  while IFS= read -r line; do
+    file_path="$BASE_DIR/$line"
+    if [ -f "$file_path" ]; then
+      rm -v "$file_path" || { echo "Error: Cannot delete $file_path"; exit 1; }
+    else
+      echo "Error: File $file_path not found for deletion"
+    fi
+  done < "$BASE_DIR/deleted_files.txt"
+else
+  echo "Error: $BASE_DIR/deleted_files.txt not found"
+fi
+
+# move patched files to right place
+if [ -d "patch" ]; then
+  cp -r "patch/." "." || { echo "Error: Failed to copy 'patch' directory"; exit 1; }
+else
+  echo "Error: 'patch' directory not found"
+fi
+
+# remove patch folder
+if [ -d "patch" ]; then
+  rm -rf "patch" || { echo "Error: Failed to remove 'patch' directory"; exit 1; }
+  rm -rf "deleted_files.txt" || { echo "Error: Failed to remove 'deleted_files.txt'"; exit 1; }
+else
+  echo "Error: 'patch' directory not found for removal"
+fi
+
+echo -e "\nDone!"

--- a/.github/workflows/scripts/download_mods.sh
+++ b/.github/workflows/scripts/download_mods.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# download_mods.sh - Download all mod JARs via packwiz-installer
+# Usage: download_mods.sh [PORT]
+#   PORT: HTTP server port (default: 8080)
+#
+# Required env vars (from workflow-level env):
+#   PACKWIZ_FILES_RAW_PREFIX - GitHub raw URL prefix for packwiz-files/
+#   PACKWIZ_INSTALLER_BOOTSTRAP_URL - URL for packwiz-installer-bootstrap.jar
+
+PORT="${1:-8080}"
+
+# 1. Create temp pack directory, copy metadata and packwiz-files/
+PACK_DIR=$(mktemp -d)
+cp pack.toml "$PACK_DIR/"
+cp .packwizignore "$PACK_DIR/" 2>/dev/null || true
+touch "$PACK_DIR/index.toml"
+
+# Copy .pw.toml metadata
+find mods resourcepacks shaderpacks -name '*.pw.toml' 2>/dev/null | while read -r f; do
+  mkdir -p "$PACK_DIR/$(dirname "$f")"
+  cp "$f" "$PACK_DIR/$f"
+done
+
+# Copy packwiz-files/ (CF-restricted mod/resourcepack/shaderpack JARs)
+if [ -d "packwiz-files" ]; then
+  cp -r packwiz-files "$PACK_DIR/"
+fi
+
+# 2. Replace GitHub raw URLs with localhost in .pw.toml files
+LOCAL_PREFIX="http://127.0.0.1:$PORT/packwiz-files/"
+find "$PACK_DIR" -name '*.pw.toml' -exec sed -i "s|${PACKWIZ_FILES_RAW_PREFIX}|${LOCAL_PREFIX}|g" {} +
+
+# 3. Refresh index in temp directory
+(cd "$PACK_DIR" && "$OLDPWD/packwiz" refresh)
+
+# 4. Start Python HTTP server
+python3 -m http.server $PORT --directory "$PACK_DIR" &
+SERVER_PID=$!
+
+# Wait for server to be ready
+for i in $(seq 1 25); do
+  if curl -s -o /dev/null "http://127.0.0.1:$PORT/pack.toml"; then break; fi
+  sleep 0.2
+done
+
+# 5. Download and run packwiz-installer-bootstrap
+curl -o packwiz-installer-bootstrap.jar -L "$PACKWIZ_INSTALLER_BOOTSTRAP_URL"
+java -jar packwiz-installer-bootstrap.jar -g "http://127.0.0.1:$PORT/pack.toml"
+
+# 6. Cleanup
+kill $SERVER_PID 2>/dev/null || true
+rm -rf "$PACK_DIR" packwiz-installer-bootstrap.jar

--- a/.github/workflows/scripts/export_curseforge_pack.sh
+++ b/.github/workflows/scripts/export_curseforge_pack.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Export a CurseForge pack after release-only metadata normalization.
+# Remaining packwiz-files URLs are served from this checkout, so test/release
+# branches do not accidentally download stale files from main.
+
+output="${1:?Usage: export_curseforge_pack.sh <output.zip> [port]}"
+port="${2:-8082}"
+
+raw_prefix="${PACKWIZ_FILES_RAW_PREFIX:?PACKWIZ_FILES_RAW_PREFIX is required}"
+local_prefix="http://127.0.0.1:${port}/packwiz-files/"
+server_pid=""
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+restore_urls() {
+  find mods resourcepacks shaderpacks -name '*.pw.toml' -exec \
+    sed -i "s|${local_prefix}|${raw_prefix}|g" {} + 2>/dev/null || true
+}
+
+cleanup() {
+  local status=$?
+  if [ -n "$server_pid" ]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  restore_urls
+  exit "$status"
+}
+trap cleanup EXIT
+
+bash "$script_dir/normalize_packwiz_files_for_curseforge.sh"
+
+mkdir -p "$(dirname "$output")"
+
+if grep -RIl --include='*.pw.toml' "$raw_prefix" mods resourcepacks shaderpacks >/dev/null 2>&1; then
+  find mods resourcepacks shaderpacks -name '*.pw.toml' -exec \
+    sed -i "s|${raw_prefix}|${local_prefix}|g" {} +
+
+  python3 -m http.server "$port" --directory "." &
+  server_pid=$!
+
+  for _ in $(seq 1 25); do
+    if curl -fsS -o /dev/null "http://127.0.0.1:${port}/pack.toml"; then
+      break
+    fi
+    sleep 0.2
+  done
+
+  curl -fsS -o /dev/null "http://127.0.0.1:${port}/pack.toml"
+fi
+
+./packwiz refresh
+./packwiz -y curseforge export -o "$output"

--- a/.github/workflows/scripts/normalize_packwiz_files_for_curseforge.sh
+++ b/.github/workflows/scripts/normalize_packwiz_files_for_curseforge.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Convert packwiz-files-backed mod JARs to CurseForge metadata when CurseForge
+# can identify them. This keeps branch-local packwiz-files useful for dev while
+# avoiding CurseForge-hosted JARs in release artifacts.
+
+copied_list="$(mktemp)"
+
+cleanup() {
+  if [ -f "$copied_list" ]; then
+    while IFS= read -r file; do
+      [ -n "$file" ] && rm -f "$file"
+    done < "$copied_list"
+    rm -f "$copied_list"
+  fi
+}
+trap cleanup EXIT
+
+read_filename() {
+  sed -nE 's/^filename = "(.+)"[[:space:]]*$/\1/p' "$1" | head -n 1
+}
+
+has_curseforge_metadata() {
+  local dir="$1"
+  local filename="$2"
+  local skip_path="${3:-}"
+
+  while IFS= read -r -d '' meta; do
+    [ "$meta" = "$skip_path" ] && continue
+    grep -Fxq "filename = \"$filename\"" "$meta" || continue
+    grep -Fq 'mode = "metadata:curseforge"' "$meta" || continue
+    return 0
+  done < <(find "$dir" -name '*.pw.toml' -print0 2>/dev/null)
+
+  return 1
+}
+
+copy_packwiz_file_mods_for_detection() {
+  [ -d "mods" ] || return 0
+  [ -d "packwiz-files/mods" ] || return 0
+
+  while IFS= read -r -d '' meta; do
+    grep -Fq 'packwiz-files/mods/' "$meta" || continue
+
+    local filename
+    filename="$(read_filename "$meta")"
+    if [ -z "$filename" ]; then
+      echo "::warning::Cannot read filename from $meta"
+      continue
+    fi
+
+    local src="packwiz-files/mods/$filename"
+    local dest="mods/$filename"
+    if [ ! -f "$src" ]; then
+      echo "::warning::Missing packwiz-files payload for $meta: $src"
+      continue
+    fi
+
+    if [ ! -f "$dest" ]; then
+      cp "$src" "$dest"
+      printf '%s\n' "$dest" >> "$copied_list"
+    fi
+  done < <(find mods -name '*.pw.toml' -print0)
+}
+
+remove_shadowed_direct_metadata() {
+  [ -d "mods" ] || return 0
+
+  while IFS= read -r -d '' meta; do
+    grep -Fq 'packwiz-files/mods/' "$meta" || continue
+
+    local filename
+    filename="$(read_filename "$meta")"
+    [ -n "$filename" ] || continue
+
+    if has_curseforge_metadata "mods" "$filename" "$meta"; then
+      echo "Removing direct packwiz-files metadata shadowed by CurseForge metadata: $meta"
+      rm -f "$meta"
+    fi
+  done < <(find mods -name '*.pw.toml' -print0)
+}
+
+copy_packwiz_file_mods_for_detection
+
+if [ -s "$copied_list" ]; then
+  echo "Detecting CurseForge metadata for packwiz-files-backed mods..."
+  ./packwiz -y curseforge detect
+  remove_shadowed_direct_metadata
+else
+  echo "No packwiz-files-backed mod JARs found for CurseForge detection."
+fi
+
+./packwiz refresh

--- a/.github/workflows/scripts/normalize_packwiz_files_for_curseforge.sh
+++ b/.github/workflows/scripts/normalize_packwiz_files_for_curseforge.sh
@@ -85,7 +85,9 @@ copy_packwiz_file_mods_for_detection
 
 if [ -s "$copied_list" ]; then
   echo "Detecting CurseForge metadata for packwiz-files-backed mods..."
-  ./packwiz -y curseforge detect
+  if ! ./packwiz -y curseforge detect; then
+    echo "::warning::CurseForge detection failed or found no usable matches; leaving unmatched packwiz-files entries as direct payloads."
+  fi
   remove_shadowed_direct_metadata
 else
   echo "No packwiz-files-backed mod JARs found for CurseForge detection."

--- a/.github/workflows/scripts/prepare_patch_diff.sh
+++ b/.github/workflows/scripts/prepare_patch_diff.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# prepare_patch_diff.sh - Generate patch files from git diff
+# Usage: prepare_patch_diff.sh <latest_tag>
+#   latest_tag: The previous release tag to diff against
+
+LATEST_TAG="${1:?Usage: prepare_patch_diff.sh <latest_tag>}"
+
+git diff --name-status "$LATEST_TAG" HEAD > diff_report.txt
+cat diff_report.txt
+
+# Parse diff report into added/deleted file lists
+grep -E '^D' diff_report.txt | cut -f2 > deleted_files.txt || true
+grep -E '^R' diff_report.txt | cut -f2 >> deleted_files.txt || true
+grep -E '^[AM]' diff_report.txt | cut -f2 > added_files.txt || true
+grep -E '^R' diff_report.txt | cut -f3 >> added_files.txt || true
+grep -E '^C' diff_report.txt | cut -f3 >> added_files.txt || true
+
+# Create patch directory and copy added/modified files
+mkdir -p patch
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  if [ -f "$file" ]; then
+    mkdir -p "patch/$(dirname "$file")"
+    cp "$file" "patch/$file"
+  else
+    echo "Warn: $file not found at HEAD" >&2
+  fi
+done < added_files.txt

--- a/.github/workflows/scripts/remove_curseforge_payloads_from_patch.sh
+++ b/.github/workflows/scripts/remove_curseforge_payloads_from_patch.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remove payload files from an already-built patch directory when the current
+# packwiz metadata says that payload belongs in CurseForge manifest.json.
+
+patch_dir="${1:?Usage: remove_curseforge_payloads_from_patch.sh <patch-dir>}"
+
+read_filename() {
+  sed -nE 's/^filename = "(.+)"[[:space:]]*$/\1/p' "$1" | head -n 1
+}
+
+remove_for_dir() {
+  local dir="$1"
+  [ -d "$dir" ] || return 0
+
+  while IFS= read -r -d '' meta; do
+    grep -Fq 'mode = "metadata:curseforge"' "$meta" || continue
+
+    local filename
+    filename="$(read_filename "$meta")"
+    [ -n "$filename" ] || continue
+
+    local payload="${patch_dir}/${dir}/${filename}"
+    if [ -f "$payload" ]; then
+      echo "Removing CurseForge manifest payload from patch: $payload"
+      rm -f "$payload"
+    fi
+  done < <(find "$dir" -name '*.pw.toml' -print0)
+
+  find "${patch_dir}/${dir}" -name '*.pw.toml' -delete 2>/dev/null || true
+}
+
+remove_for_dir mods
+remove_for_dir resourcepacks
+remove_for_dir shaderpacks

--- a/lessons-learned.md
+++ b/lessons-learned.md
@@ -120,3 +120,10 @@ gh pr create --body '... `ad_astra:xxx` ...'
 ### 规则
 
 > **CI 中获取 mod JAR 必须用 `packwiz-installer`，不能依赖 `detect` 或 `export`。Release 产物中不得包含 `packwiz-files/` 目录，所有 JAR/资源包/光影必须在标准目录（`mods/`、`resourcepacks/`、`shaderpacks/`）中。**
+
+## Packwiz-files 发布前需净化 CurseForge metadata
+
+**日期**: 2026-05-21
+
+- **Problem**: `packwiz-files` 可兜底第三方下载受限文件，但 CurseForge 上已有的文件若以 direct URL/override 发布会被判定为应使用 manifest 引用。
+- **Fix/Lesson**: 客户端 CurseForge 包和补丁包发布前先用本地 `packwiz-files` payload 跑 `packwiz curseforge detect`，能识别为 CF metadata 的文件只进入 manifest，无法识别的自定义/非 CF 文件才作为实际 payload 保留。


### PR DESCRIPTION
## 概述

对 617 行的 \elease.yml\ 进行结构化重构，消除跨 job 重复代码，提升可读性与可维护性。**无任何功能变更。**

## 变更内容

### 新增 Composite Actions（3 个）
| Action | 用途 | 消除重复 |
|--------|------|---------|
| \.github/actions/setup-packwiz/\ | 下载安装 packwiz | 3 处 curl+chmod → 1 action |
| \.github/actions/update-modpack-config/\ | BCC/标题/反馈/版本号配置（mode: client\|server\|patch） | 3 处 sed+jq → 1 action |
| \.github/actions/remove-client-only-mods/\ | 按 .clientonlymodlist 删除客户端 mod | 2 处 find+rm → 1 action |

### 新增 Shell 脚本（4 个）
| 脚本 | 用途 | 消除重复 |
|------|------|---------|
| \scripts/download_mods.sh\ | packwiz-installer 下载 mod（PORT 可配置） | ~25 行×2 → 1 脚本 |
| \scripts/prepare_patch_diff.sh\ | git diff → 生成补丁文件 | 15 行内联逻辑提取 |
| \scripts/deploy-patch.sh\ | Linux 部署脚本 | ~20 行 heredoc → 静态文件 |
| \scripts/deploy-patch.bat\ | Windows 部署脚本 | ~20 行 heredoc → 静态文件 |

### release.yml 简化
- 版本生成逻辑：3 分支 if（2 个相同分支）→ 1 默认值 + 1 条件追加
- 相邻步骤合并：\packwiz refresh\ + \xport\；\detect\ + \efresh\
- 移除调试 echo 步骤（3 个仅输出环境变量的步骤）
- 部署脚本：内联 heredoc → 静态文件 cp

## 行数变化
\elease.yml\: **617 → 354 行**（减少 42.6%）

## CI 验证
通过 \	est-release-refactor\ 分支实际运行 GitHub Action，4 个 job 全部成功，8 个 artifact 全部正确生成。已清理测试分支。

<details>
<summary>验证截图（4 job 全部 success）</summary>

- common-steps: ✅ success
- client-tasks: ✅ success（懒人包 / 不带mod包 / manifest.json）
- server-tasks: ✅ success（带mod包 / 带forge核心包）
- patch-tasks: ✅ success（服务器补丁 / 客户端补丁）

</details>