### PR TITLE
[fix] 移除应用军械师工作台的合成配方

### DIFF
--- a/kubejs/server_scripts/TACZ/recipes.js
+++ b/kubejs/server_scripts/TACZ/recipes.js
@@ -2,7 +2,8 @@ ServerEvents.recipes(e => {
     remove_recipes_id(e, [
         "tacz:gunpowder",
         "tacz:gun_smith_table",
-        "tacz:target"
+        "tacz:target",
+        "applied_armorer:worckbench_applied_armorer"
     ])
     e.recipes.kubejs.shaped(
         'tacz:target',


### PR DESCRIPTION
## 变更
- 在 TACZ 配方移除列表中追加 `applied_armorer:worckbench_applied_armorer`
- 移除 Applied Armorer 枪包新增的 `tacz:workbench_c` 工作台合成来源

## 验证
- 已执行 `git diff --check -- kubejs/server_scripts/TACZ/recipes.js`
- 未运行游戏内 `/kubejs reload server_scripts`