### PR TITLE
[fix] 修正机铁之心序列组装可以省略充电步骤

### DIFF
--- a/kubejs/server_scripts/Alex's Cave/magnetic_cave.js
+++ b/kubejs/server_scripts/Alex's Cave/magnetic_cave.js
@@ -122,7 +122,7 @@ ServerEvents.recipes(e => {
         .id("createdelight:heavyweight")
 
     //机铁之心
-    let iner_4 = "alexscaves:heart_of_iron"
+    let iner_4 = "minecraft:iron_block"
     e.recipes.create.sequenced_assembly("alexscaves:heart_of_iron", "minecraft:iron_block",
         [
             e.recipes.vintageimprovements.turning(iner_4, iner_4),


### PR DESCRIPTION
## 内容
- Cherry-pick #1757：修正机铁之心序列组装使用成品作为过渡物品的问题
- 将过渡物品改为输入铁块，避免序列组装逻辑异常

## 来源
- 原 PR：#1757
- 原提交：4ad4297acd5dd9d28101f3a788a1dd6b3fb8953b

## 验证
- 已检查本分支相对 release-v048x 的差异，仅包含 magnetic_cave.js 中 1 行 KubeJS 配方修复