### PR TITLE
[fix][dev] 把probejs的配置文件加入跟踪，保证打包时修改有效

### DIFF
--- a/kubejs/.gitignore
+++ b/kubejs/.gitignore
@@ -7,5 +7,4 @@
 !/server_scripts
 !/startup_scripts
 !/README.txt
-/config/probejs.json
 /*/jsconfig.json

--- a/kubejs/config/probejs.json
+++ b/kubejs/config/probejs.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "Is ProbeJS Loaded for First Time in the Modpack - Configured by ProbeJS Itself": false,
+  "The Timestamp of ProbeJS Remote Documents - Configured by ProbeJS Itself": 1720270423220,
+  "Disable Aggressive Mode for ProbeJS Dumps": true,
+  "Allow ProbeJS to Resolve Classes from Registries Like Item Classes or Block Classes": true,
+  "Allow ProbeJS to Generate Literal Types for Item/Block/etc. IDs": true,
+  "Should ProbeJS Only Show Command in Single Player and with Cheat Enabled": true,
+  "Should ProbeJS be Generally Enabled": true,
+  "Disable the Recipe JSON Snippet Generation for ProbeJS triggered by `#`": true,
+  "Should ProbeJS Generate Intermediate JSON Representation of Documents - Mostly for Debugging": false,
+  "Should ProbeJS Download Schema Scripts from Github for Mods without Addon Supports": false,
+  "Should ProbeJS Open the Websocket for VSCode Evaluation? 1 - enabled, others - disabled.": 0,
+  "Which port should ProbeJS listen on for VSCode Extension?": 7796
+}

--- a/lessons-learned.md
+++ b/lessons-learned.md
@@ -176,3 +176,10 @@ gh pr create --body '... `ad_astra:xxx` ...'
 
 - **Problem**: FTB Chunks login force-loading can deadlock when Lightman's Currency probes a Functional Storage controller extension and `getCapability()` resolves the controller through `Level#getBlockEntity`, which may enter `ServerChunkCache#getChunkBlocking`.
 - **Fix/Lesson**: CDC mixins should keep player/UI paths unchanged but redirect Functional Storage controller extension `getCapability()` to read only `ServerChunkCache#getChunkNow` + `LevelChunk.EntityCreationType.CHECK`, extending the same helper to `getStorage()`/`getOptional()` only if future stacks move there.
+
+## Release config edits need tracked source files
+
+**Date**: 2026-06-07
+
+- **Problem**: `update-modpack-config` can edit ignored KubeJS config files during release, but patch generation diffs only tracked `HEAD` paths and can miss generated-only files.
+- **Fix/Lesson**: Release-mutated config files such as `kubejs/config/probejs.json` must be committed as source files before workflows copy them into client/server/patch artifacts.


### PR DESCRIPTION
## Summary
- track `kubejs/config/probejs.json` so release config updates are included in packaged artifacts
- stop ignoring the ProbeJS config under `kubejs/config`
- document the release packaging pitfall in `lessons-learned.md`

## Validation
- parsed `kubejs/config/probejs.json` with PowerShell JSON parser
- parsed release workflow YAML files with PyYAML
- ran `git diff --check`