### PR TITLE
[dev] 增加知识库校验和候选沉淀流程

### DIFF
--- a/.agents/skills/knowledge-check/SKILL.md
+++ b/.agents/skills/knowledge-check/SKILL.md
@@ -25,6 +25,8 @@ Do NOT invoke for:
 
 Ask: "Did I learn anything new about THIS PROJECT that future sessions would benefit from?"
 
+If `tmp-opencode/knowledge-candidate-report.md` exists, read it before deciding; process notes require user acceptance unless the current task explicitly asked to maintain the knowledge base.
+
 Categories of worth-recording knowledge:
 - **Bug/pitfall discovered** → `lessons-learned.md`
 - **New convention or pattern** → Relevant `AGENTS.md` (root, `kubejs/`, or `CDC-mod-src/`)
@@ -62,6 +64,8 @@ Categories of worth-recording knowledge:
 - ❌ Git operations
 
 ### Step 4: Output Summary
+
+If applying or rejecting a candidate report, run `scripts/resolve-knowledge-candidate.ps1 -Status applied|rejected` after the decision so temporary process notes do not repeat.
 
 Output this block at the end:
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -7,6 +7,11 @@
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"scripts/validate-knowledge-base.ps1\"",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"scripts/write-knowledge-candidate-report.ps1\"",
+            "timeout": 30
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"scripts/validate-knowledge-base.ps1\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 
 # Root directories that manage their own allowlists.
 !/.agents/
+!/.codex/
 !/.github/
 !/PCL/
 !/config/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,9 @@ These rules ensure this knowledge base stays effective. Violating them degrades 
 - **Lessons go to `lessons-learned.md`** — Never inline long historical entries in AGENTS.md
 - **After fixing a non-obvious bug** — Add entry to `lessons-learned.md` (use `/knowledge-check` skill for guidance)
 - **Validation** — Codex `Stop` hook runs `scripts/validate-knowledge-base.ps1` to catch line-limit and stale-path failures
+- **Candidate report** — Codex `Stop` hook writes `tmp-opencode/knowledge-candidate-report.md`; it is advisory only and never edits knowledge files
+- **Process notes** — When a task hits a non-obvious failure or workaround, append a temporary note with `scripts/add-knowledge-note.ps1`; the candidate report routes it for `/knowledge-check`
+- **Candidate decision** — Apply/reject candidate reports with `scripts/resolve-knowledge-candidate.ps1`; process-note candidates need user acceptance unless knowledge maintenance was explicitly requested
 
 ## NOTES
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ CD-master-dev/
 ├── mods/             # Packwiz metadata (*.pw.toml), NOT mod JARs
 ├── packwiz-files/    # Manually-managed mod JARs (CF-restricted, custom)
 ├── scripts/          # Utility scripts (sync, update-packwiz-meta)
+├── .codex/           # Codex project hooks
+├── docs/             # Project documentation and analysis notes
 ├── .github/          # CI/CD workflows
 └── pack.toml         # Pack metadata (ONLY version source)
 ```
@@ -38,6 +40,8 @@ CD-master-dev/
 | FTB Quests | `config/ftbquests/quests/` | .snbt format |
 | Java mod dev | `CDC-mod-src/src/main/java/` | Forge mod project |
 | Version info | `pack.toml` | ONLY source - don't duplicate |
+| Release workflow | `.github/workflows/release.yml` | Use `/release` skill |
+| Historical pitfalls | `lessons-learned.md` | Do not duplicate in AGENTS |
 
 ## GLOSSARY
 
@@ -49,7 +53,7 @@ CD-master-dev/
 | **分液池** | `create:item_drain` (ItemDrainBlockEntity) |
 | **AE2** | Applied Energistics 2 |
 | **BCC** | Better Compatibility Checker |
-| **OEI** | One Enough Item (config: `kubejs/data/oei/replacements/`) |
+| **OEI** | One Enough Item |
 | **DH** | Distant Horizons |
 
 ## CONVENTIONS
@@ -79,6 +83,7 @@ CD-master-dev/
 - ❌ Overwrite `index.toml`, `ModList*.md`
 - ❌ `e.remove()` or `e.removeById()` - use `remove_recipes_id(e, [...])`
 - ❌ Duplicate version in other files
+- ❌ Treat runtime dirs (`logs/`, `crash-reports/`, `saves/`, `screenshots/`, `simplebackups/`, `tmp-*`) as source
 
 ## COMMANDS
 
@@ -103,8 +108,6 @@ cd CDC-mod-src && ./gradlew build --no-daemon
 # Output: build/libs/CDC-mod-src-*.jar (use non-all version)
 ```
 
