### PR TITLE
[fix] 移除钻石背包、保险库使用人工钻石合成的配方

### DIFF
--- a/kubejs/server_scripts/Create Better Storage/recipe.js
+++ b/kubejs/server_scripts/Create Better Storage/recipe.js
@@ -97,7 +97,7 @@ ServerEvents.recipes(e => {
         "ABA"
     ], {
         A: "create_bs:crystal_item_vault",
-        B: "#forge:gems/diamond"
+        B: "minecraft:diamond"
     })
     .id("createdelight:crafting/alt_diamond_item_vault")
     

--- a/kubejs/server_scripts/Functional Storage/recipes.js
+++ b/kubejs/server_scripts/Functional Storage/recipes.js
@@ -42,7 +42,7 @@ ServerEvents.recipes((event) => {
   fs_upgrade(
     "functionalstorage:gold_upgrade",
     "functionalstorage:diamond_upgrade",
-    "#forge:gems/diamond",
+    "minecraft:diamond",
     "#forge:storage_blocks/diamond",
     "#forge:chests/wooden"
   );

--- a/kubejs/server_scripts/Sophisticated Backpacks/recipes.js
+++ b/kubejs/server_scripts/Sophisticated Backpacks/recipes.js
@@ -32,3 +32,15 @@ function hexToDecimal(hex) {
   hex = hex.replace(/^#/, "");
   return parseInt(hex, 16);
 }
+
+ServerEvents.recipes((e) => {
+  e.recipes.sophisticatedbackpacks.backpack_upgrade("sophisticatedbackpacks:diamond_backpack", [
+    "DDD",
+    "DBD",
+    "DDD",
+  ], {
+    B: "sophisticatedbackpacks:gold_backpack",
+    D: "minecraft:diamond",
+  })
+    .id("sophisticatedbackpacks:diamond_backpack");
+});

--- a/kubejs/startup_scripts/@recipes/sophisticatedbackpacks.js
+++ b/kubejs/startup_scripts/@recipes/sophisticatedbackpacks.js
@@ -1,0 +1,12 @@
+const sophisticatedBackpacks$$ShapedRecipeSchema = Java.loadClass("dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema")
+const sophisticatedBackpacks$$RegistryInfo = Java.loadClass("dev.latvian.mods.kubejs.registry.RegistryInfo")
+
+StartupEvents.recipeSchemaRegistry(event => {
+    let serializers = sophisticatedBackpacks$$RegistryInfo.RECIPE_SERIALIZER.vanillaRegistry.keySet().map(v => v.toString())
+
+    if (serializers.indexOf("sophisticatedbackpacks:backpack_upgrade") === -1) {
+        return
+    }
+
+    event.register("sophisticatedbackpacks:backpack_upgrade", sophisticatedBackpacks$$ShapedRecipeSchema.SCHEMA)
+})


### PR DESCRIPTION
## 变更内容
- 参考 #1829，为精妙背包的 `backpack_upgrade` 注册 KubeJS recipe schema，并覆盖钻石背包升级配方。
- 将以下钻石存储升级材料从 `#forge:gems/diamond` 收紧为 `minecraft:diamond`：
  - `sophisticatedbackpacks:diamond_backpack`
  - `functionalstorage:diamond_upgrade`
  - `createdelight:crafting/alt_diamond_item_vault`
- 保留 AE2 工程处理器和高级卡的 `#forge:gems/diamond`，人工钻石仍可用于 AE 相关配方。

## 原因
`createdelight:mmd_diamond` 带有 `forge:gems/diamond` 标签。背包和存储容量升级属于钻石存储 tier，使用 tag 会让人工钻石绕过原版钻石成本；AE 处理器/高级卡不在本次收紧范围。

## 验证
- `node --check kubejs\\server_scripts\\Sophisticated Backpacks\\recipes.js`
- `node --check kubejs\\startup_scripts\\@recipes\\sophisticatedbackpacks.js`
- `node --check kubejs\\server_scripts\\Create Better Storage\\recipe.js`
- `node --check kubejs\\server_scripts\\Functional Storage\\recipes.js`
- `git diff --check`

## 注意
- 新增 startup schema，首次生效需要重启游戏。
- 未进行游戏内 JEI/工作台验证。
