### PR TITLE
修复 Boss 触发实体掉钱脚本报错

### DIFF
--- a/kubejs/server_scripts/Lightmans Currency/entity_loot.js
+++ b/kubejs/server_scripts/Lightmans Currency/entity_loot.js
@@ -1,6 +1,16 @@
 const $Mob = Java.loadClass("net.minecraft.world.entity.Mob")
 const $MobSpawnType = Java.loadClass("net.minecraft.world.entity.MobSpawnType")
 let MoneyUtil = global.MoneyUtil
+const DamageFallback = {
+    "minecraft:ender_dragon": 10,
+    "minecraft:wither": 8,
+}
+
+function getAttributeValue(mob, attribute, fallback) {
+    let instance = mob.getAttribute(attribute)
+    return instance == null ? fallback : instance.getValue()
+}
+
 EntityEvents.drops(e => {
     const { entity, source } = e
     let player = source.player
@@ -19,8 +29,9 @@ EntityEvents.drops(e => {
         let baseValue = 1
         let baseHealth = 20
         let baseDmg = 4.5
-        let dmg = mob.getAttribute("generic.attack_damage").getValue()
-        let armor = mob.getAttribute("generic.armor").getValue() / 2 + mob.getAttribute("generic.armor_toughness").getValue()
+        let damageFallback = DamageFallback[String(mob.type)]
+        let dmg = getAttributeValue(mob, "generic.attack_damage", damageFallback == null ? baseDmg : damageFallback)
+        let armor = getAttributeValue(mob, "generic.armor", 0) / 2 + getAttributeValue(mob, "generic.armor_toughness", 0)
         let maxhp = mob.maxHealth
         //血量乘算
         let multipler = Math.sqrt(maxhp / baseHealth)


### PR DESCRIPTION
## 摘要
- 参考 #1782，将 Lightman's Currency 实体掉钱脚本的 Boss 属性兜底修复移植到 main
- 为末影龙和凋灵这类缺少 generic.attack_damage 的 Boss 使用固定伤害值参与收益计算
- 对缺少护甲和护甲韧性属性的实体按 0 处理，避免同类空属性报错

## 验证
- 检查 diff 确认仅修改 kubejs/server_scripts/Lightmans Currency/entity_loot.js
- 未进游戏复测，预期可修复末影龙死亡时 getAttribute(...).getValue() 空值报错