### PR TITLE
[fix] 调整Tetra护甲与难度显示

### DIFF
--- a/kubejs/assets/geotetraarmor/lang/zh_cn.json
+++ b/kubejs/assets/geotetraarmor/lang/zh_cn.json
@@ -1,0 +1,46 @@
+{
+  "tetra/schematic/armor/head/base/vanilla.description": "香草风格的头盔。硬度主要提高护甲，密度少量提高护甲并提高韧性，韧性提高护甲韧性。",
+  "tetra.module.armor/head/base/vanilla.description": "香草风格的头盔，按普通权重从材料硬度、密度和韧性获得护甲与韧性。",
+  "tetra/schematic/armor/head/base/heavy.description": "重型风格的头盔。护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍；每个重型模块降低5%移动速度。",
+  "tetra.module.armor/head/base/heavy.description": "重型风格的头盔，护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍，但移动速度降低5%。",
+
+  "tetra/schematic/armor/chest/base/vanilla.description": "香草风格的胸甲。硬度主要提高护甲，密度少量提高护甲并提高韧性，韧性提高护甲韧性。",
+  "tetra.module.armor/chest/base/vanilla.description": "香草风格的胸甲，按普通权重从材料硬度、密度和韧性获得护甲与韧性。",
+  "tetra/schematic/armor/chest/base/heavy.description": "重型风格的胸甲。护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍；每个重型模块降低5%移动速度。",
+  "tetra.module.armor/chest/base/heavy.description": "重型风格的胸甲，护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍，但移动速度降低5%。",
+
+  "tetra/schematic/armor/chest/left/vanilla.description": "香草风格的肩甲。硬度主要提高护甲，密度少量提高护甲并提高韧性，韧性提高护甲韧性。",
+  "tetra.module.armor/chest/left/vanilla.description": "香草风格的肩甲，按普通权重从材料硬度、密度和韧性获得护甲与韧性。",
+  "tetra/schematic/armor/chest/left/heavy.description": "重型风格的肩甲。护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍；每个重型模块降低5%移动速度。",
+  "tetra.module.armor/chest/left/heavy.description": "重型风格的肩甲，护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍，但移动速度降低5%。",
+
+  "tetra/schematic/armor/chest/right/vanilla.description": "香草风格的肩甲。硬度主要提高护甲，密度少量提高护甲并提高韧性，韧性提高护甲韧性。",
+  "tetra.module.armor/chest/right/vanilla.description": "香草风格的肩甲，按普通权重从材料硬度、密度和韧性获得护甲与韧性。",
+  "tetra/schematic/armor/chest/right/heavy.description": "重型风格的肩甲。护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍；每个重型模块降低5%移动速度。",
+  "tetra.module.armor/chest/right/heavy.description": "重型风格的肩甲，护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍，但移动速度降低5%。",
+
+  "tetra/schematic/armor/legs/belt/vanilla.description": "香草风格的腰带。硬度主要提高护甲，密度少量提高护甲并提高韧性，韧性提高护甲韧性。",
+  "tetra.module.armor/legs/belt/vanilla.description": "香草风格的腰带，按普通权重从材料硬度、密度和韧性获得护甲与韧性。",
+  "tetra/schematic/armor/legs/belt/heavy.description": "重型风格的腰带。护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍；每个重型模块降低5%移动速度。",
+  "tetra.module.armor/legs/belt/heavy.description": "重型风格的腰带，护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍，但移动速度降低5%。",
+
+  "tetra/schematic/armor/legs/left/vanilla.description": "香草风格的腿甲。硬度主要提高护甲，密度少量提高护甲并提高韧性，韧性提高护甲韧性。",
+  "tetra.module.armor/legs/left/vanilla.description": "香草风格的腿甲，按普通权重从材料硬度、密度和韧性获得护甲与韧性。",
+  "tetra/schematic/armor/legs/left/heavy.description": "重型风格的腿甲。护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍；每个重型模块降低5%移动速度。",
+  "tetra.module.armor/legs/left/heavy.description": "重型风格的腿甲，护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍，但移动速度降低5%。",
+
+  "tetra/schematic/armor/legs/right/vanilla.description": "香草风格的腿甲。硬度主要提高护甲，密度少量提高护甲并提高韧性，韧性提高护甲韧性。",
+  "tetra.module.armor/legs/right/vanilla.description": "香草风格的腿甲，按普通权重从材料硬度、密度和韧性获得护甲与韧性。",
+  "tetra/schematic/armor/legs/right/heavy.description": "重型风格的腿甲。护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍；每个重型模块降低5%移动速度。",
+  "tetra.module.armor/legs/right/heavy.description": "重型风格的腿甲，护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍，但移动速度降低5%。",
+
+  "tetra/schematic/armor/feet/left/vanilla.description": "香草风格的鞋子。硬度主要提高护甲，密度少量提高护甲并提高韧性，韧性提高护甲韧性。",
+  "tetra.module.armor/feet/left/vanilla.description": "香草风格的鞋子，按普通权重从材料硬度、密度和韧性获得护甲与韧性。",
+  "tetra/schematic/armor/feet/left/heavy.description": "重型风格的鞋子。护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍；每个重型模块降低5%移动速度。",
+  "tetra.module.armor/feet/left/heavy.description": "重型风格的鞋子，护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍，但移动速度降低5%。",
+
+  "tetra/schematic/armor/feet/right/vanilla.description": "香草风格的鞋子。硬度主要提高护甲，密度少量提高护甲并提高韧性，韧性提高护甲韧性。",
+  "tetra.module.armor/feet/right/vanilla.description": "香草风格的鞋子，按普通权重从材料硬度、密度和韧性获得护甲与韧性。",
+  "tetra/schematic/armor/feet/right/heavy.description": "重型风格的鞋子。护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍；每个重型模块降低5%移动速度。",
+  "tetra.module.armor/feet/right/heavy.description": "重型风格的鞋子，护甲收益约为香草的1.2倍，韧性收益约为香草的1.5倍，但移动速度降低5%。"
+}

