### PR TITLE
[dev] 补充mod同步知识库约定

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,11 @@ CD-master-dev/
 - To add/update/remove mods/resourcepacks/shaderpacks: use `scripts/update-packwiz-meta.ps1 -Category ...` (NOT manual asset placement)
 - On `main`, remove a mod by deleting `mods/*.pw.toml`, not synced runtime JARs, because JARs are local development payloads.
 - To sync all mod JARs locally for development: use `scripts/sync-packwiz-assets.ps1`
+- After pulling mod metadata or `packwiz-files` changes, run `scripts/sync-packwiz-assets.ps1` before launching because Git hooks are local and runtime JARs are not tracked.
 - `pack.toml`/`index.toml` are generated from `modpack.toml`; don't commit them
 - `CDC-mod-src/` is a git submodule and must stay out of Packwiz artifacts because packages ship pack files, not Java source trees
 - For CDC artifact updates, use matching CF metadata when published; otherwise put the dev JAR in `packwiz-files/mods/`, update `mods/create-delight-core.pw.toml`, and align the `CDC-mod-src/` submodule pointer
+- Unpublished CDC builds must keep the artifact filename `Create-Delight-Core-1.20.1-dev.jar` because versioned dev filenames can leave multiple CDC JARs in synced runtime dirs.
 
 ## ANTI-PATTERNS
 


### PR DESCRIPTION
## 变更
- 在根 AGENTS.md 记录拉取 mod metadata 或 packwiz-files 变更后，启动前需要运行 sync-packwiz-assets.ps1。
- 记录未发布 CDC 构建固定使用 Create-Delight-Core-1.20.1-dev.jar 文件名，避免 runtime 目录中残留多个 CDC JAR。
- 更新 CDC 子模块指针以包含 CDC 版本号约定文档。

## 关联
- CDC 子模块 PR: https://github.com/Jasons-impart/Create-Delight-Core/pull/51

## 验证
- ./scripts/validate-knowledge-base.ps1 通过。
- 存在既有 warning：release workflow guidance appears 4 times; expected <= 3。