### PR TITLE
[fix] 修复打包action包含文件错误的问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,12 +163,6 @@ jobs:
           ./packwiz refresh
       - name: 下载所有服务端文件本体（packwiz-installer）
         run: bash .github/workflows/scripts/download_mods.sh 8080 server
-      - name: 删除与服务端无关的文件
-        run: |
-            rm -rf resourcepacks shaderpacks packwiz-files
-            rm -f ModList0.4a.md README.md TODOlist.md KubeJSStyleGuide.md DevGuide.md client_jvm_args.example.txt
-            find mods -name "*.pw.toml" -exec rm {} +
-            rm -f modpack.toml pack.toml index.toml .packwizignore packwiz
       - name: 更新整合包配置与版本信息
         uses: ./.github/actions/update-modpack-config
         with:
@@ -185,6 +179,14 @@ jobs:
         run: |
           pip install requests
           python .github/workflows/scripts/update_credits.py --mode real
+      - name: 删除服务端产物无关文件
+        run: |
+            rm -rf resourcepacks shaderpacks packwiz-files .agents .codex .github docs scripts
+            rm -f ModList0.4a.md README.md TODOlist.md KubeJSStyleGuide.md DevGuide.md \
+                  client_jvm_args.example.txt AGENTS.md lessons-learned.md .gitignore \
+                  sync-packwiz-assets.bat update-packwiz-meta.bat
+            find mods -name "*.pw.toml" -exec rm {} +
+            rm -f modpack.toml pack.toml index.toml .packwizignore packwiz
       - name: 【版本】服务端启动bat脚本改为CRLF & 替换版本号
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,8 @@ jobs:
                   client_jvm_args.example.txt AGENTS.md lessons-learned.md .gitignore \
                   sync-packwiz-assets.bat update-packwiz-meta.bat
             find mods -name "*.pw.toml" -exec rm {} +
-            rm -f modpack.toml pack.toml index.toml .packwizignore packwiz
+            rm -f modpack.toml pack.toml index.toml .packwizignore packwiz \
+                  packwiz.json packwiz-installer.jar
       - name: 【版本】服务端启动bat脚本改为CRLF & 替换版本号
         run: |
           set -euo pipefail

--- a/.packwizignore
+++ b/.packwizignore
@@ -40,6 +40,12 @@
 !/shaderpacks/**
 
 # ═══ 模组附属数据 ═══
+!/hotai
+!/hotai/**
+!/ldlib
+!/ldlib/**
+!/minemenu
+!/minemenu/**
 !/schematics
 !/schematics/**
 !/tacz

--- a/.packwizignore
+++ b/.packwizignore
@@ -53,10 +53,3 @@
 !/PCL
 !/PCL/**
 
-# ═══ 开发/文档 ═══
-!.github
-!.github/**
-!.vscode
-!.vscode/**
-!/docs
-!/docs/**

--- a/mods/extraholopage.pw.toml
+++ b/mods/extraholopage.pw.toml
@@ -1,6 +1,6 @@
 name = "ExtraHoloPage"
 filename = "ExtraHoloPage-6.9.0-1.2.13.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/tetra-view.pw.toml
+++ b/mods/tetra-view.pw.toml
@@ -1,6 +1,6 @@
 name = "Tetra View"
 filename = "Tetra View-6.9.0-1.0.2.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"


### PR DESCRIPTION
## Summary
- allow `hotai/`, `ldlib/`, and `minemenu/` through `.packwizignore`
- keep support folders such as `.agents/`, `.codex/`, `packwiz-files/`, and `scripts/` ignored

## Verification
- Used a temporary git repo with `.packwizignore` copied to `.gitignore`, then ran `git check-ignore --no-index` against representative paths.
- Results: `hotai/data.json`, `ldlib/data.json`, and `minemenu/menu.json` were `NOT_IGNORED`; `.agents/SKILL.md`, `.codex/config.toml`, `packwiz-files/mods/example.jar`, and `scripts/update-packwiz-meta.ps1` were `IGNORED`.