### PR TITLE
fix: 恢复 ME 扩展驱动器配方

### DIFF
--- a/kubejs/server_scripts/AE2/machine.js
+++ b/kubejs/server_scripts/AE2/machine.js
@@ -10,7 +10,6 @@ ServerEvents.recipes((event) => {
     "ae2:network/blocks/io_condenser",
     "ae2:tools/matter_cannon",
     "ae2:network/blocks/spatial_anchor",
-    "expatternprovider:ex_drive",
     "ae2:network/blocks/inscribers",
     "expatternprovider:assembler_matrix_crafter",
     "expatternprovider:assembler_matrix_frame",


### PR DESCRIPTION
## Summary
- 从 AE2 配方删除列表中移除 expatternprovider:ex_drive
- 恢复 ExtendedAE 的 ME 扩展驱动器原始配方

## Testing
- 未运行游戏内验证；改动仅为 KubeJS 配方移除列表的一行删除