### PR TITLE
[fix] 修复Create Functional Storage材质包没有记为从curseforge下载的问题；发布v0.4.8.13

### DIFF
--- a/docs/announcement.md
+++ b/docs/announcement.md
@@ -1,2 +1,2 @@
-### 最新版本! v0.4.8.12!已推出
-- 修复Create Functional Storage材质包导出位置
+### 最新版本! v0.4.8.13!已推出
+- 改用CurseForge元数据管理Create Functional Storage材质包

--- a/pack.toml
+++ b/pack.toml
@@ -1,6 +1,6 @@
 name = "Create-Delight-Remake"
 author = "JSI"
-version = "v0.4.8.12"
+version = "v0.4.8.13"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/resourcepacks/create-functional-storage.pw.toml
+++ b/resourcepacks/create-functional-storage.pw.toml
@@ -1,8 +1,13 @@
 name = "Create Functional Storage"
-filename = "create-functional-storage-1.20.1-v1.0.0.zip"
+filename = "【1.20.1】§l§n§a§oCreate Functional Storage §c§lv1.0.0.zip"
 side = "both"
 
 [download]
-url = "https://raw.githubusercontent.com/Jasons-impart/Create-Delight-Remake/main/packwiz-files/resourcepacks/create-functional-storage-1.20.1-v1.0.0.zip"
-hash-format = "sha256"
-hash = "34a35b044c0d5408fbbe0f3744b0a3a785f6d01500ac4a14acc7f801f6e3dfe3"
+hash-format = "sha1"
+hash = "c07892fbbc762c373feb68a9addbe3fbcdd8d3b5"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8094407
+project-id = 1543940


### PR DESCRIPTION
## 内容
- 将 Create Functional Storage 材质包从 GitHub raw 下载改为 CurseForge metadata 依赖
- 固定 CurseForge project-id 1543940 / file-id 8094407，对应 v1.0.0 文件

## 验证
- 在临时 pack 中运行 packwiz refresh + packwiz curseforge export
- 导出的 manifest.json 包含 projectID 1543940 / fileID 8094407
- overrides 中不再包含该材质包 zip