### PR TITLE
补充遗漏的 AE 无限熔融流体

### DIFF
--- a/kubejs/server_scripts/AE2/infinity_cell.js
+++ b/kubejs/server_scripts/AE2/infinity_cell.js
@@ -26,6 +26,8 @@ const Inf_Fluid = [
   "createmetallurgy:molten_bronze",
   "createmetallurgy:molten_void_steel",
   "createdelightcore:molten_andesite",
+  "createdelightcore:molten_titanium",
+  "createdelightcore:molten_martian_steel",
   "createdelightcore:molten_scarlet_neodymium",
   "createdelightcore:molten_azure_neodymium",
   "createdelightcore:molten_fire_steel",

--- a/kubejs/startup_scripts/creative_tab/expatternprovider.js
+++ b/kubejs/startup_scripts/creative_tab/expatternprovider.js
@@ -23,6 +23,8 @@ StartupEvents.modifyCreativeTab("expatternprovider:tab_main", e => {
     "createmetallurgy:molten_bronze",
     "createmetallurgy:molten_void_steel",
     "createdelightcore:molten_andesite",
+    "createdelightcore:molten_titanium",
+    "createdelightcore:molten_martian_steel",
     "createdelightcore:molten_scarlet_neodymium",
     "createdelightcore:molten_azure_neodymium",
     "createdelightcore:molten_fire_steel",


### PR DESCRIPTION
## 概要
- 将熔融钛与熔融火星钢加入 AE 无限流体元件配方生成列表
- 将对应无限流体元件加入 Extended Pattern Provider 创造标签页展示列表

## 验证
- 对比 KubeJS 中出现的熔融流体与 AE 无限流体列表，确认钛和火星钢不再遗漏