### PR TITLE
[fix] 修复 packwiz 同名文件 hash 刷新

### DIFF
--- a/lessons-learned.md
+++ b/lessons-learned.md
@@ -284,3 +284,10 @@ gh pr create --body '... `ad_astra:xxx` ...'
 - **Problem**: `iafdragonfix` disables Ice and Fire dragon cave/roost placed features and re-registers them as structures with its own biome tags, so the pack's Northstar-only dragon placement can be bypassed.
 - **Fix/Lesson**: Override `data/iafdragonfix/tags/worldgen/biome/has_*_dragon_*.json` with `replace: true` and tune `data/iafdragonfix/worldgen/structure_set/*.json`, because Ice and Fire `config/iceandfire/*_dragon*_biomes.json` no longer controls the replacement structures.
 
+## Packwiz-files same-name replacements must compare hashes
+
+**Date**: 2026-06-29
+
+- **Problem**: `scripts/update-packwiz-meta.ps1` skipped raw-URL local assets when the referenced filename still existed, so replacing `packwiz-files` payloads with the same filename left stale `.pw.toml` SHA256 hashes.
+- **Fix/Lesson**: Compare existing `.pw.toml` SHA256 values against same-name local files and refresh packwiz-files metadata on mismatch, because filename presence alone does not prove the payload is current.
+

--- a/mods/create-delight-core.pw.toml
+++ b/mods/create-delight-core.pw.toml
@@ -5,4 +5,4 @@ side = "both"
 [download]
 url = "https://raw.githubusercontent.com/Jasons-impart/Create-Delight-Remake/main/packwiz-files/mods/Create-Delight-Core-1.20.1-dev.jar"
 hash-format = "sha256"
-hash = "8e9328be582ed0104e30146be41df65be48340abd5590c8a917cd7c2a5bda35c"
+hash = "5fb04376bdbd80cb055f17499f049265809b5aca0ca24420e06258c6d9f13989"