--- a/kubejs/client_scripts/render/render_difficulty_gui.js
+++ b/kubejs/client_scripts/render/render_difficulty_gui.js
@@ -7,7 +7,16 @@ let Difficulty = {}
  */
 Difficulty.getPlayerRawValue = function () {
     let value = global.difficultyCache
-    return typeof value == "number" ? value : 0
+    if (value == null)
+        return 0
+    if (typeof value == "number")
+        return value
+    if (value.getAsInt != null)
+        return value.getAsInt()
+    if (value.intValue != null)
+        return value.intValue()
+    value = Number(value)
+    return isNaN(value) ? 0 : value
 }
 
 Difficulty.getPlayerTier = function () {

--- a/kubejs/data/tetra/modules/armor/chest/base/heavy.json
+++ b/kubejs/data/tetra/modules/armor/chest/base/heavy.json
@@ -1,0 +1,71 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "chest/base"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "key": "heavy_chest_base/",
+      "aspects": {
+        "armor": 2,
+        "armor_chest": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_chest"
+      ],
+      "attributes": {
+        "**minecraft:generic.movement_speed": -0.05
+      },
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.605042
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.151261,
+          "minecraft:generic.armor_toughness": 0.141509
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.070755
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 48,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "base"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/heavy/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/chest/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/chest/base/vanilla.json
+++ b/kubejs/data/tetra/modules/armor/chest/base/vanilla.json
@@ -1,0 +1,72 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "chest/base"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "key": "vanilla_chest_base/",
+      "aspects": {
+        "armor": 2,
+        "armor_chest": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_chest"
+      ],
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.504202
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.12605,
+          "minecraft:generic.armor_toughness": 0.09434
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.04717
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 48,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "base"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/vanilla/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/chest/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/chest/left/heavy.json
+++ b/kubejs/data/tetra/modules/armor/chest/left/heavy.json
@@ -1,0 +1,71 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "chest/left"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "key": "heavy_chest_left/",
+      "aspects": {
+        "armor": 2,
+        "armor_chest": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_chest"
+      ],
+      "attributes": {
+        "**minecraft:generic.movement_speed": -0.05
+      },
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.302521
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.07563,
+          "minecraft:generic.armor_toughness": 0.070755
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.035377
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 0,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "left"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/heavy/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/chest/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/chest/left/vanilla.json
+++ b/kubejs/data/tetra/modules/armor/chest/left/vanilla.json
@@ -1,0 +1,71 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "chest/left"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "key": "vanilla_chest_left/",
+      "aspects": {
+        "armor": 2,
+        "armor_chest": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_chest"
+      ],
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.252101
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.063025,
+          "minecraft:generic.armor_toughness": 0.04717
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.023585
+        },
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 0,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "left"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/vanilla/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/chest/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/chest/right/heavy.json
+++ b/kubejs/data/tetra/modules/armor/chest/right/heavy.json
@@ -1,0 +1,71 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "chest/right"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "key": "heavy_chest_right/",
+      "aspects": {
+        "armor": 2,
+        "armor_chest": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_chest"
+      ],
+      "attributes": {
+        "**minecraft:generic.movement_speed": -0.05
+      },
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.302521
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.07563,
+          "minecraft:generic.armor_toughness": 0.070755
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.035377
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 16,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "right"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/heavy/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/chest/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/chest/right/vanilla.json
+++ b/kubejs/data/tetra/modules/armor/chest/right/vanilla.json
@@ -1,0 +1,72 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "chest/right"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "key": "vanilla_chest_right/",
+      "aspects": {
+        "armor": 2,
+        "armor_chest": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_chest"
+      ],
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.252101
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.063025,
+          "minecraft:generic.armor_toughness": 0.04717
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.023585
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 16,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "right"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/vanilla/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/chest/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/feet/left/heavy.json
+++ b/kubejs/data/tetra/modules/armor/feet/left/heavy.json
@@ -1,0 +1,71 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "feet/left"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "key": "heavy_feet_left/",
+      "aspects": {
+        "armor": 2,
+        "armor_feet": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_feet"
+      ],
+      "attributes": {
+        "**minecraft:generic.movement_speed": -0.05
+      },
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.201681
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.05042,
+          "minecraft:generic.armor_toughness": 0.141509
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.070755
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 192,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "left"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/heavy/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/feet/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/feet/left/vanilla.json
+++ b/kubejs/data/tetra/modules/armor/feet/left/vanilla.json
@@ -1,0 +1,72 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "feet/left"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "key": "vanilla_feet_left/",
+      "aspects": {
+        "armor": 2,
+        "armor_feet": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_feet"
+      ],
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.168067
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.042017,
+          "minecraft:generic.armor_toughness": 0.09434
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.04717
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 192,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "left"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/vanilla/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/feet/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/feet/right/heavy.json
+++ b/kubejs/data/tetra/modules/armor/feet/right/heavy.json
@@ -1,0 +1,71 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "feet/right"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "key": "heavy_feet_right/",
+      "aspects": {
+        "armor": 2,
+        "armor_feet": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_feet"
+      ],
+      "attributes": {
+        "**minecraft:generic.movement_speed": -0.05
+      },
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.201681
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.05042,
+          "minecraft:generic.armor_toughness": 0.141509
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.070755
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 208,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "right"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/heavy/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/feet/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/feet/right/vanilla.json
+++ b/kubejs/data/tetra/modules/armor/feet/right/vanilla.json
@@ -1,0 +1,72 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "feet/right"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "key": "vanilla_feet_right/",
+      "aspects": {
+        "armor": 2,
+        "armor_feet": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_feet"
+      ],
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.168067
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.042017,
+          "minecraft:generic.armor_toughness": 0.09434
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.04717
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 208,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "right"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/vanilla/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/feet/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/head/base/heavy.json
+++ b/kubejs/data/tetra/modules/armor/head/base/heavy.json
@@ -1,0 +1,71 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "head/base"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "key": "heavy_head_base/",
+      "aspects": {
+        "armor": 2,
+        "armor_head": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_head"
+      ],
+      "attributes": {
+        "**minecraft:generic.movement_speed": -0.05
+      },
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.403361
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.10084,
+          "minecraft:generic.armor_toughness": 0.283019
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.141509
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 176,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "base"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/heavy/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/head/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/head/base/vanilla.json
+++ b/kubejs/data/tetra/modules/armor/head/base/vanilla.json
@@ -1,0 +1,69 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "head/base"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "key": "vanilla_head_base/",
+      "aspects": {
+        "armor": 2,
+        "armor_head": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 111,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_head"
+      ],
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.336134
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.084034,
+          "minecraft:generic.armor_toughness": 0.188679
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.09434
+        },
+        "durability": 0.16,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 176,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "base"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/vanilla/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/head/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/legs/belt/heavy.json
+++ b/kubejs/data/tetra/modules/armor/legs/belt/heavy.json
@@ -1,0 +1,75 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "legs/belt"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "key": "heavy_legs_belt/",
+      "aspects": {
+        "armor": 2,
+        "armor_legs": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_legs"
+      ],
+      "attributes": {
+        "**minecraft:generic.movement_speed": -0.05
+      },
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.504202
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.12605,
+          "minecraft:generic.armor_toughness": 0.141509
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.070755
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 112,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "base"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/heavy/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/legs/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/legs/belt/vanilla.json
+++ b/kubejs/data/tetra/modules/armor/legs/belt/vanilla.json
@@ -1,0 +1,72 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "legs/belt"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "key": "vanilla_legs_belt/",
+      "aspects": {
+        "armor": 2,
+        "armor_legs": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_legs"
+      ],
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.420168
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.105042,
+          "minecraft:generic.armor_toughness": 0.09434
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.04717
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 112,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "base"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/vanilla/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/legs/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/legs/left/heavy.json
+++ b/kubejs/data/tetra/modules/armor/legs/left/heavy.json
@@ -1,0 +1,71 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "legs/left"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "key": "heavy_legs_left/",
+      "aspects": {
+        "armor": 2,
+        "armor_legs": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_legs"
+      ],
+      "attributes": {
+        "**minecraft:generic.movement_speed": -0.05
+      },
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.252101
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.063025,
+          "minecraft:generic.armor_toughness": 0.070755
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.035377
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 80,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "left"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/heavy/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/legs/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/legs/left/vanilla.json
+++ b/kubejs/data/tetra/modules/armor/legs/left/vanilla.json
@@ -1,0 +1,72 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "legs/left"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "key": "vanilla_legs_left/",
+      "aspects": {
+        "armor": 2,
+        "armor_legs": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_legs"
+      ],
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.210084
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.052521,
+          "minecraft:generic.armor_toughness": 0.04717
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.023585
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 80,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "left"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/vanilla/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/legs/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/legs/right/heavy.json
+++ b/kubejs/data/tetra/modules/armor/legs/right/heavy.json
@@ -1,0 +1,71 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "legs/right"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "key": "heavy_legs_right/",
+      "aspects": {
+        "armor": 2,
+        "armor_legs": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_legs"
+      ],
+      "attributes": {
+        "**minecraft:generic.movement_speed": -0.05
+      },
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.252101
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.063025,
+          "minecraft:generic.armor_toughness": 0.070755
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.035377
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 96,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "right"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/heavy/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/legs/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/modules/armor/legs/right/vanilla.json
+++ b/kubejs/data/tetra/modules/armor/legs/right/vanilla.json
@@ -1,0 +1,72 @@
+{
+  "replace": true,
+  "type": "tetra:basic_major_module",
+  "slots": [
+    "legs/right"
+  ],
+  "improvements": [
+    "tetra:armor/shared/"
+  ],
+  "variants": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "key": "vanilla_legs_right/",
+      "aspects": {
+        "armor": 2,
+        "armor_legs": 2,
+        "wearable": 2,
+        "breakable": 2
+      },
+      "durability": 7,
+      "integrity": 1,
+      "contexts": [
+        "armor",
+        "armor_legs"
+      ],
+      "extract": {
+        "primaryAttributes": {
+          "minecraft:generic.armor": 0.210084
+        },
+        "secondaryAttributes": {
+          "minecraft:generic.armor": 0.052521,
+          "minecraft:generic.armor_toughness": 0.04717
+        },
+        "tertiaryAttributes": {
+          "minecraft:generic.armor_toughness": 0.023585
+        },
+        "primaryEffects": {},
+        "secondaryEffects": {},
+        "tertiaryEffects": {},
+        "durability": 0.3,
+        "integrity": 1,
+        "magicCapacity": 1,
+        "glyph": {
+          "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+          "textureX": 96,
+          "textureY": 0
+        },
+        "availableTextures": [
+          "right"
+        ],
+        "models": [
+          {
+            "type": "gecko",
+            "location": "geotetraarmor:item/armor/vanilla/"
+          },
+          {
+            "location": "geotetraarmor:item/module/armor/legs/"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/chest/base/heavy.json
+++ b/kubejs/data/tetra/schematics/armor/chest/base/heavy.json
@@ -1,0 +1,38 @@
+{
+  "replace": true,
+  "slots": [
+    "chest/base"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 5
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 3
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 2
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 48,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "countFactor": 3,
+      "moduleKey": "armor/chest/base/heavy",
+      "moduleVariant": "heavy_chest_base/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/chest/base/vanilla.json
+++ b/kubejs/data/tetra/schematics/armor/chest/base/vanilla.json
@@ -1,0 +1,42 @@
+{
+  "replace": true,
+  "slots": [
+    "chest/base"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 4
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 2
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 1
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 48,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "countFactor": 3,
+      "moduleKey": "armor/chest/base/vanilla",
+      "moduleVariant": "vanilla_chest_base/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/chest/left/heavy.json
+++ b/kubejs/data/tetra/schematics/armor/chest/left/heavy.json
@@ -1,0 +1,38 @@
+{
+  "replace": true,
+  "slots": [
+    "chest/left"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 5
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 3
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 2
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 0,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "countFactor": 2,
+      "moduleKey": "armor/chest/left/heavy",
+      "moduleVariant": "heavy_chest_left/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/chest/left/vanilla.json
+++ b/kubejs/data/tetra/schematics/armor/chest/left/vanilla.json
@@ -1,0 +1,42 @@
+{
+  "replace": true,
+  "slots": [
+    "chest/left"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 4
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 2
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 1
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 0,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "countFactor": 2,
+      "moduleKey": "armor/chest/left/vanilla",
+      "moduleVariant": "vanilla_chest_left/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/chest/right/heavy.json
+++ b/kubejs/data/tetra/schematics/armor/chest/right/heavy.json
@@ -1,0 +1,38 @@
+{
+  "replace": true,
+  "slots": [
+    "chest/right"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 5
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 3
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 2
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 16,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "countFactor": 2,
+      "moduleKey": "armor/chest/right/heavy",
+      "moduleVariant": "heavy_chest_right/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/chest/right/vanilla.json
+++ b/kubejs/data/tetra/schematics/armor/chest/right/vanilla.json
@@ -1,0 +1,42 @@
+{
+  "replace": true,
+  "slots": [
+    "chest/right"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 4
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 2
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 1
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 16,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "countFactor": 2,
+      "moduleKey": "armor/chest/right/vanilla",
+      "moduleVariant": "vanilla_chest_right/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/feet/left/heavy.json
+++ b/kubejs/data/tetra/schematics/armor/feet/left/heavy.json
@@ -1,0 +1,37 @@
+{
+  "replace": true,
+  "slots": [
+    "feet/left"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 5
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 3
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 2
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 192,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "moduleKey": "armor/feet/left/heavy",
+      "moduleVariant": "heavy_feet_left/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/feet/left/vanilla.json
+++ b/kubejs/data/tetra/schematics/armor/feet/left/vanilla.json
@@ -1,0 +1,41 @@
+{
+  "replace": true,
+  "slots": [
+    "feet/left"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 4
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 2
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 1
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 192,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "moduleKey": "armor/feet/left/vanilla",
+      "moduleVariant": "vanilla_feet_left/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/feet/right/heavy.json
+++ b/kubejs/data/tetra/schematics/armor/feet/right/heavy.json
@@ -1,0 +1,37 @@
+{
+  "replace": true,
+  "slots": [
+    "feet/right"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 5
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 3
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 2
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 208,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "moduleKey": "armor/feet/right/heavy",
+      "moduleVariant": "heavy_feet_right/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/feet/right/vanilla.json
+++ b/kubejs/data/tetra/schematics/armor/feet/right/vanilla.json
@@ -1,0 +1,41 @@
+{
+  "replace": true,
+  "slots": [
+    "feet/right"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 4
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 2
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 1
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 208,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "moduleKey": "armor/feet/right/vanilla",
+      "moduleVariant": "vanilla_feet_right/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/head/base/heavy.json
+++ b/kubejs/data/tetra/schematics/armor/head/base/heavy.json
@@ -1,0 +1,38 @@
+{
+  "replace": true,
+  "slots": [
+    "head/base"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 5
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 3
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 2
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 176,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "countFactor": 2,
+      "moduleKey": "armor/head/base/heavy",
+      "moduleVariant": "heavy_head_base/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/head/base/vanilla.json
+++ b/kubejs/data/tetra/schematics/armor/head/base/vanilla.json
@@ -1,0 +1,42 @@
+{
+  "replace": true,
+  "slots": [
+    "head/base"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 4
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 2
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 1
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 176,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "countFactor": 2,
+      "moduleKey": "armor/head/base/vanilla",
+      "moduleVariant": "vanilla_head_base/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/legs/belt/heavy.json
+++ b/kubejs/data/tetra/schematics/armor/legs/belt/heavy.json
@@ -1,0 +1,42 @@
+{
+  "replace": true,
+  "slots": [
+    "legs/belt"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 5
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 3
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 2
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 112,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "countFactor": 2,
+      "moduleKey": "armor/legs/belt/heavy",
+      "moduleVariant": "heavy_legs_belt/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/legs/belt/vanilla.json
+++ b/kubejs/data/tetra/schematics/armor/legs/belt/vanilla.json
@@ -1,0 +1,42 @@
+{
+  "replace": true,
+  "slots": [
+    "legs/belt"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 4
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 2
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 1
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 112,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "countFactor": 2,
+      "moduleKey": "armor/legs/belt/vanilla",
+      "moduleVariant": "vanilla_legs_belt/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/legs/left/heavy.json
+++ b/kubejs/data/tetra/schematics/armor/legs/left/heavy.json
@@ -1,0 +1,37 @@
+{
+  "replace": true,
+  "slots": [
+    "legs/left"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 5
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 3
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 2
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 80,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "moduleKey": "armor/legs/left/heavy",
+      "moduleVariant": "heavy_legs_left/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/legs/left/vanilla.json
+++ b/kubejs/data/tetra/schematics/armor/legs/left/vanilla.json
@@ -1,0 +1,41 @@
+{
+  "replace": true,
+  "slots": [
+    "legs/left"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 4
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 2
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 1
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 80,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "moduleKey": "armor/legs/left/vanilla",
+      "moduleVariant": "vanilla_legs_left/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/legs/right/heavy.json
+++ b/kubejs/data/tetra/schematics/armor/legs/right/heavy.json
@@ -1,0 +1,37 @@
+{
+  "replace": true,
+  "slots": [
+    "legs/right"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 5
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 3
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 2
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 96,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/"
+      ],
+      "moduleKey": "armor/legs/right/heavy",
+      "moduleVariant": "heavy_legs_right/"
+    }
+  ]
+}

--- a/kubejs/data/tetra/schematics/armor/legs/right/vanilla.json
+++ b/kubejs/data/tetra/schematics/armor/legs/right/vanilla.json
@@ -1,0 +1,41 @@
+{
+  "replace": true,
+  "slots": [
+    "legs/right"
+  ],
+  "materialSlotCount": 1,
+  "displayType": "major",
+  "translation": {
+    "primaryAttributes": {
+      "generic.armor": 4
+    },
+    "secondaryAttributes": {
+      "generic.armor": 1,
+      "generic.armor_toughness": 2
+    },
+    "tertiaryAttributes": {
+      "generic.armor_toughness": 1
+    }
+  },
+  "glyph": {
+    "textureLocation": "geotetraarmor:textures/gui/gui_gta.png",
+    "textureX": 96,
+    "textureY": 0
+  },
+  "outcomes": [
+    {
+      "materials": [
+        "tetra:wood/",
+        "tetra:gem/",
+        "tetra:metal/",
+        "tetra:bone/",
+        "tetra:fabric/",
+        "tetra:fibre/",
+        "tetra:skin/",
+        "tetra:scale/"
+      ],
+      "moduleKey": "armor/legs/right/vanilla",
+      "moduleVariant": "vanilla_legs_right/"
+    }
+  ]
+}

--- a/kubejs/startup_scripts/global_value.js
+++ b/kubejs/startup_scripts/global_value.js
@@ -1,0 +1,1 @@
+global.difficultyCache = 0


### PR DESCRIPTION
﻿## 变更内容
- 覆盖 GeoTetraArmor 的 Tetra 护甲模块数值：硬度影响护甲，密度影响护甲与韧性，韧性影响护甲韧性，并移除负韧性系数。
- 补充护甲 schematic 的材质属性转化说明，区分香草与重型权重；重型描述注明护甲/韧性收益倍率与移动速度惩罚。
- 新增 GeoTetraArmor 中文描述覆盖，说明香草/重型护甲材料属性与减速规则。
- 修复难度 GUI 对 `global.difficultyCache` 非原生 number 值的读取，并新增启动脚本默认初始化。

## 验证
- `git diff --cached --check`
- JSON 解析校验：`kubejs/data/tetra/modules/armor`、`kubejs/data/tetra/schematics/armor`、`kubejs/assets/geotetraarmor/lang/zh_cn.json`

## 备注
- 未启动游戏实测；资源描述更新可能需要客户端重载资源或重启。
