### PR TITLE
[quest] 同步调整 main 的动力合成编码器任务依赖

### DIFF
--- a/config/ftbquests/quests/chapters/Alloy_Innovation.snbt
+++ b/config/ftbquests/quests/chapters/Alloy_Innovation.snbt
@@ -1738,10 +1738,7 @@
 			y: 2.5d
 		}
 		{
-			dependencies: [
-				"3EB042CCCB8D54FA"
-				"1499DD7E2925CBAA"
-			]
+			dependencies: ["3EB042CCCB8D54FA"]
 			id: "57CA7AEC66490057"
 			subtitle: "更轻松的动力合成自动化！"
 			tasks: [{

--- a/lessons-learned.md
+++ b/lessons-learned.md
@@ -235,3 +235,10 @@ gh pr create --body '... `ad_astra:xxx` ...'
 - **Problem**: ExtendedAE's `expatternprovider:ex_drive` recipe existed upstream but was hidden because `kubejs/server_scripts/AE2/machine.js` removed its recipe ID.
 - **Fix/Lesson**: Before adding replacement recipes, search KubeJS `remove_recipes_id` lists for the missing recipe ID so original mod recipes can be restored by removing stale deletes.
 
+## Quest dependencies must match actual crafting prerequisites
+
+**Date**: 2026-06-17
+
+- **Problem**: The mechanical craft encoder quest depended on the molecular assembler quest even though the encoder only needs earlier mechanical crafting progression.
+- **Fix/Lesson**: When editing FTB Quest dependencies, compare each dependency ID against the item's real recipe path so optional downstream machines do not gate unrelated tools.
+


### PR DESCRIPTION
## 背景
- 参考 #1814 检查 `main` 后，确认仍存在同类问题：`Alloy_Innovation.snbt` 中动力合成编码器任务仍额外依赖 `1499DD7E2925CBAA`。
- 动力合成编码器只需要更早的动力合成进度，不应被分子装配室链路额外卡住。

## 变更内容
- 将动力合成编码器任务 `57CA7AEC66490057` 的依赖收敛为 `3EB042CCCB8D54FA`。
- 在 `lessons-learned.md` 记录 FTB Quest 依赖需要对照真实配方路径。

## 验证
- `rg -n -F "1499DD7E2925CBAA" config/ftbquests/quests/chapters/Alloy_Innovation.snbt`
  - 无输出，旧依赖已移除。
- `rg -n -C 4 -F "id: \"57CA7AEC66490057\"" config/ftbquests/quests/chapters/Alloy_Innovation.snbt`
  - 目标任务仅依赖 `3EB042CCCB8D54FA`。
- `git diff --check`