--- a/scripts/update-packwiz-meta.ps1
+++ b/scripts/update-packwiz-meta.ps1
@@ -349,6 +349,8 @@ function Parse-PwToml {
     if ($content -match '(?m)^filename\s*=\s*"(.+)"') { $result['Filename'] = $Matches[1] }
     if ($content -match '(?m)^side\s*=\s*"(.+)"')     { $result['Side'] = $Matches[1] }
     if ($content -match '(?m)^url\s*=\s*"(.+)"')      { $result['DownloadUrl'] = $Matches[1] }
+    if ($content -match '(?m)^hash-format\s*=\s*"(.+)"') { $result['HashFormat'] = $Matches[1] }
+    if ($content -match '(?m)^hash\s*=\s*"(.+)"')     { $result['Hash'] = $Matches[1] }
 
     $hasMetadataMode = $content -match 'mode\s*=\s*"metadata:(curseforge|modrinth)"'
     $hasUpdateBlock = $content -match '\[update\.(curseforge|modrinth)\]'
@@ -1074,7 +1076,11 @@ function Add-PackwizFilesMetadata {
     New-Item -ItemType Directory -Force -Path $PackwizFilesCategoryRoot | Out-Null
 
     $packwizFilePath = Join-Path $PackwizFilesCategoryRoot $SourceFilename
-    Copy-Item -LiteralPath $SourcePath -Destination $packwizFilePath -Force
+    $sourceFullPath = [IO.Path]::GetFullPath($SourcePath)
+    $packwizFullPath = [IO.Path]::GetFullPath($packwizFilePath)
+    if (-not [string]::Equals($sourceFullPath, $packwizFullPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Copy-Item -LiteralPath $SourcePath -Destination $packwizFilePath -Force
+    }
 
     if (-not $DisplayName) {
         $DisplayName = Get-DisplayNameFromSource -Filename $SourceFilename -JarMetadata $JarMetadata
@@ -1157,6 +1163,59 @@ file-id = $($releaseIdentity.FileId)
 
     Write-Utf8NoBomFile -Path $PwTomlPath -Content $newContent
     return $true
+}
+
+function Get-PackwizFilesReleaseCurseForgeContent {
+    param([string]$PwTomlPath)
+
+    if (-not (Test-Path $PwTomlPath)) { return $null }
+
+    $content = Get-Content -LiteralPath $PwTomlPath -Raw
+    if ($content -match '(?ms)\[release\.curseforge\].*') {
+        return $Matches[0]
+    }
+
+    return $null
+}
+
+function Get-LocalMetadataHashRefresh {
+    param(
+        [pscustomobject]$Entry,
+        [hashtable]$SourceFiles,
+        [hashtable]$PackwizFiles
+    )
+
+    if ($Entry.IsManaged) { return $null }
+
+    $filename = $Entry.Filename
+    if (-not $filename) { return $null }
+
+    $downloadUrl = Get-TomlVal -Data $Entry.Data -Key 'DownloadUrl'
+    if (-not (Test-PackwizFilesRawUrl -Url $downloadUrl)) { return $null }
+
+    $hashFormat = Get-TomlVal -Data $Entry.Data -Key 'HashFormat'
+    if ($hashFormat -and $hashFormat -ne "sha256") { return $null }
+
+    $existingHash = Get-TomlVal -Data $Entry.Data -Key 'Hash'
+    if ([string]::IsNullOrWhiteSpace($existingHash)) { return $null }
+    $existingHash = $existingHash.ToLowerInvariant()
+
+    $candidatePaths = @()
+    if ($SourceFiles.ContainsKey($filename)) {
+        $candidatePaths += $SourceFiles[$filename]
+    }
+    if ($PackwizFiles.ContainsKey($filename)) {
+        $candidatePaths += $PackwizFiles[$filename]
+    }
+
+    foreach ($candidatePath in $candidatePaths) {
+        $actualHash = (Get-FileHash -LiteralPath $candidatePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualHash -ne $existingHash) {
+            return $candidatePath
+        }
+    }
+
+    return $null
 }
 
 function Remove-PackwizFilesAssetIfOwned {
@@ -1343,6 +1402,16 @@ try {
     foreach ($entry in $pwEntries) {
         $currentFilename = $entry.Filename
         if (-not $currentFilename) { continue }
+        $hashRefreshSourcePath = Get-LocalMetadataHashRefresh -Entry $entry -SourceFiles $sourceFiles -PackwizFiles $packwizFiles
+        if ($hashRefreshSourcePath) {
+            $localUpdates += [pscustomobject]@{
+                Entry = $entry
+                OldFilename = $currentFilename
+                NewFilename = $currentFilename
+                SourcePath = $hashRefreshSourcePath
+            }
+            continue
+        }
         if ($sourceFiles.ContainsKey($currentFilename)) { continue }
         if ($packwizFiles.ContainsKey($currentFilename)) { continue }
         if ($entry.IsManaged) { continue }
@@ -1372,6 +1441,7 @@ try {
                 Entry = $entry
                 OldFilename = $currentFilename
                 NewFilename = $newFilename
+                SourcePath = $sourceFiles[$newFilename]
             }
         }
     }
@@ -1459,7 +1529,7 @@ try {
 
     foreach ($update in $localUpdates) {
         $entry = $update.Entry
-        $sourcePath = $sourceFiles[$update.NewFilename]
+        $sourcePath = $update.SourcePath
         $jarMetadata = Get-JarMetadata -Path $sourcePath
         $displayName = $entry.Name
         if (-not $displayName) {
@@ -1468,7 +1538,7 @@ try {
 
         $candidates = @(Get-CurseForgeCandidates -Filename $update.NewFilename -JarMetadata $jarMetadata)
         $cfMetadata = $null
-        $releaseCurseForgeContent = $null
+        $releaseCurseForgeContent = Get-PackwizFilesReleaseCurseForgeContent -PwTomlPath $entry.PwTomlPath
         if ($candidates.Count -gt 0) {
             $cfMetadata = Try-ResolveCurseForgeMetadata -SourcePath $sourcePath -SourceFilename $update.NewFilename -Candidates $candidates -Category $Category
         }


### PR DESCRIPTION
## 概要

- 修复 scripts/update-packwiz-meta.ps1 对同名替换的 packwiz-files payload 不刷新 SHA256 的问题
- 直接替换 packwiz-files 中同名文件时跳过自复制，只重算 hash 并写回 metadata
- 更新 mods/create-delight-core.pw.toml 的 CDC dev jar hash，并补充 lessons-learned 记录

## 验证

- PowerShell 脚本语法解析通过
- 已确认 mods/create-delight-core.pw.toml hash 与 packwiz-files/mods/Create-Delight-Core-1.20.1-dev.jar 实际 SHA256 一致
- 已用临时函数级测试验证同名 payload hash 变化会触发 metadata 刷新