### PR TITLE
[fix] 统一饺子与馄饨配方兼容

### DIFF
--- a/kubejs/server_scripts/Brewin and Chewin/recipe.js
+++ b/kubejs/server_scripts/Brewin and Chewin/recipe.js
@@ -47,6 +47,7 @@ ServerEvents.recipes(e => {
         "brewinandchewin:fermenting/scarlet_cheese_from_milk",
         "brewinandchewin:fermenting/withering_dross_from_salty_folly",
         "brewinandchewin:emptying/create/potion",
+        "brewinandchewin:cooking/scarlet_pierogi",
         "/brewinandchewin:emptying\/create\/farmersrespite\/.*/"
     ])
     create.filling("brewinandchewin:unripe_flaxen_cheese_wheel", [
@@ -213,6 +214,15 @@ ServerEvents.recipes(e => {
         'brewinandchewin:creamy_onion_soup',
         1, 200, "minecraft:bowl"
     ).id("createdelight:cooking/creamy_onion_soup")
+    wonton(e,
+        [
+            "create:dough",
+            "brewinandchewin:scarlet_cheese_wedge",
+            "minecraft:nether_wart",
+            "#forge:shrimps"
+        ], 
+        'brewinandchewin:scarlet_pierogi', 1.0, 200
+    )
     ratatouille.baking(
         "brewinandchewin:jerky",
         "#forge:meat/cooked"

--- a/kubejs/server_scripts/Create BitterBallen/recipe.js
+++ b/kubejs/server_scripts/Create BitterBallen/recipe.js
@@ -48,7 +48,9 @@ ServerEvents.recipes(e => {
         "create_bic_bit:filling/mayonnaise_ketchup_frikandel_sandwich",
         "create_bic_bit:filling/wrapped_ketchup_fries",
         "create_bic_bit:filling/wrapped_mayonnaise_ketchup_fries",
-        "create_bic_bit:deep_frying/enderball"
+        "create_bic_bit:deep_frying/enderball",
+        "create_deepfried:compat/farmersdelight/mixing/raw_tempura",
+        "create_deepfried:mixing/raw_tempura"
     ])
     remove_recipes_output(e, [
         'create_bic_bit:cheese_souffle', 

--- a/kubejs/server_scripts/Custom/order/data.js
+++ b/kubejs/server_scripts/Custom/order/data.js
@@ -1331,7 +1331,6 @@ ServerEvents.tags("minecraft:item", e => {
         "youkaishomecoming:mantou",
         "youkaishomecoming:oyaki",
         "festival_delicacies:mantou",
-        "festival_delicacies:baozi",
         "vintagedelight:oatmeal",
         "vintagedelight:overnight_oats",
         "farmersdelight:stuffed_potato",
@@ -1425,9 +1424,6 @@ ServerEvents.tags("minecraft:item", e => {
         "dumplings_delight:calamari_boiled_dumpling",
         "dumplings_delight:pork_celery_boiled_dumpling",
         "dumplings_delight:tomato_egg_boiled_dumpling",
-        "festival_delicacies:boiled_dumpling",
-        "festival_delicacies:steamed_dumpling",
-        "festival_delicacies:wonton"
     )
     e.add("createdelight:order/monster",
         "dungeonsdelight:ghast_roll",

--- a/kubejs/server_scripts/Festival Delicacies/dumplings.js
+++ b/kubejs/server_scripts/Festival Delicacies/dumplings.js
@@ -60,6 +60,8 @@ ServerEvents.recipes(e => {
         "festival_delicacies:wonton_fd/fd_pork_carrot_wonton_recipe",
         "festival_delicacies:wonton/pork_carrot_wonton_recipe",
         "festival_delicacies:wonton/pork_carrot_wonton_recipe_2",
+        "festival_delicacies:fd_cooking/wonton_fd_cooking",
+        "festival_delicacies:default/wonton",
 
         // Dumplings Delight: remove overlapping dumpling/wonton recipes, keep our unified versions below.
         "dumplings_delight:dumpling/chicken_mushroom_boiled_dumpling_recipe",
@@ -107,111 +109,25 @@ ServerEvents.recipes(e => {
         "dumplings_delight:greenonion_from_crate",
         "dumplings_delight:vinegar"
     ])
-    dumpling(e, [
-        'create:dough',
-        "butchercraft:pork_stewmeat",
-        "#forge:vegetables/chinese_cabbage",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:pork_cabbage_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "butchercraft:pork_stewmeat",
-        "minecraft:kelp",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:pork_kelp_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "minecraft:brown_mushroom",
-        "butchercraft:pork_stewmeat",
-        "#forge:vegetables/onion",
-        "minecraft:potato"
-    ], "2x dumplings_delight:pork_potato_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "butchercraft:pork_stewmeat",
-        "festival_delicacies:fennel",
-        "#forge:vegetables/onion"
-    ], "dumplings_delight:pork_fennel_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "butchercraft:lamb_stewmeat",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:mutton_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "butchercraft:chicken_stewmeat",
-        "minecraft:brown_mushroom",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:chicken_mushroom_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "farmersdelight:cod_slice",
-        "minecraft:egg",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:cod_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "farmersdelight:salmon_slice",
-        "minecraft:carrot"
-    ], "2x dumplings_delight:salmon_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "minecraft:egg",
-        "#forge:vegetables/onion",
-        "#forge:vegetables/eggplant"
-    ], "2x dumplings_delight:eggplant_egg_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "minecraft:brown_mushroom",
-        "minecraft:red_mushroom",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:mushroom_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "minecraft:warped_fungus",
-        "minecraft:crimson_fungus",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:fungus_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "festival_delicacies:garlic_chive",
-        "minecraft:egg"
-    ], "2x dumplings_delight:garlic_chive_egg_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "minecraft:dandelion",
-        "minecraft:egg",
-        "minecraft:brown_mushroom"
-    ], "2x dumplings_delight:dandelion_leaf_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        'create:dough',
-        "butchercraft:rabbit_stewmeat",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:rabbit_meat_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        "create:dough",
-        "2x butchercraft:beef_stewmeat",
-        "some_assembly_required:tomato_slices",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:beef_tomato_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        "create:dough",
-        "createdelight:raw_calamari",
-        "minecraft:brown_mushroom",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:calamari_boiled_dumpling", 1.0, 200)
-    // dumpling(e, [
-    //     "create:dough",
-    //     "butchercraft:pork_stewmeat",
-    //     "festival_delicacies:greenonion",
-    //     "#forge:vegetables/onion"
-    // ], "2x dumplings_delight:pork_celery_boiled_dumpling", 1.0, 200)
-    dumpling(e, [
-        "create:dough",
-        "some_assembly_required:tomato_slices",
-        "minecraft:egg",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:tomato_egg_boiled_dumpling", 1.0, 200)
+    e.replaceInput({id: "dumplings_delight:dumpling_medley"}, "dumplings_delight:vinegar", "vintagedelight:vinegar_bottle")
+    dumpling(e, ["butchercraft:pork_stewmeat", "#forge:vegetables/chinese_cabbage"], "2x dumplings_delight:pork_cabbage_boiled_dumpling")
+    dumpling(e, ["butchercraft:pork_stewmeat", "minecraft:kelp"], "2x dumplings_delight:pork_kelp_boiled_dumpling")
+    dumpling(e, ["butchercraft:pork_stewmeat", "minecraft:potato"], "2x dumplings_delight:pork_potato_boiled_dumpling")
+    dumpling(e, ["butchercraft:pork_stewmeat", "festival_delicacies:fennel"], "2x dumplings_delight:pork_fennel_boiled_dumpling")
+    dumpling(e, ["butchercraft:lamb_stewmeat", "#forge:vegetables/carrots"], "2x dumplings_delight:mutton_boiled_dumpling")
+    dumpling(e, ["butchercraft:chicken_stewmeat", "#forge:mushrooms"], "2x dumplings_delight:chicken_mushroom_boiled_dumpling")
+    dumpling(e, ["farmersdelight:cod_slice", "#forge:eggs"], "2x dumplings_delight:cod_boiled_dumpling")
+    dumpling(e, ["farmersdelight:salmon_slice", "#forge:eggs"], "2x dumplings_delight:salmon_boiled_dumpling")
+    dumpling(e, ["#forge:vegetables/eggplant", "#forge:eggs"], "2x dumplings_delight:eggplant_egg_boiled_dumpling")
+    dumpling(e, ["#forge:mushrooms", "#forge:mushrooms"], "2x dumplings_delight:mushroom_boiled_dumpling")
+    dumpling(e, [["minecraft:warped_fungus", "minecraft:crimson_fungus"],["minecraft:crimson_fungus", "minecraft:warped_fungus"]], "2x dumplings_delight:fungus_boiled_dumpling")
+    dumpling(e, ["festival_delicacies:garlic_chive", "#forge:eggs"], "2x dumplings_delight:garlic_chive_egg_boiled_dumpling")
+    dumpling(e, ["minecraft:dandelion", "#forge:eggs", "#forge:mushrooms"], "2x dumplings_delight:dandelion_leaf_boiled_dumpling")
+    dumpling(e, ["butchercraft:rabbit_stewmeat", "#forge:vegetables/chinese_cabbage"], "2x dumplings_delight:rabbit_meat_boiled_dumpling")
+    dumpling(e, ["butchercraft:beef_stewmeat", "some_assembly_required:tomato_slices",], "2x dumplings_delight:beef_tomato_boiled_dumpling")
+    dumpling(e, ["some_assembly_required:tomato_slices", "#forge:eggs",], "2x dumplings_delight:tomato_egg_boiled_dumpling")  
+    dumpling(e, ["createdelight:raw_calamari", "minecraft:brown_mushroom",], "2x dumplings_delight:calamari_boiled_dumpling")
+    dumpling(e, ["crabbersdelight:pufferfish_slice", "#forge:eggs"], "2x dumplings_delight:pufferfish_boiled_dumpling")
     wonton(e, [
         'create:dough',
         "#forge:raw_pork",

--- a/kubejs/server_scripts/Festival Delicacies/tags.js
+++ b/kubejs/server_scripts/Festival Delicacies/tags.js
@@ -25,6 +25,9 @@ ServerEvents.tags("minecraft:item", e => {
             'festival_delicacies:garlic'
         ]
     )
+    e.add("forge:vegetables/carrots", [
+        'minecraft:carrot'
+    ])
 })
 
 ServerEvents.tags("minecraft:block", e => {

--- a/kubejs/server_scripts/Oceanic Delight/recipes.js
+++ b/kubejs/server_scripts/Oceanic Delight/recipes.js
@@ -10,12 +10,6 @@ ServerEvents.recipes(e => {
         "oceanic_delight:sea_pickle_roll"
     ])
     e.replaceInput({id: "oceanic_delight:fish_egg_noodle_soup"}, "#forge:pasta", 'createdelight:vermicelli')
-    // 河豚水饺
-    dumpling(e, [
-        "crabbersdelight:pufferfish_slice",
-        "#forge:dough",
-        "#forge:vegetables/onion"
-    ], "2x dumplings_delight:pufferfish_boiled_dumpling", 1.0, 200)
     // 鱿鱼须相关
     cutting_2(e, "oceanic_delight:squid_tentacles", [["createdelight:raw_calamari", 3]])
     cutting_2(e, "oceanic_delight:glow_squid_tentacles", [["createdelight:raw_calamari", 3]])

--- a/kubejs/server_scripts/util/festival_delicacies.js
+++ b/kubejs/server_scripts/util/festival_delicacies.js
@@ -1,23 +1,40 @@
 /**
- * @param { Internal.RecipesEventJS } event 
+ * @param { Internal.RecipesEventJS } e 
  * @param { InputItem_[] } inputs 
  * @param { OutputItem_ } output 
  * @param { number } exp 
  * @param { number } time 
  */
-function dumpling(event, inputs, output, exp, time) {
-    event.recipes.festival_delicacies.stove(inputs, output, exp, time, "default")
-        .id(`createdelight:stove/${output.split(":")[1]}`)
+function dumpling(e, inputs, output, exp, time) {
+    exp = 1.0 || exp
+    time = 200 || time
+    e.recipes.festival_delicacies.stove(
+        [
+            "create:dough",
+            "#forge:vegetables/onion",
+        ].concat(inputs),
+        output,
+        exp, time, "default"
+    ).id(`createdelight:stove/${output.split(":")[1]}`)
+    e.recipes.farmersdelight.cooking(
+        [
+            "create:dough",
+            "#forge:vegetables/onion",
+        ].concat(inputs),
+        output, exp, time
+    ).id(`createdelight:cooking/${output.split(":")[1]}`)
 }
 
 /**
- * @param { Internal.RecipesEventJS } event 
+ * @param { Internal.RecipesEventJS } e 
  * @param { InputItem_[] } inputs 
  * @param { OutputItem_ } output 
  * @param { number } exp 
  * @param { number } time 
  */
-function wonton(event, inputs, output, exp, time) {
-    event.recipes.festival_delicacies.stove(inputs, output, exp, time, "default", "minecraft:bowl")
+function wonton(e, inputs, output, exp, time) {
+    e.recipes.festival_delicacies.stove(inputs, output, exp, time, "default", "minecraft:bowl")
         .id(`createdelight:stove/${output.split(":")[1]}`)
+    e.recipes.farmersdelight.cooking(inputs, output, exp, time, "minecraft:bowl")
+        .id(`createdelight:cooking/${output.split(":")[1]}`)
 }

--- a/kubejs/startup_scripts/creative_tab/festival_delicacies.js
+++ b/kubejs/startup_scripts/creative_tab/festival_delicacies.js
@@ -4,4 +4,10 @@ StartupEvents.modifyCreativeTab("festival_delicacies:festival_delicacies", e => 
       "createdelight:artemisia_argyi_seed"
     ]
   )
+  e.remove([
+    Item.of('festival_delicacies:boiled_dumpling', '{BlockEntityTag:{Dumpling:[{Count:1b,id:"festival_delicacies:garlic_chive"},{Count:1b,id:"minecraft:egg"}]}}'),
+    Item.of('festival_delicacies:steamed_dumpling', '{BlockEntityTag:{Dumpling:[{Count:1b,id:"festival_delicacies:chinese_cabbage_leaf"},{Count:1b,id:"minecraft:cooked_porkchop"}]}}'),
+    Item.of('festival_delicacies:steamed_dumpling', '{BlockEntityTag:{Dumpling:[{Count:1b,id:"festival_delicacies:chinese_cabbage_leaf"},{Count:1b,id:"minecraft:cooked_porkchop"}]}}'),
+    'festival_delicacies:wonton'
+  ])
 })


### PR DESCRIPTION
- 收束 Dumplings Delight 饺子配方，统一补充节庆佳肴炉灶和农夫乐事烹饪锅产线

- 调整馄饨、绯红奶酪饺和河豚水饺配方位置，清理重复与冲突配方

- 更新订单分类、胡萝卜蔬菜标签和节庆佳肴创造栏隐藏项