### PR TITLE
[fix] 修正 Alex 洞穴提示并补充知识库

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,9 @@ CD-master-dev-048x/
 ├── tacz/             # TACZ gunpacks and gun data
 ├── hotai/            # HotAI patch data
 ├── ldlib/            # Multiblocked/LDLib assets and machine definitions
-├── mods/             # Mod jars managed by packwiz/release process
-├── resourcepacks/    # Bundled resource packs
-├── shaderpacks/      # Bundled shader packs
+├── mods/             # Packwiz-managed mod jars
+├── resourcepacks/    # Packwiz-managed bundled resource packs
+├── shaderpacks/      # Packwiz-managed bundled shader packs
 ├── .github/          # Release workflows and helper scripts
 ├── pack.toml         # Pack metadata and only version source
 └── index.toml        # Packwiz generated index
@@ -74,7 +74,8 @@ CD-master-dev-048x/
 - Commit style follows Conventional Commits loosely: `[fix]`, `[feat]`, `[mod]`, `[dev]`, `[conf]`, `[quest]`.
 - PR titles and descriptions should be written in Chinese unless the user explicitly requests another language.
 - Formal release flow is documented in `DevGuide.md`; GitHub Actions build test artifacts from `test-client`, `test-server`, and `test-patch`.
-- Do not overwrite `index.toml`; run `packwiz refresh` after tracked file changes that need index updates.
+- Packwiz only manages `mods/`, `resourcepacks/`, and `shaderpacks/`; only run `packwiz refresh` for changes in those areas.
+- Do not overwrite `index.toml`; KubeJS, config, docs, lang, and other ordinary repo changes should not trigger `packwiz refresh`.
 - Avoid destructive bulk deletes in `config/`, `defaultconfigs/`, `kubejs/`, `mods/`, `hotai/`, `ldlib/`, `PCL/`, and `tacz/`.
 
 ## COMMANDS

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -56,6 +56,12 @@ Historical project knowledge: non-obvious bugs, release pitfalls, and workflow d
 
 **Lesson**: Treat `pack.toml` as the only version source; release automation should derive other versioned outputs.
 
+## Packwiz Scope
+
+**Problem**: Running `packwiz refresh` after ordinary repo changes can rewrite `index.toml` and accidentally index local instance files.
+
+**Lesson**: Packwiz-managed resources are limited to `mods/`, `resourcepacks/`, and `shaderpacks/`; do not refresh for KubeJS, config, docs, lang, or other non-packwiz changes.
+
 ## PowerShell Here-Doc Pitfall
 
 **Problem**: Bash-style `<<EOF` heredocs do not work in PowerShell.

--- a/kubejs/AGENTS.md
+++ b/kubejs/AGENTS.md
@@ -17,6 +17,7 @@ For cross-module conventions, release notes, and safety rules, see root `AGENTS.
 | Selling/procurement logic | `startup_scripts/custom/procurement.js` and `server_scripts/mbd2/sell_bin.js` |
 | Custom textures/lang/models | `assets/{namespace}/` |
 | OEI item replacements | `data/oei/replacements/` |
+| Alex's Caves placement | `startup_scripts/custom_portal.js`, `data/createdelight/dimension/`, `data/northstar/dimension/`, `../config/alexscaves_biome_generation/` |
 | Shared helpers | `server_scripts/util/` and `server_scripts/mbd2_recipes/proxy_recipe/` |
 
 ## SEARCH PITFALLS
@@ -55,6 +56,13 @@ Other helpers: `util/metallurgy.js`, `util/ratatouille.js`, `util/loot.js`, `uti
 - Common ingredients should use the `quality_food:material_whitelist` tag when they should be accepted by value and procurement systems.
 - `ValueBlackList` excludes items from value assignment; do not use zero value as a substitute for exclusion.
 - Client price tooltip logic is in `client_scripts/tool_tip.js`.
+
+## ALEX'S CAVES PLACEMENT
+
+- Vanilla Alex's Caves biome generation is disabled in `../config/alexscaves_biome_generation/*.json`; do not infer current placement from those `dimensions` arrays alone.
+- Independent cave dimensions are defined in `data/createdelight/dimension/`: abyssal chasm, primordial caves, forlorn hollows, and candy cavity. Their portal entry rules are in `startup_scripts/custom_portal.js`.
+- Planet-embedded cave biomes are added to Northstar dimension biome sources: magnetic caves in `data/northstar/dimension/moon.json`, and toxic caves in `data/northstar/dimension/venus.json`.
+- When updating tips, quests, or access instructions, check the dimension JSON and Northstar planet JSON first. `server_scripts/Alex's Cave/Biology.js` only blocks non-Alex monster spawns and may contain stale dimension IDs.
 
 ## COMMANDS
 

--- a/kubejs/assets/createdelight/lang/zh_cn.json
+++ b/kubejs/assets/createdelight/lang/zh_cn.json
@@ -649,7 +649,7 @@
     "createdelight.tip.dragon_spawn": "火龙在火星、水星与金星，电龙在金星，冰龙在火星山峰与高地。",
     "createdelight.tip.dread_update_smithing_template": "悚怖锻造模板可以在悚陵中的\"悚怖女皇\"所在层数的四个箱子中获取。",
     "createdelight.tip.ender_reverb": "附近有小黑时被传送？看看你手上的工具有没有用末地烛作手柄。",
-    "createdelight.tip.enter_alexscaves_dimension": "alex的每个洞穴都被分别放到了一个维度中, 进入方法请参见任务。",
+    "createdelight.tip.enter_alexscaves_dimension": "Alex洞穴中，磁力洞穴与剧毒洞穴在星球上，具体位置详见任务书；其余洞穴为独立维度。",
     "createdelight.tip.fasten_letios_compost": "将忘魂肥料放在灵魂沙峡谷会加速其忘却速度。",
     "createdelight.tip.faucet": "水龙头搭配水源方块能够提供取之不尽的水。这在搭建锅炉时会很有用!",
     "createdelight.tip.forged_ruin_collect": "你需要使用精准采集的锤子才能将锻造仪器的东西带走。",


### PR DESCRIPTION
## 概述

- 修正 Alex 洞穴提示，说明磁力洞穴与剧毒洞穴在星球上，其余洞穴为独立维度
- 记录 Alex 洞穴放置相关代码位置
- 记录 Packwiz 仅管理 mods/resourcepacks/shaderpacks 的范围，避免普通资源改动误刷索引

## 验证

- 已用 PowerShell `ConvertFrom-Json` 校验 `zh_cn.json`
- 已运行 `git diff --check`
