### PR TITLE
[fix] 修复OEV流体成本计价

### DIFF
--- a/config/jei/recipe-category-sort-order.ini
+++ b/config/jei/recipe-category-sort-order.ini
@@ -204,9 +204,6 @@ jeitetra:material
 jeitetra:module
 jeitetra:replacement
 apotheosis:spawner_modifiers
-minecraft:tag_recipes/block
-minecraft:tag_recipes/fluid
-minecraft:tag_recipes/item
 ali:cat_morning_gift
 ali:piglin_bartering
 ali:sniffer_digging

--- a/kubejs/server_scripts/One Enough Value/recipe_handler.js
+++ b/kubejs/server_scripts/One Enough Value/recipe_handler.js
@@ -94,6 +94,79 @@ function safeExtractItem(item) {
     }
 }
 
+function isValidItemStack(stack) {
+    try {
+        return stack && typeof stack.isEmpty === 'function' && !stack.isEmpty()
+            && typeof stack.getCount === 'function' && stack.getCount() > 0;
+    } catch (e) {
+        logSkippedItem(stack, 'isValidItemStack', e);
+        return false;
+    }
+}
+
+function collectItemIds(items) {
+    let ids = {};
+    toArray(items).forEach(item => {
+        let extracted = safeExtractItem(item);
+        if (!extracted) return;
+
+        try {
+            ids[String(extracted.stack.getItem().getId())] = true;
+        } catch (e) {
+            logSkippedItem(item, 'collectItemIds', e);
+        }
+    });
+
+    return ids;
+}
+
+function getRecipeOutputStacks(recipe, registryAccess) {
+    let outputs = [];
+
+    try {
+        let stack = recipe.getResultItem(registryAccess);
+        if (isValidItemStack(stack)) outputs.push(stack);
+    } catch (e) {
+        logSkippedItem(recipe, 'outputGetter:getResultItem', e);
+    }
+
+    if (outputs.length > 0 || !recipe.getRollableResults) return outputs;
+
+    try {
+        toArray(recipe.getRollableResults()).forEach(result => {
+            let extracted = safeExtractItem(result);
+            if (extracted) outputs.push(extracted.stack);
+        });
+    } catch (e) {
+        logSkippedItem(recipe, 'outputGetter:getRollableResults', e);
+    }
+
+    return outputs;
+}
+
+function getNewRollableResults(recipe, knownItemIds) {
+    let results = [];
+    if (!recipe.getRollableResults) return results;
+
+    try {
+        toArray(recipe.getRollableResults()).forEach(result => {
+            let extracted = safeExtractItem(result);
+            if (!extracted) return;
+
+            try {
+                let itemId = String(extracted.stack.getItem().getId());
+                if (!knownItemIds[itemId]) results.push(result);
+            } catch (e) {
+                logSkippedItem(result, 'getNewRollableResults:itemId', e);
+            }
+        });
+    } catch (e) {
+        logSkippedItem(recipe, 'getNewRollableResults', e);
+    }
+
+    return results;
+}
+
 function logSkippedItem(item, source, error) {
     try {
         let info = (item && item.getClass) ? item.getClass().getName() : typeof item;
@@ -138,6 +211,221 @@ function calculateValueDistribution(items, itemCountMap, totalUnpricedCnt, consu
         totalUnpricedCnt: totalUnpricedCnt,
         consumedValue: consumedValue
     };
+}
+
+function safeCallNoArg(target, methodName, source) {
+    if (!target) return null;
+
+    try {
+        if (typeof target[methodName] === 'function') {
+            return target[methodName]();
+        }
+    } catch (e) {
+        logSkippedItem(target, source + ':' + methodName, e);
+    }
+
+    return null;
+}
+
+function getDefaultRecipeExtraValue(extraValueGetter, recipe) {
+    try {
+        if (!extraValueGetter) return 0;
+        if (typeof extraValueGetter.get === 'function') return Number(extraValueGetter.get(recipe)) || 0;
+        if (typeof extraValueGetter === 'function') return Number(extraValueGetter(recipe)) || 0;
+    } catch (e) {
+        logSkippedItem(recipe, 'extraValueGetter:default', e);
+    }
+
+    return 0;
+}
+
+function getFluidId(fluidStack) {
+    if (!fluidStack) return null;
+
+    try {
+        if (fluidStack.id) return String(fluidStack.id);
+    } catch (e) {
+        logSkippedItem(fluidStack, 'getFluidId:id', e);
+    }
+
+    try {
+        if (typeof fluidStack.getFluidStack === 'function') {
+            let innerStack = fluidStack.getFluidStack();
+            let innerId = getFluidId(innerStack);
+            if (innerId) return innerId;
+        }
+    } catch (e) {
+        logSkippedItem(fluidStack, 'getFluidId:getFluidStack', e);
+    }
+
+    try {
+        if (typeof fluidStack.getFluid === 'function') {
+            let fluid = fluidStack.getFluid();
+            let fluidKey = global.CDLightmansCurrencyApi.ForgeRegistries.FLUIDS.getKey(fluid);
+            if (fluidKey) return String(fluidKey);
+        }
+    } catch (e) {
+        logSkippedItem(fluidStack, 'getFluidId:getFluid', e);
+    }
+
+    try {
+        if (fluidStack.fluid) {
+            let fluidKey = global.CDLightmansCurrencyApi.ForgeRegistries.FLUIDS.getKey(fluidStack.fluid);
+            if (fluidKey) return String(fluidKey);
+        }
+    } catch (e) {
+        logSkippedItem(fluidStack, 'getFluidId:fluid', e);
+    }
+
+    return null;
+}
+
+function getFluidAmount(fluidStack, fallbackAmount) {
+    if (!fluidStack) return fallbackAmount || 1000;
+
+    try {
+        if (typeof fluidStack.getAmount === 'function') return Number(fluidStack.getAmount()) || fallbackAmount || 1000;
+    } catch (e) {
+        logSkippedItem(fluidStack, 'getFluidAmount:getAmount', e);
+    }
+
+    try {
+        if (fluidStack.amount !== undefined) return Number(fluidStack.amount) || fallbackAmount || 1000;
+    } catch (e) {
+        logSkippedItem(fluidStack, 'getFluidAmount:amount', e);
+    }
+
+    return fallbackAmount || 1000;
+}
+
+function getFluidValuePer1000(fluidId) {
+    if (!fluidId || !global.FluidIngredientValueDict) return 0;
+
+    try {
+        let value = global.FluidIngredientValueDict.get(fluidId);
+        if (value !== undefined) return Number(value) || 0;
+    } catch (e) {
+        logSkippedItem(fluidId, 'getFluidValuePer1000', e);
+    }
+
+    return 0;
+}
+
+function calculateFluidStackValue(fluidId, amount) {
+    let valuePer1000 = getFluidValuePer1000(fluidId);
+    if (valuePer1000 <= 0 || amount <= 0) return 0;
+
+    return valuePer1000 * amount / 1000.0;
+}
+
+function extractFluidCandidates(fluidIngredient) {
+    let candidates = [];
+    if (!fluidIngredient) return candidates;
+
+    let fallbackAmount = getFluidAmount(fluidIngredient, 1000);
+
+    try {
+        let matchingStacks = safeCallNoArg(fluidIngredient, 'getMatchingFluidStacks', 'fluidIngredient');
+        toArray(matchingStacks).forEach(stack => {
+            let fluidId = getFluidId(stack);
+            if (!fluidId) return;
+
+            candidates.push({
+                fluid: fluidId,
+                amount: getFluidAmount(stack, fallbackAmount)
+            });
+        });
+    } catch (e) {
+        logSkippedItem(fluidIngredient, 'extractFluidCandidates:matchingStacks', e);
+    }
+
+    if (candidates.length === 0) {
+        let fluidId = getFluidId(fluidIngredient);
+        if (fluidId) {
+            candidates.push({
+                fluid: fluidId,
+                amount: fallbackAmount
+            });
+        }
+    }
+
+    return candidates;
+}
+
+function calculateFluidIngredientValue(fluidIngredient) {
+    let minValue = null;
+
+    extractFluidCandidates(fluidIngredient).forEach(candidate => {
+        let value = calculateFluidStackValue(candidate.fluid, candidate.amount);
+        if (value <= 0) return;
+        if (minValue === null || value < minValue) minValue = value;
+    });
+
+    return minValue || 0;
+}
+
+function getRecipeFluidIngredients(recipe) {
+    let fluidIngredients = [];
+
+    let addFluidIngredientValue = function (value) {
+        if (!value) return;
+
+        let values = toArray(value);
+        if (values.length > 0) {
+            values.forEach(fluidIngredient => fluidIngredients.push(fluidIngredient));
+            return;
+        }
+
+        fluidIngredients.push(value);
+    }
+
+    addFluidIngredientValue(safeCallNoArg(recipe, 'getFluidIngredients', 'recipeFluidInput'));
+
+    if (fluidIngredients.length === 0) {
+        addFluidIngredientValue(safeCallNoArg(recipe, 'getFluidIngredient', 'recipeFluidInput'));
+    }
+
+    try {
+        if (fluidIngredients.length === 0 && recipe.fluidIngredients) {
+            addFluidIngredientValue(recipe.fluidIngredients);
+        }
+    } catch (e) {
+        logSkippedItem(recipe, 'recipeFluidInput:field', e);
+    }
+
+    return fluidIngredients;
+}
+
+function calculateRecipeFluidInputValue(recipe) {
+    let fluidValue = 0.0;
+
+    getRecipeFluidIngredients(recipe).forEach(fluidIngredient => {
+        try {
+            fluidValue += calculateFluidIngredientValue(fluidIngredient);
+        } catch (e) {
+            logSkippedItem(fluidIngredient, 'calculateRecipeFluidInputValue', e);
+        }
+    });
+
+    return fluidValue;
+}
+
+function calculateHiddenFluidRecipeValue(recipeTypeName) {
+    if (!global.HiddenFluidCostByRecipeType) return 0;
+
+    let hiddenFluids = global.HiddenFluidCostByRecipeType.get(recipeTypeName);
+    if (!hiddenFluids) return 0;
+
+    let hiddenValue = 0.0;
+    toArray(hiddenFluids).forEach(fluidCost => {
+        try {
+            hiddenValue += calculateFluidStackValue(String(fluidCost.fluid), Number(fluidCost.amount) || 0);
+        } catch (e) {
+            logSkippedItem(fluidCost, 'calculateHiddenFluidRecipeValue', e);
+        }
+    });
+
+    return hiddenValue;
 }
 
 
@@ -199,15 +487,18 @@ OEVEvents.addRecipeHandler(event => {
             },
             (recipe, registryAccess) => {
                 try {
-                    let stack = recipe.getResultItem(registryAccess);
-                    if (!stack || stack.isEmpty() || stack.getCount() === 0) return [];
-                    return [stack];
+                    return getRecipeOutputStacks(recipe, registryAccess);
                 } catch (e) {
                     logSkippedItem(recipe, 'outputGetter', e);
                     return [];
                 }
             },
-            event.defaultRecipeExtraValueGetter,
+            (recipe) => {
+                let extraValue = getDefaultRecipeExtraValue(event.defaultRecipeExtraValueGetter, recipe);
+                extraValue += calculateRecipeFluidInputValue(recipe);
+                extraValue += calculateHiddenFluidRecipeValue(typeName);
+                return Math.ceil(extraValue);
+            },
             // event.defaultRecipeValueSetter
             (recipe, stacks, totalValue, setter) => {
                 try {
@@ -220,6 +511,7 @@ OEVEvents.addRecipeHandler(event => {
 
                     let stacksArr = toArray(stacks);
                     let rollableResults = null;
+                    let stackItemIds = collectItemIds(stacksArr);
 
                     // 2. 先计算 stacks 中的物品价值分配
                     let stacksResult = calculateValueDistribution(stacksArr, itemCountMap, totalUnpricedCnt, consumedValue);
@@ -230,7 +522,7 @@ OEVEvents.addRecipeHandler(event => {
                     // 3. 如果是机械动力概率产出，补充计算 序列组装的产出物 中的物品价值分配
                     if (recipe.getRollableResults) {
                         try {
-                            rollableResults = recipe.getRollableResults();
+                            rollableResults = getNewRollableResults(recipe, stackItemIds);
                             let rollableResult = calculateValueDistribution(rollableResults, itemCountMap, totalUnpricedCnt, consumedValue);
                             itemCountMap = rollableResult.itemCountMap;
                             totalUnpricedCnt = rollableResult.totalUnpricedCnt;

--- a/kubejs/startup_scripts/custom/value_data.js
+++ b/kubejs/startup_scripts/custom/value_data.js
@@ -366,3 +366,27 @@ let RecipeValueMultiplierDict = {
     "crafting": 1
 }
 global.RecipeValueMultiplierDict = new Map(Object.entries(RecipeValueMultiplierDict));
+
+// Fluid values are counted per 1000 mB. They are used by the OEV recipe handler
+// because OneEnoughValue only prices ItemStack outputs natively.
+let FluidIngredientValueDict = {
+    "minecraft:milk": 8,
+    "create:honey": 8,
+    "createdelight:egg_yolk": 8,
+    "createdelight:artificial_egg_yolk": 8,
+    "createdieselgenerators:plant_oil": 4,
+    "create_bic_bit:frying_oil": 4,
+    "create_bic_bit:mayonnaise": 8,
+    "create_central_kitchen:tomato_sauce": 16,
+}
+global.FluidIngredientValueDict = new Map(Object.entries(FluidIngredientValueDict));
+
+// Some recipe types consume fluid through their machine state instead of putting
+// the fluid in the recipe JSON. Keep these costs aligned with equivalent Create
+// processing recipes so OEV does not prefer the hidden-fluid path.
+let HiddenFluidCostByRecipeType = {
+    "casualness_delight:deep_frying": [
+        { fluid: "createdieselgenerators:plant_oil", amount: 25 }
+    ]
+}
+global.HiddenFluidCostByRecipeType = new Map(Object.entries(HiddenFluidCostByRecipeType));

--- a/lessons-learned.md
+++ b/lessons-learned.md
@@ -277,3 +277,17 @@ gh pr create --body '... `ad_astra:xxx` ...'
 - **Problem**: Ratatouille 1.3.8 `SqueezingRecipe#matches` and `#match` call `FluidIngredient#test` without checking `getRequiredAmount`, so recipes like `createdelight:squeezing/raw_sausage` can run with 1 mB of a matching fluid.
 - **Fix/Lesson**: CDC patches both recipe matching entry points to require matching fluid type and amount before the press starts, because `process` drains the configured amount only after the recipe has already passed matching.
 
+## OEV fluid input costs need explicit recipe extra value
+
+**Date**: 2026-06-22
+
+- **Problem**: OneEnoughValue only prices `ItemStack`/`Ingredient` inputs natively, so Create fluid ingredients and hidden machine fluids such as `casualness_delight:deep_frying` oil cost can be ignored and make processed foods price like raw inputs.
+- **Fix/Lesson**: Add fluid costs through OEV recipe extra value using a per-1000 mB fluid value table, and mirror hidden fluid consumption by recipe type so alternate recipes cannot undercut the explicit-fluid path.
+
+## OEV Create processing outputs may be rollable results
+
+**Date**: 2026-06-22
+
+- **Problem**: Create processing recipes such as mixing can expose their outputs through `getRollableResults()` while `getResultItem(registryAccess)` is empty, so OEV may skip recipe-derived values and fall back to food nutrition pricing.
+- **Fix/Lesson**: OEV output getters should fall back to extracted `getRollableResults()` stacks and avoid counting the same item ID twice when value setters also inspect rollable outputs.
+


### PR DESCRIPTION
## 摘要
- 为 OEV 配方价值累积补充流体输入价值计算，支持按 1000mB 配置流体价值。
- 为 `casualness_delight:deep_frying` 补充隐藏植物油消耗，避免无显式流体配方低估成本。
- 让 OEV 在普通 `getResultItem(registryAccess)` 为空时回退读取 Create `getRollableResults()` 输出，使 `create:mixing/raw_tonkatsu` 这类配方能写入配方价值。
- 移除 JEI 排序中 tag_recipes 分类条目，并记录 OEV 流体与 Create 输出计价经验。

## 验证
- `node --check "kubejs/server_scripts/One Enough Value/recipe_handler.js"`
- `node --check kubejs/startup_scripts/custom/value_data.js`
- `git diff --check`