### PR TITLE
[dev] 增加仓库同步流程技能，提高agent拉取后遵循规则跑sync的概率

### DIFF
--- a/.agents/skills/repo-sync/SKILL.md
+++ b/.agents/skills/repo-sync/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: repo-sync
+description: Keep the Create-Delight Remake checkout current and locally runnable after Git updates. Use when the user asks to pull latest changes, switch to main, rebase on main, merge upstream changes, update a branch, or otherwise run Git operations that may bring in packwiz metadata, packwiz-files payloads, or CDC submodule pointer changes.
+---
+
+# Repo Sync
+
+## Workflow
+
+Use this workflow for repository update tasks before reporting completion.
+
+1. Confirm the worktree is clean enough to switch or update:
+
+```powershell
+git status --short --branch
+```
+
+2. Record the pre-update target commit before pull, rebase, or merge.
+
+For updating the current branch:
+
+```powershell
+$oldHead = git rev-parse HEAD
+```
+
+For switching to `main` and pulling, record `main` before updating it:
+
+```powershell
+$oldHead = git rev-parse main
+git checkout main
+```
+
+3. Perform the requested Git operation. Prefer non-interactive commands such as:
+
+```powershell
+git pull --ff-only origin main
+git rebase origin/main
+```
+
+4. Record the ending commit and inspect changed pack metadata paths:
+
+```powershell
+$newHead = git rev-parse HEAD
+git diff --name-only $oldHead $newHead -- mods resourcepacks shaderpacks packwiz-files
+```
+
+5. If any changed file is under `packwiz-files/` or ends with `.pw.toml` under `mods/`, `resourcepacks/`, or `shaderpacks/`, run:
+
+```powershell
+./scripts/sync-packwiz-assets.ps1
+```
+
+6. If `CDC-mod-src` changed or `git status` reports the submodule modified after update, run:
+
+```powershell
+git submodule update --init --recursive
+```
+
+7. Finish with:
+
+```powershell
+git status --short --branch
+```
+
+Report whether packwiz sync was required, whether it succeeded, and whether the final worktree is clean.
+
+## Notes
+
+- Runtime JARs are local development payloads and are normally not tracked.
+- Do not commit local sync side effects unless they are intentional source changes.
+- If sync leaves tracked config changes, inspect them before deciding whether to keep or restore them.

--- a/.agents/skills/repo-sync/agents/openai.yaml
+++ b/.agents/skills/repo-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repo Sync"
+  short_description: "Sync packwiz assets after Git updates"
+  default_prompt: "Use $repo-sync to pull or rebase this repository and sync packwiz assets when metadata changes."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ CD-master-dev/
 - To add/update/remove mods/resourcepacks/shaderpacks: use `scripts/update-packwiz-meta.ps1 -Category ...` (NOT manual asset placement)
 - On `main`, remove a mod by deleting `mods/*.pw.toml`, not synced runtime JARs, because JARs are local development payloads.
 - To sync all mod JARs locally for development: use `scripts/sync-packwiz-assets.ps1`
-- After pulling mod metadata or `packwiz-files` changes, run `scripts/sync-packwiz-assets.ps1` before launching because Git hooks are local and runtime JARs are not tracked.
+- After any pull/rebase/merge, compare pre-update target commit..new HEAD; if `mods|resourcepacks|shaderpacks/**/*.pw.toml` or `packwiz-files/**` changed, run `scripts/sync-packwiz-assets.ps1` because runtime JARs are local.
 - `pack.toml`/`index.toml` are generated from `modpack.toml`; don't commit them
 - `CDC-mod-src/` is a git submodule and must stay out of Packwiz artifacts because packages ship pack files, not Java source trees
 - For CDC artifact updates, use matching CF metadata when published; otherwise put the dev JAR in `packwiz-files/mods/`, update `mods/create-delight-core.pw.toml`, and align the `CDC-mod-src/` submodule pointer


### PR DESCRIPTION
## 内容
- 收紧 AGENTS.md 中 pull/rebase/merge 后的 packwiz sync 规则，要求比较更新前后提交
- 新增 `.agents/skills/repo-sync`，让“拉最新 / rebase main / 更新分支”等任务触发完整同步流程

## 验证
- `python C:/Users/wanquan/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/repo-sync`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/validate-knowledge-base.ps1`（通过；保留既有 release guidance 重复警告）
- `git diff --check`