### PR TITLE
[fix] 恢复 main 的 ME 扩展驱动器配方

### DIFF
--- a/kubejs/server_scripts/AE2/machine.js
+++ b/kubejs/server_scripts/AE2/machine.js
@@ -10,7 +10,6 @@ ServerEvents.recipes((event) => {
     "ae2:network/blocks/io_condenser",
     "ae2:tools/matter_cannon",
     "ae2:network/blocks/spatial_anchor",
-    "expatternprovider:ex_drive",
     "ae2:network/blocks/inscribers",
     "expatternprovider:assembler_matrix_crafter",
     "expatternprovider:assembler_matrix_frame",

--- a/lessons-learned.md
+++ b/lessons-learned.md
@@ -228,3 +228,10 @@ gh pr create --body '... `ad_astra:xxx` ...'
 - **Problem**: After migrating from Ad Astra to Northstar, FTB Quests and tips still pointed players to old `ad_astra:*` dimensions such as removed Glacio.
 - **Fix/Lesson**: When changing planet systems, search `config/ftbquests` and player-facing lang/tip files for old dimension IDs and planet names so quest gates remain reachable.
 
+## Restored recipes may be blocked by removal lists
+
+**Date**: 2026-06-17
+
+- **Problem**: ExtendedAE's `expatternprovider:ex_drive` recipe existed upstream but was hidden because `kubejs/server_scripts/AE2/machine.js` removed its recipe ID.
+- **Fix/Lesson**: Before adding replacement recipes, search KubeJS `remove_recipes_id` lists for the missing recipe ID so original mod recipes can be restored by removing stale deletes.
+


### PR DESCRIPTION
## 背景
- 参考 #1812 检查 `main` 后，确认仍存在同类问题：`kubejs/server_scripts/AE2/machine.js` 的配方删除列表仍移除了 `expatternprovider:ex_drive`。
- 这会隐藏 ExtendedAE 的 ME 扩展驱动器原始配方。

## 变更内容
- 从 AE2 机器配方脚本的 `remove_recipes_id` 列表中移除 `expatternprovider:ex_drive`。
- 在 `lessons-learned.md` 记录排查缺失配方时需要先检查 KubeJS 删除列表。

## 验证
- `rg -n "expatternprovider:ex_drive" kubejs/server_scripts/AE2 lessons-learned.md -S`
  - 仅剩 `lessons-learned.md` 的经验记录。
- `node --check kubejs/server_scripts/AE2/machine.js`
- `git diff --check`