-**发布流程**: Use `/release` skill for version bump, tag, and GitHub release workflow.
-
 ## KNOWLEDGE BASE MAINTENANCE
 
 These rules ensure this knowledge base stays effective. Violating them degrades agent performance.
@@ -118,12 +121,12 @@ These rules ensure this knowledge base stays effective. Violating them degrades 
 - **Iterate, don't upfront** — Add rules only when agent makes a repeated mistake. Remove rules agent always follows correctly
 - **Lessons go to `lessons-learned.md`** — Never inline long historical entries in AGENTS.md
 - **After fixing a non-obvious bug** — Add entry to `lessons-learned.md` (use `/knowledge-check` skill for guidance)
+- **Validation** — Codex `Stop` hook runs `scripts/validate-knowledge-base.ps1` to catch line-limit and stale-path failures
 
 ## NOTES
 
 - **AGENTS.md 是本地开发知识库，已加入 .gitignore，不需要推送到远程仓库**
 - **`.agents/skills/` 存放技能文件，OpenCode 和 Codex 都能自动发现**
-- `pack.toml` is the ONLY version source - CI auto-updates other configs
 - Client-only mods → add to `.clientonlymodlist` (server startup required)
 - Server-only mods → add to `.serveronlymodlist`
 - Language files validated by `.vscode/probe.lang-schema.json`

--- a/lessons-learned.md
+++ b/lessons-learned.md
@@ -127,3 +127,10 @@ gh pr create --body '... `ad_astra:xxx` ...'
 
 - **Problem**: `packwiz-files` 可兜底第三方下载受限文件，但 CurseForge 上已有的文件若以 direct URL/override 发布会被判定为应使用 manifest 引用。
 - **Fix/Lesson**: 客户端 CurseForge 包和补丁包发布前先用本地 `packwiz-files` payload 跑 `packwiz curseforge detect`，能识别为 CF metadata 的文件只进入 manifest，无法识别的自定义/非 CF 文件才作为实际 payload 保留。
+
+## PowerShell helper 函数不要使用 `$Args` 作为参数名
+
+**日期**: 2026-05-21
+
+- **Problem**: `write-knowledge-candidate-report.ps1` 使用 `[string[]]$Args` 作为 helper 参数名后，调用 `Invoke-Git -Args ...` 时 git 文件发现结果为空，候选报告误判为无改动。
+- **Fix/Lesson**: helper 参数改名为 `$GitArgs` 并用 `-GitArgs` 调用；项目脚本避免把 PowerShell 自动变量名当作自定义参数名。

