### PR TITLE
[fix] 移除内存清扫卡顿提示

### DIFF
--- a/kubejs/assets/createdelight/lang/zh_cn.json
+++ b/kubejs/assets/createdelight/lang/zh_cn.json
@@ -687,7 +687,6 @@
     "createdelight.tip.high_rank_reward": "高难度下的部分怪物有额外掉落!",
     "createdelight.tip.infinite_crude_oil": "含有原油的区块的原油的储量是无限的。",
     "createdelight.tip.mechanical_crafter_force_crafting": "给动力合成器一个红石脉冲可使其无视空栏位强制合成。",
-    "createdelight.tip.memory_sweep_lag": "内存清扫的卡顿可被解决, 详细内容请参考mcmod页面上该mod的介绍。",
     "createdelight.tip.molten_metal_fluid_interaction": "熔融金属源碰到水会直接生成对应的金属块!",
     "createdelight.tip.money_obtain": "你可以通过与村民交易, 与系统商店交易, 或者悬赏板来获取钱币。",
     "createdelight.tip.more_hammer": "龙钢锤为七级锤, 悚怖钢/末影钢为八级锤。",

--- a/kubejs/assets/createdelight/tips/memory_sweep_lag.json
+++ b/kubejs/assets/createdelight/tips/memory_sweep_lag.json
@@ -1,5 +1,0 @@
-{
-    "tip": {
-        "translate": "createdelight.tip.memory_sweep_lag"
-    }
-}


### PR DESCRIPTION
## Summary
- remove the memory_sweep_lag tip asset so it no longer appears in-game
- remove the now-unused zh_cn translation key

## Validation
- rg found no remaining memory_sweep_lag / createdelight.tip.memory_sweep_lag / 内存清扫 references under kubejs
- parsed kubejs/assets/createdelight/lang/zh_cn.json with ConvertFrom-Json