### PR TITLE
quest: 调整动力合成编码器依赖

### DIFF
--- a/config/ftbquests/quests/chapters/Alloy_Innovation.snbt
+++ b/config/ftbquests/quests/chapters/Alloy_Innovation.snbt
@@ -1670,10 +1670,7 @@
 			y: 2.25d
 		}
 		{
-			dependencies: [
-				"3EB042CCCB8D54FA"
-				"1499DD7E2925CBAA"
-			]
+			dependencies: ["3EB042CCCB8D54FA"]
 			id: "57CA7AEC66490057"
 			subtitle: "更轻松的动力合成自动化！"
 			tasks: [{


### PR DESCRIPTION
Summary: 调整“体系渐成”章节中动力合成编码器任务的依赖，仅保留 3EB042CCCB8D54FA。Testing: 未运行游戏内验证，改动仅限 FTB Quests 任务依赖配置。