### PR TITLE
[conf] 调整线轴序列组装循环次数

### DIFF
--- a/kubejs/server_scripts/Create Addition/recipes.js
+++ b/kubejs/server_scripts/Create Addition/recipes.js
@@ -130,7 +130,7 @@ ServerEvents.recipes(e => {
                 e.recipes.create.sequenced_assembly(spool[0], 'createaddition:spool', [
                     e.recipes.create.deploying("createaddition:spool", ["createaddition:spool", spool[1]])
                 ])
-                .loops(2)
+                .loops(4)
                 .transitionalItem("createaddition:spool")
                 .id(`createdelight:sequenced_assembly/${spool[0].split(':')[1]}`)
             })


### PR DESCRIPTION
## 变更内容
- 将 Create Addition 线轴序列组装配方循环次数从 2 次调整为 4 次
- 涉及 copper_spool、superconducting_spool、gold_spool、electrum_spool

## 验证
- 已检查 diff 仅包含目标配方循环次数变更
- 未运行 packwiz refresh