### PR TITLE
[fix] 禁止人工钻石升级钻石背包

### DIFF
--- a/kubejs/server_scripts/Sophisticated Backpacks/recipes.js
+++ b/kubejs/server_scripts/Sophisticated Backpacks/recipes.js
@@ -32,3 +32,16 @@ function hexToDecimal(hex) {
   hex = hex.replace(/^#/, "");
   return parseInt(hex, 16);
 }
+
+ServerEvents.recipes((e) => {
+  // 替换配方：钻石背包
+  e.recipes.sophisticatedbackpacks.backpack_upgrade("sophisticatedbackpacks:diamond_backpack", [
+    "DDD",
+    "DBD",
+    "DDD",
+  ], {
+    B: "sophisticatedbackpacks:gold_backpack",
+    D: "minecraft:diamond",
+  })
+    .id("sophisticatedbackpacks:diamond_backpack");
+});

--- a/kubejs/startup_scripts/@recipes/sophisticatedbackpacks.js
+++ b/kubejs/startup_scripts/@recipes/sophisticatedbackpacks.js
@@ -1,0 +1,12 @@
+const sophisticatedBackpacks$$ShapedRecipeSchema = Java.loadClass("dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema")
+const sophisticatedBackpacks$$RegistryInfo = Java.loadClass("dev.latvian.mods.kubejs.registry.RegistryInfo")
+
+StartupEvents.recipeSchemaRegistry(event => {
+    let serializers = sophisticatedBackpacks$$RegistryInfo.RECIPE_SERIALIZER.vanillaRegistry.keySet().map(v => v.toString())
+
+    if (serializers.indexOf("sophisticatedbackpacks:backpack_upgrade") === -1) {
+        return
+    }
+
+    event.register("sophisticatedbackpacks:backpack_upgrade", sophisticatedBackpacks$$ShapedRecipeSchema.SCHEMA)
+})


### PR DESCRIPTION
## 变更内容
- 为精妙背包的 `backpack_upgrade` 注册 KubeJS recipe schema。
- 使用 `sophisticatedbackpacks:backpack_upgrade` 覆盖钻石背包升级配方。
- 将钻石背包升级材料从 `#forge:gems/diamond` 固定为 `minecraft:diamond`，避免人工钻石参与合成。

## 验证
- `node --check kubejs\server_scripts\Sophisticated Backpacks\recipes.js`
- `node --check kubejs\startup_scripts\@recipes\sophisticatedbackpacks.js`

## 注意
- 新增 startup schema，首次生效需要重启游戏。
- 未进行游戏内 JEI/工作台验证。
