### PR TITLE
[conf] 关闭新建世界时的 Terralith 欢迎信息

### DIFF
--- a/mods/remove-terralith-intro-message.pw.toml
+++ b/mods/remove-terralith-intro-message.pw.toml
@@ -1,0 +1,13 @@
+name = "Remove Stardust Labs Intro Message"
+filename = "zRemove_SDL_Intro_v1.2.2.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/sk4iFZGy/versions/BHr8OLOk/zRemove_SDL_Intro_v1.2.2.jar"
+hash-format = "sha512"
+hash = "2a5b1f3a074d567c6134b918cd711ad64015cf3db0c1dfaf083f66af56004ae2ecda80e63593e1c20dae99f7237b718efde851e1e85f6e1ba604ba87469f60ff"
+
+[update]
+[update.modrinth]
+mod-id = "sk4iFZGy"
+version = "BHr8OLOk"


### PR DESCRIPTION
## Summary
- add Remove Stardust Labs Intro Message metadata from Modrinth
- use the Forge-compatible v1.2.2 jar to suppress Stardust Labs/Terralith first-load chat intro
- leave generated pack.toml/index.toml out of the PR per current modpack metadata rules

## Verification
- generated temporary packwiz files from modpack.toml
- ran packwiz refresh in the temporary output directory