### PR TITLE
[conf] 关闭节气 DH FullData 渲染转换 mixin

### DIFF
--- a/config/eclipticseasons-mixins.toml
+++ b/config/eclipticseasons-mixins.toml
@@ -1,0 +1,131 @@
+
+[common]
+
+	[common.biome]
+		MixinBiome = true
+
+	[common.block]
+		MixinBeehiveBlockEntity = true
+		MixinBlockState = true
+		MixinBlockStateBase = true
+		MixinFireBlock = true
+		MixinIBlockExtension = true
+		MixinLayeredCauldronBlock = true
+		MixinLightningRodBlock = true
+		MixinFallingBlock = true
+
+	[common.chunk]
+		MixinChunkAccess = true
+		MixinImposterProtoChunk = true
+		MixinLevelChunk = true
+
+	[common.command]
+		MixinWeatherCommand = true
+
+	[common.entity]
+		MixinEntity = true
+		MixinLivingEntity = true
+
+		[common.entity.animal]
+
+			[common.entity.animal.bee]
+				MixinBee = true
+				MixinBee_BeePollinateGoal = true
+
+			[common.entity.animal.fox]
+				MixinFox = true
+				MixinFox_SeekShelterGoal = true
+
+			[common.entity.animal.pandas]
+				MixinPanda = true
+
+		[common.entity.monster]
+			MixinMonster = true
+
+		[common.entity.projectile]
+			MixinThrownTrident = true
+
+	[common.level]
+		MixinDimensionType = true
+		MixinHeightmap_Types = true
+		MixinLevel = true
+		MixinLevelReader = true
+		MixinLevelTimeAccess = true
+		MixinServerLevel = true
+
+	[common.loot]
+		MixinWeatherCheck = true
+
+	[common.wg]
+		MixinSurfaceSystem = true
+
+	[common.item]
+		MixinMapItem = true
+
+[data]
+	MixinsRegistriesDatapackGenerator = true
+	RegistrySetBuilderMixin = true
+
+[game]
+	MixinBee_BeePollinateGoal = true
+	MixinBeehiveBlockEntity = true
+	MixinBreedGoal = true
+	MixinCow = true
+	MixinFishingHook = true
+
+[client]
+	MixinClientClientLevel = true
+	MixinClientLevel = true
+	MixinMinecraftClient = true
+
+	[client.biome]
+		MixinBiomeColors = true
+		MixinClientBiome = true
+
+	[client.block]
+		MixinLeavesBlock = true
+		MixinLightningRodBlock = true
+
+	[client.entity]
+		MixinClientPanda = true
+
+	[client.model]
+		MixinModelBakery = true
+		MixinModelManager = true
+		MixinMultiPart = true
+		MixinSpriteLoader = true
+
+	[client.render]
+		MixinGameRenderer = true
+		MixinLevelRender = true
+
+		[client.render.chunk]
+			MixinBlockRenderVanilla = true
+			MixinChunkRenderDispatcher = true
+			MixinChunkSlice = true
+			MixinRenderRegionCache = true
+
+	[client.sound]
+		MixinLocalPlayer = true
+		MixinMusicManager = true
+
+[compat]
+
+	[compat.distanthorizons]
+		MixinClientLevel = true
+		MixinFullDataToRenderDataTransformer = false
+		MixinQuadTree = true
+		MixinTintWithoutLevelOverrider = true
+		MixinAbstractDhTintGetter = true
+
+	[compat.embeddium]
+		MixinBlockOcclusionCache = true
+		MixinBlockRender2 = true
+		MixinBlockRenderTask = true
+		MixinChunkSlice = true
+		MixinClonedChunkSection = true
+
+	[compat.oculus]
+		MixinBiomeUniforms = true
+		MixinIrisForgeHelpers = true
+


### PR DESCRIPTION
## 说明
- 新增 Ecliptic Seasons mixin 配置文件。
- 将 compat.distanthorizons 下的 MixinFullDataToRenderDataTransformer 设置为 false。
- 用于规避该 mixin 导致 Distant Horizons 远处内容无法正常渲染的问题。

## 验证
- 已确认 PR diff 不再包含 DistantHorizonsWinterLOD 改动。
- 未运行完整客户端测试。