### PR TITLE
[mod] 升级 Advanced Loot Info 尝试解决卡顿问题

### DIFF
--- a/mods/advanced-loot-info.pw.toml
+++ b/mods/advanced-loot-info.pw.toml
@@ -1,13 +1,13 @@
 name = "Advanced Loot Info"
-filename = "AdvancedLootInfo-forge-1.20.1-1.9.0.jar"
+filename = "AdvancedLootInfo-forge-1.20.1-1.12.0.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "b69a1e7225a7db47da7c6951ff7cad1acb9b1836"
+hash = "bbf7742a49e6cbe90c5d805538ec46ce223e6e0b"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7927613
+file-id = 8168726
 project-id = 1205426


### PR DESCRIPTION
## Summary
- Update Advanced Loot Info from 1.20.1-1.9.0 to 1.20.1-1.12.0
- Use CurseForge file id 8168726 and matching SHA1 metadata

## Validation
- Ran packwiz refresh
