### PR TITLE
[dev] add CDC submodule and release exclusions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: false
       - name: 安装 Packwiz
         uses: ./.github/actions/setup-packwiz
       - name: 重命名HMCL配置和options
@@ -155,6 +156,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: false
       - name: 安装 Packwiz
         uses: ./.github/actions/setup-packwiz
       - name: 更新文件索引
@@ -181,9 +183,9 @@ jobs:
           python .github/workflows/scripts/update_credits.py --mode real
       - name: 删除服务端产物无关文件
         run: |
-            rm -rf resourcepacks shaderpacks packwiz-files .agents .codex .github docs scripts
+            rm -rf resourcepacks shaderpacks packwiz-files CDC-mod-src .agents .codex .github docs scripts
             rm -f ModList0.4a.md README.md TODOlist.md KubeJSStyleGuide.md DevGuide.md \
-                  client_jvm_args.example.txt AGENTS.md lessons-learned.md .gitignore \
+                  client_jvm_args.example.txt AGENTS.md lessons-learned.md .gitignore .gitmodules \
                   sync-packwiz-assets.bat update-packwiz-meta.bat
             find mods -name "*.pw.toml" -exec rm {} +
             rm -f modpack.toml pack.toml index.toml .packwizignore packwiz \
@@ -229,6 +231,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          submodules: false
       - name: 安装 Packwiz
         uses: ./.github/actions/setup-packwiz
       - name: 获取最近的tag并配置环境变量
@@ -256,7 +259,9 @@ jobs:
           python3 scripts/packwiz-side.py delete-payloads --metadata-base . --payload-base patch --side client --verbose
           rm -f patch/ModList0.4a.md patch/README.md patch/TODOlist.md \
                 patch/KubeJSStyleGuide.md patch/DevGuide.md patch/modpack.toml \
-                patch/pack.toml patch/index.toml patch/client_jvm_args.example.txt
+                patch/pack.toml patch/index.toml patch/client_jvm_args.example.txt \
+                patch/.gitmodules
+          rm -rf patch/CDC-mod-src
           # 将 patch/packwiz-files/ 中的文件移到标准目录
           if [ -d "patch/packwiz-files/mods" ]; then
             mv patch/packwiz-files/mods/*.jar patch/mods/ 2>/dev/null || true

--- a/.github/workflows/scripts/prepare_patch_diff.sh
+++ b/.github/workflows/scripts/prepare_patch_diff.sh
@@ -7,7 +7,23 @@ set -euo pipefail
 
 LATEST_TAG="${1:?Usage: prepare_patch_diff.sh <latest_tag>}"
 
-git diff --name-status "$LATEST_TAG" HEAD > diff_report.txt
+git diff --name-status "$LATEST_TAG" HEAD > diff_report.raw.txt
+awk -F '\t' '
+  function excluded(path) {
+    return path == ".gitmodules" || path == "CDC-mod-src" || path ~ /^CDC-mod-src\//
+  }
+  /^R/ {
+    if (!excluded($2) && !excluded($3)) print
+    next
+  }
+  /^C/ {
+    if (!excluded($3)) print
+    next
+  }
+  {
+    if (!excluded($2)) print
+  }
+' diff_report.raw.txt > diff_report.txt
 cat diff_report.txt
 
 # Parse diff report into added/deleted file lists

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Root files we intentionally version.
 !/.gitignore
+!/.gitmodules
 !/.hmclversion.cfg
 !/.options.txt
 !/.packwizignore
@@ -27,6 +28,7 @@
 !/.github/
 !/PCL/
 !/config/
+!/CDC-mod-src/
 !/defaultconfigs/
 !/docs/
 !/hotai/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "CDC-mod-src"]
+	path = CDC-mod-src
+	url = https://github.com/Jasons-impart/Create-Delight-Core

--- a/.packwizignore
+++ b/.packwizignore
@@ -5,6 +5,10 @@
 # 先忽略一切
 *
 
+# ═══ 开发源码（不进入发行包） ═══
+/CDC-mod-src
+/CDC-mod-src/**
+
 # ═══ 整合包核心文件 ═══
 !/pack.toml
 !/index.toml

--- a/.packwizignore
+++ b/.packwizignore
@@ -5,10 +5,6 @@
 # 先忽略一切
 *
 
-# ═══ 开发源码（不进入发行包） ═══
-/CDC-mod-src
-/CDC-mod-src/**
-
 # ═══ 整合包核心文件 ═══
 !/pack.toml
 !/index.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Create-Delight Remake (齿轮盛宴) - A deep-modded Minecraft 1.20.1 Forge modp
 ```
 CD-master-dev/
 ├── kubejs/           # KubeJS scripts - MAIN DEV AREA (see kubejs/AGENTS.md)
-├── CDC-mod-src/      # Custom Java mod (see CDC-mod-src/AGENTS.md)
+├── CDC-mod-src/      # Create Delight Core git submodule (Java mod source; not packaged)
 ├── config/           # 50+ mod configs
 ├── defaultconfigs/   # First-run defaults copied to config/
 ├── tacz/             # TACZ gun data: armorer packs & gun config
@@ -38,7 +38,7 @@ CD-master-dev/
 | Custom loot/functions | `kubejs/data/` | Datapack overlay |
 | Mod configs | `config/{mod-name}.toml` | 50+ files |
 | FTB Quests | `config/ftbquests/quests/` | .snbt format |
-| Java mod dev | `CDC-mod-src/src/main/java/` | Forge mod project |
+| Java mod dev | `CDC-mod-src/src/main/java/` | Git submodule; commit source changes in Create-Delight-Core |
 | Version info | `modpack.toml` | ONLY source - don't duplicate |
 | Release workflow | `.github/workflows/release.yml` | Use `/release` skill |
 | Historical pitfalls | `lessons-learned.md` | Do not duplicate in AGENTS |
@@ -76,6 +76,8 @@ CD-master-dev/
 - To add/update/remove mods: use `scripts/update-packwiz-meta.ps1` (NOT manual JAR placement)
 - To sync all mod JARs locally for development: use `scripts/sync-packwiz-assets.ps1`
 - `pack.toml`/`index.toml` are generated from `modpack.toml`; don't commit them
+- `CDC-mod-src/` is a git submodule and must stay out of Packwiz artifacts because packages ship pack files, not Java source trees
+- Keep `CDC-mod-src/` code version aligned with the shipped Create Delight Core jar in `mods/create-delight-core.pw.toml` to prevent source/debug drift from the shipped mod
 
 ## ANTI-PATTERNS
 
@@ -105,7 +107,7 @@ packwiz curseforge export
 
 # CDC mod build
 cd CDC-mod-src && ./gradlew build --no-daemon
-# Output: build/libs/CDC-mod-src-*.jar (use non-all version)
+# Output: build/libs/*.jar (use the non-all/non-sources jar)
 ```
 
 ## KNOWLEDGE BASE MAINTENANCE


### PR DESCRIPTION
## Summary
- add Create-Delight-Core as CDC-mod-src git submodule
- exclude CDC source submodule from Packwiz, server artifacts, and patch artifacts
- document CDC submodule handling and version alignment with mods/create-delight-core.pw.toml

## Dependency
- CDC submodule points to Jasons-impart/Create-Delight-Core#43 commit 8e645a5

## Validation
- scripts/validate-knowledge-base.ps1 passed
- git diff --cached --check passed before commit
- bash -n .github/workflows/scripts/prepare_patch_diff.sh passed
- mods/*.pw.toml vs local jar scan found no basename/case/hash mismatches; one extra unreferenced jar remains: packwiz-files/mods/create_wizardry-1.20.1-0.4.2.jar