### PR TITLE
补充坚钢无限流体元件

### DIFF
--- a/kubejs/server_scripts/AE2/infinity_cell.js
+++ b/kubejs/server_scripts/AE2/infinity_cell.js
@@ -18,6 +18,7 @@ const Inf_Fluid = [
   "createmetallurgy:molten_brass",
   "createmetallurgy:molten_tungsten",
   "createmetallurgy:molten_steel",
+  "createmetallurgy:molten_obdurium",
   "createmetallurgy:molten_netherite",
   "createmetallurgy:molten_silver",
   "createmetallurgy:molten_tin",

--- a/kubejs/startup_scripts/creative_tab/expatternprovider.js
+++ b/kubejs/startup_scripts/creative_tab/expatternprovider.js
@@ -15,6 +15,7 @@ StartupEvents.modifyCreativeTab("expatternprovider:tab_main", e => {
     "createmetallurgy:molten_brass",
     "createmetallurgy:molten_tungsten",
     "createmetallurgy:molten_steel",
+    "createmetallurgy:molten_obdurium",
     "createmetallurgy:molten_netherite",
     "createmetallurgy:molten_silver",
     "createmetallurgy:molten_tin",


### PR DESCRIPTION
## 概要
- 将熔融坚钢加入 AE 无限流体元件配方列表
- 在 Extended Pattern Provider 创造栏中补充对应的无限流体元件展示

## 验证
- 已由用户进游戏确认生效