### PR TITLE
[fix] 恢复 Lightman 货币拆分配方；[dev] 将lightman相关的顶层变量加载放到统一文件下

### DIFF
--- a/kubejs/server_scripts/Lightmans Currency/economic.js
+++ b/kubejs/server_scripts/Lightmans Currency/economic.js
@@ -1,6 +1,7 @@
 ServerEvents.recipes(e => {
     e.replaceInput({ id: "lightmanscurrency:upgrades/coin_chest_magnet_upgrade_1" }, "minecraft:ender_pearl", "create_sa:copper_magnet")
     e.replaceInput({ id: "lightmanscurrency:upgrades/network_upgrade" }, "minecraft:ender_eye", 'ae2:singularity')
+    global.MoneyUtil.addCoreCoinDownExchangeRecipes(e)
     e.recipes.kubejs.shaped(
         'lightmanscurrency:trading_core',
         [

--- a/kubejs/server_scripts/Quality Food/absorber.js
+++ b/kubejs/server_scripts/Quality Food/absorber.js
@@ -1,5 +1,6 @@
 ItemEvents.rightClicked("createdelight:quality_absorber", e => {
     const {player} = e
+    let MoneyUtil = global.MoneyUtil
     if (player == null || !player.isPlayer())
         return
     let items = player.getCapability(ForgeCapabilities.ITEM_HANDLER).orElse(null)
@@ -15,8 +16,8 @@ ItemEvents.rightClicked("createdelight:quality_absorber", e => {
     })
     if (amount == 0)
         return
-    let money = $CoinValue.fromNumber("main", amount)
-    $MoneyAPI.getApi().GetPlayersMoneyHandler(player).insertMoney(money, false)
+    let money = MoneyUtil.coinValueFromBase(amount)
+    MoneyUtil.insertPlayerMoney(player, money)
     player.tell(Component.of("将物品栏中的所有品质去除物品，并将其转化为了").append(money.getText()))
 
 })

--- a/kubejs/server_scripts/mbd2/sell_bin.js
+++ b/kubejs/server_scripts/mbd2/sell_bin.js
@@ -1,8 +1,6 @@
 
 const $ClientboundSetTitleTextPacket = Java.loadClass("net.minecraft.network.protocol.game.ClientboundSetTitleTextPacket")
 const $ClientboundSetSubtitleTextPacket = Java.loadClass("net.minecraft.network.protocol.game.ClientboundSetSubtitleTextPacket")
-const $CoinValue = Java.loadClass("io.github.lightman314.lightmanscurrency.api.money.value.builtin.CoinValue")
-const $MoneyAPI = Java.loadClass("io.github.lightman314.lightmanscurrency.api.money.MoneyAPI")
 let MoneyUtil = global.MoneyUtil
 
 MBDMachineEvents.onTick("createdelight:sell_bin", e => {
@@ -50,7 +48,7 @@ MBDMachineEvents.onTick("createdelight:sell_bin", e => {
         //     itemSlot.shrink(itemSlot.count)
         // }
     })
-    let coinValue = $CoinValue["fromNumber(java.lang.String,long)"]("main", values)
+    let coinValue = MoneyUtil.coinValueFromBase(values)
     if (!coinValue.empty) {
         if (player != null) {
             if (player instanceof $ServerPlayer) {
@@ -67,7 +65,7 @@ MBDMachineEvents.onTick("createdelight:sell_bin", e => {
             let total = Component.translate("message.createdelight.sell_bin_total", MoneyUtil.convertBaseValueToString(values))
             player.tell(total)
             player.tell(Component.of("§e-----------------------"))
-            $MoneyAPI.getApi().GetPlayersMoneyHandler(player).insertMoney(coinValue, false)
+            MoneyUtil.insertPlayerMoney(player, coinValue)
         } else {
             MoneyUtil.convertBaseValueToItems(values).forEach(coin => {
                 itemSlots.insertItem(coin, false)

--- a/kubejs/startup_scripts/custom/order/system.js
+++ b/kubejs/startup_scripts/custom/order/system.js
@@ -8,7 +8,6 @@ const $BrassDroneEntity = Java.loadClass("net.mcreator.createstuffadditions.enti
 const $QualityUtils = Java.loadClass("de.cadentem.quality_food.util.QualityUtils")
 const $QualityConfig = Java.loadClass("de.cadentem.quality_food.config.QualityConfig")
 const $FoodList = Java.loadClass("com.tarinoita.solsweetpotato.tracking.FoodList")
-const $CoinValue = Java.loadClass("io.github.lightman314.lightmanscurrency.api.money.value.builtin.CoinValue")
 const $TraderAPI = Java.loadClass("io.github.lightman314.lightmanscurrency.api.traders.TraderAPI")
 //订单系统
 //玩家通过某种方式获取到订单。订单通常包括多组方便量产的物品，完成订单后玩家会获取一定的报酬
@@ -321,8 +320,8 @@ Order.getRewardContract = function (type, count) {
 Order.addOrderToAuction = function() {
     let data = new $AuctionTradeData({})
     data.auctionItems.add(Item.of("createdelight:unopened_order"))
-    data.setMinBidDifferent($CoinValue.fromItemOrValue("createdeco:copper_coin", 1))
-    data.setStartingBid($CoinValue.fromItemOrValue("createdelightcore:gold_coin", 1).multiplyValue(Utils.random.nextFloat(0.5, 2)))
+    data.setMinBidDifferent(global.MoneyUtil.coinValueFromItemOrValue("createdeco:copper_coin", 1))
+    data.setStartingBid(global.MoneyUtil.coinValueFromItemOrValue("createdelightcore:gold_coin", 1).multiplyValue(Utils.random.nextFloat(0.5, 2)))
     data.setDuration(1000 * 60 * 60 * 1)
     $TraderAPI.getApi().GetTrader(false, 0).addTrade(data, null, false)
 }

--- a/kubejs/startup_scripts/utils/lightmans_currency_api.js
+++ b/kubejs/startup_scripts/utils/lightmans_currency_api.js
@@ -1,0 +1,9 @@
+// priority: 1100
+
+global.CDLightmansCurrencyApi = {
+    CoinValue: Java.loadClass("io.github.lightman314.lightmanscurrency.api.money.value.builtin.CoinValue"),
+    MoneyAPI: Java.loadClass("io.github.lightman314.lightmanscurrency.api.money.MoneyAPI"),
+    CoinAPI: Java.loadClass("io.github.lightman314.lightmanscurrency.api.money.coins.CoinAPI"),
+    ForgeRegistries: Java.loadClass("net.minecraftforge.registries.ForgeRegistries"),
+    CDConfig: Java.loadClass("io.github.jasonsimpart.createdelightcore.CDConfig")
+}

--- a/kubejs/startup_scripts/utils/money.js
+++ b/kubejs/startup_scripts/utils/money.js
@@ -1,9 +1,50 @@
-const $MoneyAPI = Java.loadClass("io.github.lightman314.lightmanscurrency.api.money.MoneyAPI")
-const $CoinAPI = Java.loadClass("io.github.lightman314.lightmanscurrency.api.money.coins.CoinAPI")
-const $ChainData = Java.loadClass("io.github.lightman314.lightmanscurrency.api.money.coins.data.ChainData")
-// QualityUtils、QualityConfig、CoinValue 已在system.js里引用
+// priority: 1050
 
+let LightmansCurrencyApi = global.CDLightmansCurrencyApi
 let MoneyUtil = {}
+
+MoneyUtil.getMoneyChain = function () {
+    return LightmansCurrencyApi.CDConfig.moneyChain
+}
+
+MoneyUtil.coinValueFromBase = function (value) {
+    return LightmansCurrencyApi.CoinValue["fromNumber(java.lang.String,long)"](MoneyUtil.getMoneyChain(), value)
+}
+
+MoneyUtil.coinValueFromItemOrValue = function (item, value) {
+    return LightmansCurrencyApi.CoinValue.fromItemOrValue(Item.of(item).item, value)
+}
+
+MoneyUtil.insertPlayerMoney = function (player, moneyValue) {
+    LightmansCurrencyApi.MoneyAPI.getApi().GetPlayersMoneyHandler(player).insertMoney(moneyValue, false)
+}
+
+MoneyUtil.getItemId = function (item) {
+    return LightmansCurrencyApi.ForgeRegistries.ITEMS.getKey(item).toString()
+}
+
+MoneyUtil.getCoinName = function (item) {
+    return LightmansCurrencyApi.ForgeRegistries.ITEMS.getKey(item).getPath().replace("_coin", "")
+}
+
+MoneyUtil.addCoreCoinDownExchangeRecipes = function (e) {
+    let chain = LightmansCurrencyApi.CoinAPI.getApi().ChainData(MoneyUtil.getMoneyChain())
+    if (chain == null) return
+
+    chain.getCoreChain().forEach(entry => {
+        let lowerExchange = entry.getLowerExchange()
+        if (lowerExchange == null) return
+
+        let input = entry.getCoin()
+        let output = lowerExchange.getFirst().getCoin()
+        let count = Number(lowerExchange.getSecond())
+
+        e.recipes.minecraft.crafting_shapeless(
+            Item.of(MoneyUtil.getItemId(output), count),
+            [MoneyUtil.getItemId(input)]
+        ).id(`createdelight:${MoneyUtil.getCoinName(input)}_2_${MoneyUtil.getCoinName(output)}`)
+    })
+}
 
 /**
  * 将数字的值转化为含有货币的列表
@@ -12,7 +53,7 @@ let MoneyUtil = {}
  */
 MoneyUtil.convertBaseValueToItems = function (value) {
     /** @type {Internal.CoinValue} */
-    let coinValue = $CoinValue.fromNumber("main", value)
+    let coinValue = MoneyUtil.coinValueFromBase(value)
     if (coinValue.getAsItemList)
         return coinValue.getAsItemList()
     return ["minecraft:air"]


### PR DESCRIPTION
## Summary
- 新增最早加载的 Lightman Currency API prelude，集中 `CoinValue` / `MoneyAPI` / `CoinAPI` / `ForgeRegistries` / `CDConfig` 顶层引用。
- 将订单、出货箱、品质吸收器等业务脚本改为通过 `global.MoneyUtil` 使用货币 API。
- 从当前 Lightman 核心货币链自动生成相邻币种向下拆分配方，避免写死兑换比例和币种 ID。

## Test Plan
- `node --check` for changed KubeJS scripts.
- `git diff --check` for changed KubeJS scripts.
- `scripts\validate-knowledge-base.ps1`.
- 重启游戏后确认：
  - `Create-Delight-Core-1.20.1-dev.jar` 被发现并加载。
  - `CDConfig` 在 `utils/lightmans_currency_api.js` 中加载成功。
  - `startup_scripts` 为 `97/97`，`0 errors and 0 warnings`。
  - `server_scripts` 为 `326/326`，`0 errors and 0 warnings`。
  - recipe event 为 `0 failed recipes`。
  - 不再出现 `createdelightcore:*_coin` missing item 或 `CDConfig` class load error。

Closes #1738