### PR TITLE
[conf] 关闭懒惰刻配方缓存

### DIFF
--- a/config/createlazytick-common.toml
+++ b/config/createlazytick-common.toml
@@ -70,7 +70,7 @@
 	#
 	#--------------------------------------------------------------------------
 	#Whether to enable item drain lazy tick
-	enable_lazy_item_drain = true
+	enable_lazy_item_drain = false
 	#
 	#--------------------------------------------------------------------------
 	#max delay tick if something stuck on the item drain

--- a/config/createlazytick-common.toml
+++ b/config/createlazytick-common.toml
@@ -70,7 +70,7 @@
 	#
 	#--------------------------------------------------------------------------
 	#Whether to enable item drain lazy tick
-	enable_lazy_item_drain = false
+	enable_lazy_item_drain = true
 	#
 	#--------------------------------------------------------------------------
 	#max delay tick if something stuck on the item drain

--- a/config/createlazytick-common.toml
+++ b/config/createlazytick-common.toml
@@ -57,7 +57,7 @@
 	#
 	#--------------------------------------------------------------------------
 	#Whether to enable saw cache to improve efficiency of finding recipes
-	enable_cache_saw = true
+	enable_cache_saw = false
 	#
 	#--------------------------------------------------------------------------
 	#max cache count for each saw
@@ -66,7 +66,7 @@
 	#
 	#--------------------------------------------------------------------------
 	#Whether to enable basin lazy tick by cached recipes(Influence on mechanical mixer and mechanical press)
-	enable_lazy_basin = true
+	enable_lazy_basin = false
 	#
 	#--------------------------------------------------------------------------
 	#Whether to enable item drain lazy tick
@@ -86,7 +86,7 @@
 	#
 	#--------------------------------------------------------------------------
 	#Whether to enable crafter cache to improve efficiency of finding recipes
-	enable_cache_crafter = true
+	enable_cache_crafter = false
 	#
 	#--------------------------------------------------------------------------
 	#Whether to enable crafter debugger to show cache stats.
@@ -142,4 +142,3 @@
 	#The max delay tick for blocks in the 'Weak Lazy' list.
 	#Range: > 1
 	arm_weak_delay_max = 10
-


### PR DESCRIPTION
## 变更内容
- 关闭 Create: LazyTick 的锯、盆和机械合成器配方缓存相关开关
- 保持物品排液口懒惰刻开关不变
- 保持模组 JAR 不变，当前 2.4.9-6.0.x 已是 1.20.1 Forge / Create 6.0.x 对应最新版本

## 验证
- git diff --check -- config/createlazytick-common.toml