--- a/scripts/add-knowledge-note.ps1
+++ b/scripts/add-knowledge-note.ps1
@@ -1,0 +1,46 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Summary,
+
+    [string]$Problem = "",
+    [string]$Fix = "",
+    [string]$Target = "lessons-learned.md",
+    [string]$Root = "",
+    [string]$NotesPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Root)) {
+    $Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+
+if ([string]::IsNullOrWhiteSpace($NotesPath)) {
+    $NotesPath = Join-Path $Root "tmp-opencode/knowledge-notes.md"
+}
+
+$notesDir = Split-Path -Parent $NotesPath
+if (-not (Test-Path -LiteralPath $notesDir)) {
+    New-Item -ItemType Directory -Path $notesDir -Force | Out-Null
+}
+
+$timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss zzz"
+$lines = @(
+    "## $timestamp",
+    "",
+    "- Target: $Target",
+    "- Summary: $Summary"
+)
+
+if (-not [string]::IsNullOrWhiteSpace($Problem)) {
+    $lines += "- Problem: $Problem"
+}
+
+if (-not [string]::IsNullOrWhiteSpace($Fix)) {
+    $lines += "- Fix: $Fix"
+}
+
+$lines += ""
+
+Add-Content -LiteralPath $NotesPath -Value $lines -Encoding UTF8
+Write-Host "Knowledge note appended to $(Resolve-Path -LiteralPath $NotesPath)"

--- a/scripts/resolve-knowledge-candidate.ps1
+++ b/scripts/resolve-knowledge-candidate.ps1
@@ -1,0 +1,62 @@
+param(
+    [ValidateSet("accepted", "rejected", "applied")]
+    [string]$Status = "applied",
+
+    [string]$Reason = "",
+    [string]$Root = "",
+    [string]$DecisionPath = "",
+    [string]$NotesPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Root)) {
+    $Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+
+if ([string]::IsNullOrWhiteSpace($DecisionPath)) {
+    $DecisionPath = Join-Path $Root "tmp-opencode/knowledge-candidate-decision.json"
+}
+
+if ([string]::IsNullOrWhiteSpace($NotesPath)) {
+    $NotesPath = Join-Path $Root "tmp-opencode/knowledge-notes.md"
+}
+
+$timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss zzz"
+$decision = [ordered]@{
+    status = $Status
+    decidedAt = $timestamp
+    reason = $Reason
+}
+
+if (Test-Path -LiteralPath $DecisionPath) {
+    try {
+        $existing = Get-Content -Raw -LiteralPath $DecisionPath | ConvertFrom-Json
+        foreach ($property in $existing.PSObject.Properties) {
+            if (-not $decision.Contains($property.Name)) {
+                $decision[$property.Name] = $property.Value
+            }
+        }
+        $decision["status"] = $Status
+        $decision["decidedAt"] = $timestamp
+        $decision["reason"] = $Reason
+    } catch {
+    }
+}
+
+$decisionDir = Split-Path -Parent $DecisionPath
+if (-not (Test-Path -LiteralPath $decisionDir)) {
+    New-Item -ItemType Directory -Path $decisionDir -Force | Out-Null
+}
+
+$decision | ConvertTo-Json | Set-Content -LiteralPath $DecisionPath -Encoding UTF8
+
+if (($Status -eq "rejected" -or $Status -eq "applied") -and (Test-Path -LiteralPath $NotesPath)) {
+    try {
+        Remove-Item -LiteralPath $NotesPath -Force
+    } catch {
+        Set-Content -LiteralPath $NotesPath -Value "" -Encoding UTF8
+    }
+}
+
+Write-Host "Knowledge candidate marked as $Status."

--- a/scripts/validate-knowledge-base.ps1
+++ b/scripts/validate-knowledge-base.ps1
@@ -1,0 +1,158 @@
+param(
+    [string]$Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+    [switch]$StrictWarnings
+)
+
+$ErrorActionPreference = "Stop"
+
+$failures = New-Object System.Collections.Generic.List[string]
+$warnings = New-Object System.Collections.Generic.List[string]
+
+function Add-Failure([string]$Message) {
+    $script:failures.Add($Message) | Out-Null
+}
+
+function Add-Warning([string]$Message) {
+    $script:warnings.Add($Message) | Out-Null
+}
+
+function Get-RelPath([string]$Path) {
+    return $Path.Replace($Root, "").TrimStart("\", "/")
+}
+
+function Test-ProjectPath([string]$RelativePath) {
+    return Test-Path -LiteralPath (Join-Path $Root $RelativePath)
+}
+
+function Get-LineCount([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return 0
+    }
+    return (Get-Content -LiteralPath $Path).Count
+}
+
+function Get-FileText([string]$RelativePath) {
+    $path = Join-Path $Root $RelativePath
+    if (-not (Test-Path -LiteralPath $path)) {
+        return ""
+    }
+    return Get-Content -Raw -LiteralPath $path
+}
+
+$knowledgeFiles = @(
+    @{ Path = "AGENTS.md"; MaxLines = 150; Required = $true },
+    @{ Path = "kubejs/AGENTS.md"; MaxLines = 80; Required = $true },
+    @{ Path = "CDC-mod-src/AGENTS.md"; MaxLines = 80; Required = $true }
+)
+
+foreach ($file in $knowledgeFiles) {
+    $path = Join-Path $Root $file.Path
+    if (-not (Test-Path -LiteralPath $path)) {
+        if ($file.Required) {
+            Add-Failure "Missing knowledge file: $($file.Path)"
+        }
+        continue
+    }
+
+    $lineCount = Get-LineCount $path
+    if ($lineCount -gt $file.MaxLines) {
+        Add-Failure "$($file.Path) has $lineCount lines; limit is $($file.MaxLines)."
+    }
+}
+
+$requiredPaths = @(
+    "AGENTS.md",
+    "kubejs/AGENTS.md",
+    "CDC-mod-src/AGENTS.md",
+    "lessons-learned.md",
+    ".agents/skills/knowledge-check/SKILL.md",
+    ".github/workflows/release.yml",
+    "scripts/sync-packwiz-assets.ps1",
+    "scripts/update-packwiz-meta.ps1",
+    "kubejs/data/oei/replacements",
+    "pack.toml"
+)
+
+foreach ($relativePath in $requiredPaths) {
+    if (-not (Test-ProjectPath $relativePath)) {
+        Add-Failure "Documented path does not exist: $relativePath"
+    }
+}
+
+$allAgentsText = ($knowledgeFiles | ForEach-Object { Get-FileText $_.Path }) -join "`n"
+$duplicateChecks = @(
+    @{
+        Name = "pack.toml version source";
+        Pattern = 'pack\.toml.*ONLY version source|Version ONLY in `pack\.toml`';
+        Max = 2
+    },
+    @{
+        Name = "release workflow guidance";
+        Pattern = "/release|release workflow";
+        Max = 3
+    },
+    @{
+        Name = "lessons-learned routing";
+        Pattern = "lessons-learned\.md";
+        Max = 5
+    }
+)
+
+foreach ($check in $duplicateChecks) {
+    $matches = [regex]::Matches($allAgentsText, $check.Pattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if ($matches.Count -gt $check.Max) {
+        Add-Warning "Possible duplicated knowledge: $($check.Name) appears $($matches.Count) times; expected <= $($check.Max)."
+    }
+}
+
+$antiPatterns = @(
+    @{ Pattern = "e\.remove\(\) or e\.removeById\(\).*e\.remove\(\) or e\.removeById\(\)"; Message = "Recipe removal anti-pattern appears duplicated." },
+    @{ Pattern = "PowerShell.*反引号.*AGENTS\.md"; Message = "Long historical lesson appears to be in AGENTS.md; move history to lessons-learned.md." }
+)
+
+foreach ($antiPattern in $antiPatterns) {
+    if ($allAgentsText -match $antiPattern.Pattern) {
+        Add-Warning $antiPattern.Message
+    }
+}
+
+$lessonsPath = Join-Path $Root "lessons-learned.md"
+if (Test-Path -LiteralPath $lessonsPath) {
+    $lessonsText = Get-Content -Raw -LiteralPath $lessonsPath
+    $sections = [regex]::Split($lessonsText, "(?m)^##\s+").Where({ $_.Trim().Length -gt 0 })
+    foreach ($section in $sections) {
+        $firstLine = ($section -split "`r?`n", 2)[0].Trim()
+        if ($firstLine -eq "# Lessons Learned") {
+            continue
+        }
+        if ($section -notmatch "\d{4}-\d{2}-\d{2}") {
+            Add-Warning "Lesson '$firstLine' has no YYYY-MM-DD date."
+        }
+        if ($section -notmatch "(?i)(Problem|Fix|Lesson|场景|根因|正确做法|规则)") {
+            Add-Warning "Lesson '$firstLine' may lack problem/fix structure."
+        }
+    }
+}
+
+if ($warnings.Count -gt 0) {
+    Write-Host "Knowledge base validation warnings:" -ForegroundColor Yellow
+    foreach ($warning in $warnings) {
+        Write-Host "WARN: $warning" -ForegroundColor Yellow
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "Knowledge base validation failed:" -ForegroundColor Red
+    foreach ($failure in $failures) {
+        Write-Host "FAIL: $failure" -ForegroundColor Red
+    }
+    exit 1
+}
+
+if ($StrictWarnings -and $warnings.Count -gt 0) {
+    Write-Host "Knowledge base validation failed because -StrictWarnings was set." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Knowledge base validation passed." -ForegroundColor Green
+exit 0

--- a/scripts/validate-knowledge-base.ps1
+++ b/scripts/validate-knowledge-base.ps1
@@ -1,9 +1,13 @@
 param(
-    [string]$Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+    [string]$Root = "",
     [switch]$StrictWarnings
 )
 
 $ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Root)) {
+    $Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
 
 $failures = New-Object System.Collections.Generic.List[string]
 $warnings = New-Object System.Collections.Generic.List[string]

--- a/scripts/write-knowledge-candidate-report.ps1
+++ b/scripts/write-knowledge-candidate-report.ps1
@@ -1,0 +1,208 @@
+param(
+    [string]$Root = "",
+    [string]$OutputPath = "",
+    [string]$StatePath = "",
+    [string]$NotesPath = "",
+    [string]$DecisionPath = "",
+    [int]$RecentCommits = 1
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Root)) {
+    $Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Join-Path $Root "tmp-opencode/knowledge-candidate-report.md"
+}
+
+if ([string]::IsNullOrWhiteSpace($StatePath)) {
+    $StatePath = Join-Path $Root "tmp-opencode/knowledge-candidate-state.json"
+}
+
+if ([string]::IsNullOrWhiteSpace($NotesPath)) {
+    $NotesPath = Join-Path $Root "tmp-opencode/knowledge-notes.md"
+}
+
+if ([string]::IsNullOrWhiteSpace($DecisionPath)) {
+    $DecisionPath = Join-Path $Root "tmp-opencode/knowledge-candidate-decision.json"
+}
+
+function Invoke-Git([string[]]$GitArgs) {
+    $output = & git -C $Root @GitArgs 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+    return @($output)
+}
+
+function Add-Unique([System.Collections.Generic.List[string]]$List, [string]$Value) {
+    if (-not [string]::IsNullOrWhiteSpace($Value) -and -not $List.Contains($Value)) {
+        $List.Add($Value) | Out-Null
+    }
+}
+
+function ConvertTo-Target([string]$Path) {
+    $normalized = $Path -replace "\\", "/"
+    if ($normalized -eq "AGENTS.md") { return "AGENTS.md" }
+    if ($normalized -eq "lessons-learned.md") { return "lessons-learned.md" }
+    if ($normalized -like "kubejs/*") { return "kubejs/AGENTS.md" }
+    if ($normalized -like "CDC-mod-src/*") { return "CDC-mod-src/AGENTS.md" }
+    if ($normalized -like ".github/*" -or $normalized -like "scripts/*" -or $normalized -like "mods/*" -or $normalized -like "packwiz-files/*" -or $normalized -eq "pack.toml") { return "AGENTS.md" }
+    if ($normalized -like "config/*" -or $normalized -like "defaultconfigs/*") { return "lessons-learned.md" }
+    return ""
+}
+
+function ConvertTo-Reason([string]$Path) {
+    $normalized = $Path -replace "\\", "/"
+    if ($normalized -like "kubejs/server_scripts/*") { return "KubeJS recipe or tag pattern may have changed." }
+    if ($normalized -like "kubejs/startup_scripts/*") { return "KubeJS registry/startup behavior may require restart or new conventions." }
+    if ($normalized -like "kubejs/data/*") { return "Datapack/OEI/tag structure may need a routing note." }
+    if ($normalized -like "CDC-mod-src/src/main/java/*") { return "CDC Java package, mixin, registry, or compatibility pattern may have changed." }
+    if ($normalized -like "CDC-mod-src/src/generated/*") { return "Datagen output changed; check whether the generator rule is still accurate." }
+    if ($normalized -like "scripts/*") { return "Project automation changed; root knowledge may need a command or workflow note." }
+    if ($normalized -like ".github/*") { return "CI/release workflow changed; root knowledge may need an update." }
+    if ($normalized -like "config/*" -or $normalized -like "defaultconfigs/*") { return "Config behavior changed; record only non-obvious side effects." }
+    if ($normalized -like "mods/*" -or $normalized -like "packwiz-files/*" -or $normalized -eq "pack.toml") { return "Packwiz/modpack metadata changed; check version or mod-management rules." }
+    if ($normalized -like "*AGENTS.md" -or $normalized -eq "lessons-learned.md") { return "Knowledge base changed; run validation and check for duplicate facts." }
+    return "Changed file may encode a reusable project pattern."
+}
+
+$dirtyFiles = Invoke-Git -GitArgs @("diff", "--name-only")
+$stagedFiles = Invoke-Git -GitArgs @("diff", "--cached", "--name-only")
+$untrackedFiles = Invoke-Git -GitArgs @("ls-files", "--others", "--exclude-standard")
+$head = (Invoke-Git -GitArgs @("rev-parse", "HEAD") | Select-Object -First 1)
+$lastReportedHead = ""
+if (Test-Path -LiteralPath $StatePath) {
+    try {
+        $state = Get-Content -Raw -LiteralPath $StatePath | ConvertFrom-Json
+        $lastReportedHead = [string]$state.lastReportedHead
+    } catch {
+        $lastReportedHead = ""
+    }
+}
+
+$hasCurrentChanges = (@($dirtyFiles + $stagedFiles + $untrackedFiles).Count -gt 0)
+$recentFiles = @()
+if (-not $hasCurrentChanges -and $head -and $head -ne $lastReportedHead) {
+    $recentFiles = Invoke-Git -GitArgs @("diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD")
+}
+
+$allFiles = New-Object System.Collections.Generic.List[string]
+foreach ($file in @($dirtyFiles + $stagedFiles + $untrackedFiles + $recentFiles)) {
+    Add-Unique $allFiles $file
+}
+
+$knowledgeFiles = @("AGENTS.md", "kubejs/AGENTS.md", "CDC-mod-src/AGENTS.md", "lessons-learned.md")
+$changedKnowledge = New-Object System.Collections.Generic.List[string]
+$targets = New-Object System.Collections.Generic.List[string]
+$signals = New-Object System.Collections.Generic.List[string]
+
+foreach ($file in $allFiles) {
+    if ($knowledgeFiles -contains ($file -replace "\\", "/")) {
+        Add-Unique $changedKnowledge $file
+    }
+
+    $target = ConvertTo-Target $file
+    if ($target) {
+        Add-Unique $targets $target
+    }
+
+    $reason = ConvertTo-Reason $file
+    Add-Unique $signals "$file - $reason"
+}
+
+$recommendation = "No candidate knowledge update detected."
+$hasProcessNotes = Test-Path -LiteralPath $NotesPath
+$processNotes = ""
+if ($hasProcessNotes) {
+    $processNotes = (Get-Content -Raw -LiteralPath $NotesPath).Trim()
+}
+
+if ($hasProcessNotes -and -not [string]::IsNullOrWhiteSpace($processNotes)) {
+    $recommendation = "Process notes found; review them for lessons-learned.md or the relevant AGENTS.md."
+    Add-Unique $targets "lessons-learned.md"
+} elseif ($allFiles.Count -eq 0) {
+    $recommendation = "No git changes or recent commit files were found."
+} elseif ($changedKnowledge.Count -gt 0) {
+    $recommendation = "Knowledge files changed; validate structure and avoid duplicate facts."
+} elseif ($targets.Count -gt 0) {
+    $recommendation = "Review whether these changes introduced reusable project-specific knowledge."
+}
+
+$timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss zzz"
+$reportDir = Split-Path -Parent $OutputPath
+if (-not (Test-Path -LiteralPath $reportDir)) {
+    New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+}
+
+$decisionStatus = "none"
+if ($recommendation -ne "No git changes or recent commit files were found." -and $recommendation -ne "No candidate knowledge update detected.") {
+    $decisionStatus = "pending"
+    $decisionObject = [ordered]@{
+        status = "pending"
+        createdAt = $timestamp
+        target = @($targets)
+        recommendation = $recommendation
+        reportPath = $OutputPath
+    }
+    $decisionObject | ConvertTo-Json | Set-Content -LiteralPath $DecisionPath -Encoding UTF8
+}
+
+$lines = New-Object System.Collections.Generic.List[string]
+$lines.Add("# Knowledge Candidate Report") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add("- Generated: $timestamp") | Out-Null
+$lines.Add("- Scope: working tree, index, and HEAD commit") | Out-Null
+$lines.Add("- Mode: report only; no knowledge files were edited") | Out-Null
+$lines.Add("- Decision: $decisionStatus") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add("## Recommendation") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add($recommendation) | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add("## Suggested Targets") | Out-Null
+$lines.Add("") | Out-Null
+if ($targets.Count -eq 0) {
+    $lines.Add("- none") | Out-Null
+} else {
+    foreach ($target in $targets) {
+        $lines.Add("- $target") | Out-Null
+    }
+}
+$lines.Add("") | Out-Null
+$lines.Add("## Signals") | Out-Null
+$lines.Add("") | Out-Null
+if ($signals.Count -eq 0) {
+    $lines.Add("- none") | Out-Null
+} else {
+    foreach ($signal in $signals) {
+        $lines.Add("- $signal") | Out-Null
+    }
+}
+$lines.Add("") | Out-Null
+$lines.Add("## Process Notes") | Out-Null
+$lines.Add("") | Out-Null
+if ([string]::IsNullOrWhiteSpace($processNotes)) {
+    $lines.Add("- none") | Out-Null
+} else {
+    $lines.Add($processNotes) | Out-Null
+}
+$lines.Add("") | Out-Null
+$lines.Add("## Next Step") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add('If the recommendation is actionable, ask the user to accept it unless the current task explicitly authorized knowledge maintenance.') | Out-Null
+$lines.Add('After applying or rejecting it, run `scripts/resolve-knowledge-candidate.ps1 -Status applied|rejected` to clear temporary notes.') | Out-Null
+
+Set-Content -LiteralPath $OutputPath -Value $lines -Encoding UTF8
+
+if ($head) {
+    $stateObject = [ordered]@{
+        lastReportedHead = $head
+        lastReportTime = $timestamp
+    }
+    $stateObject | ConvertTo-Json | Set-Content -LiteralPath $StatePath -Encoding UTF8
+}
+
+Write-Host "Knowledge candidate report written to $(Resolve-Path -LiteralPath $OutputPath)"


### PR DESCRIPTION
# Summary

- add Codex Stop-hook knowledge-base validation
- add candidate report generation from git changes and process notes
- add decision workflow for applying or rejecting candidates
- document the workflow in AGENTS and knowledge-check skill

# Verification

- powershell -NoProfile -ExecutionPolicy Bypass -File scripts\validate-knowledge-base.ps1
