### PR TITLE
[fix] 避免小地图遮挡 FPS 显示

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -83,3 +83,4 @@ xaerominimap_entities.json
 !/Obscuria
 !/createlazytick-common.toml
 !/MouseTweaks.cfg
+!/xaerominimap.txt

--- a/config/xaerominimap.txt
+++ b/config/xaerominimap.txt
@@ -1,0 +1,1 @@
+module;id=xaerominimap:minimap;fromRight=true; # prevent override Embeddium's show FPS


### PR DESCRIPTION
## 摘要
- 新增 `config/xaerominimap.txt`，将 Xaero 小地图模块锚定到右侧
- 在 `config/.gitignore` 中放行该配置文件

## 验证
- 参考 #1890 补丁确认当前分支缺少同类配置
- 已检查暂存/提交内容仅包含 Xaero 配置修复