### PR TITLE
[fix] 调整线轴序列组装循环次数避免利用拆链接器掉落4线刷金属

### DIFF
--- a/kubejs/server_scripts/Create Addition/recipes.js
+++ b/kubejs/server_scripts/Create Addition/recipes.js
@@ -130,7 +130,7 @@ ServerEvents.recipes(e => {
                 e.recipes.create.sequenced_assembly(spool[0], 'createaddition:spool', [
                     e.recipes.create.deploying("createaddition:spool", ["createaddition:spool", spool[1]])
                 ])
-                .loops(2)
+                .loops(4)
                 .transitionalItem("createaddition:spool")
                 .id(`createdelight:sequenced_assembly/${spool[0].split(':')[1]}`)
             })

--- a/lessons-learned.md
+++ b/lessons-learned.md
@@ -214,3 +214,10 @@ gh pr create --body '... `ad_astra:xxx` ...'
 - **Problem**: Vintage Delight 0.1.6 `FermentingJarBlockEntity#consumeIngredient` scans input slots from 0 for every `Ingredient`, so recipes with repeated matching ingredients consume multiple items from the first matching slot.
 - **Fix/Lesson**: CDC patches the jar with a pseudo mixin that tracks consumed input slots during `craftItem`, because the mod is not a compile dependency and repeated ingredients must be distributed across distinct matched slots.
 
+## Create Addition spool recipes must match connector drop economics
+
+**Date**: 2026-06-17
+
+- **Problem**: `createaddition:*_spool` sequenced assembly at `.loops(2)` let players craft a spool with 2 wires, place/break connectors, and recover 4 wires through link drops.
+- **Fix/Lesson**: Keep spool sequenced assembly at `.loops(4)` so wire input matches connector-link recovery and cannot duplicate metals.
+


### PR DESCRIPTION
## 变更
- 将 Create Addition 4 种线轴的序列组装循环次数从 2 调整为 4。
- 补充 lessons 记录，说明线轴配方需要匹配链接器掉落经济性。

## 原因
- 旧配方只消耗 2 根线即可做出线轴，玩家可通过放置/拆除链接器回收 4 根线，形成金属复制漏洞。

## 验证
- `git diff --check`