### PR TITLE
add config to prevent minimap override FPS show

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -86,3 +86,4 @@ xaerominimap_entities.json
 !/MouseTweaks.cfg
 !/fluidlogistics-common.toml
 !/createredstonelinkgui-client.toml
+!/xaerominimap.txt

--- a/config/xaerominimap.txt
+++ b/config/xaerominimap.txt
@@ -1,0 +1,1 @@
+module;id=xaerominimap:minimap;fromRight=true; # prevent override Embeddium's show FPS


### PR DESCRIPTION
Try fix issue https://github.com/Jasons-impart/Create-Delight-Remake/issues/1889.

Not tested whether CI would apply it correctly.

Just manually add the new file to overrides/config/ in zip and it works.

<img width="1273" height="610" alt="2026-06-26_17-37" src="https://github.com/user-attachments/assets/50d9aa23-8510-4d87-a827-4378a0a6a4ae" />


<img width="1280" height="707" alt="2026-06-26_16-21" src="https://github.com/user-attachments/assets/641127cd-44e8-4b8c-a98b-8ee8c4e15ef7" />
