### PR TITLE
[dev] 优化 Packwiz Git hook 安装流程

### DIFF
--- a/scripts/.githooks/post-checkout
+++ b/scripts/.githooks/post-checkout
@@ -3,10 +3,13 @@ if [ "$3" != "1" ]; then
   exit 0
 fi
 
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
+
 if command -v pwsh >/dev/null 2>&1; then
-  pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-checkout" -OldRev "$1" -NewRev "$2"
+  pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "$repo_root/scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-checkout" -OldRev "$1" -NewRev "$2"
 elif command -v powershell.exe >/dev/null 2>&1; then
-  powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-checkout" -OldRev "$1" -NewRev "$2"
+  powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "$repo_root/scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-checkout" -OldRev "$1" -NewRev "$2"
 else
   printf >&2 "%s\n" "PowerShell 7 was not found; skipping Packwiz runtime asset sync."
 fi

--- a/scripts/.githooks/post-merge
+++ b/scripts/.githooks/post-merge
@@ -1,8 +1,11 @@
 #!/bin/sh
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
+
 if command -v pwsh >/dev/null 2>&1; then
-  pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-merge" -OldRev "ORIG_HEAD" -NewRev "HEAD"
+  pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "$repo_root/scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-merge" -OldRev "ORIG_HEAD" -NewRev "HEAD"
 elif command -v powershell.exe >/dev/null 2>&1; then
-  powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-merge" -OldRev "ORIG_HEAD" -NewRev "HEAD"
+  powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "$repo_root/scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-merge" -OldRev "ORIG_HEAD" -NewRev "HEAD"
 else
   printf >&2 "%s\n" "PowerShell 7 was not found; skipping Packwiz runtime asset sync."
 fi

--- a/scripts/.githooks/post-rewrite
+++ b/scripts/.githooks/post-rewrite
@@ -3,10 +3,13 @@ if [ "$1" != "rebase" ]; then
   exit 0
 fi
 
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
+
 if command -v pwsh >/dev/null 2>&1; then
-  pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-rewrite" -OldRev "ORIG_HEAD" -NewRev "HEAD"
+  pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "$repo_root/scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-rewrite" -OldRev "ORIG_HEAD" -NewRev "HEAD"
 elif command -v powershell.exe >/dev/null 2>&1; then
-  powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-rewrite" -OldRev "ORIG_HEAD" -NewRev "HEAD"
+  powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "$repo_root/scripts/sync-packwiz-assets.ps1" -IfGitChanged -HookName "post-rewrite" -OldRev "ORIG_HEAD" -NewRev "HEAD"
 else
   printf >&2 "%s\n" "PowerShell 7 was not found; skipping Packwiz runtime asset sync."
 fi

--- a/scripts/install-git-hooks.ps1
+++ b/scripts/install-git-hooks.ps1
@@ -74,12 +74,21 @@ function Install-HookShim {
         $existing = Get-Content -LiteralPath $targetHook -Raw -ErrorAction SilentlyContinue
         if ($existing -notmatch [regex]::Escape($marker)) {
             if (Test-Path -LiteralPath $localHook) {
-                Write-InstallMessage "Skipped $Name because $targetHook is custom and $localHook already exists."
-                return
-            }
+                $timestamp = Get-Date -Format "yyyyMMddHHmmss"
+                $backupHook = Join-Path $gitHooksPath "$Name.local.$timestamp"
+                $suffix = 1
+                while (Test-Path -LiteralPath $backupHook) {
+                    $backupHook = Join-Path $gitHooksPath "$Name.local.$timestamp.$suffix"
+                    $suffix++
+                }
 
-            Move-Item -LiteralPath $targetHook -Destination $localHook
-            Write-InstallMessage "Preserved existing $Name as $Name.local"
+                Move-Item -LiteralPath $targetHook -Destination $backupHook
+                Write-InstallMessage "Preserved existing $Name as $(Split-Path $backupHook -Leaf)"
+            }
+            else {
+                Move-Item -LiteralPath $targetHook -Destination $localHook
+                Write-InstallMessage "Preserved existing $Name as $Name.local"
+            }
         }
     }
 
@@ -87,12 +96,14 @@ function Install-HookShim {
 #!/bin/sh
 # $marker. Edit scripts/.githooks/$Name for project behavior.
 hook_dir=`$(dirname "`$0")
-local_hook="`$hook_dir/$Name.local"
-if [ -x "`$local_hook" ]; then
-  "`$local_hook" "`$@" || exit `$?
-elif [ -f "`$local_hook" ]; then
-  sh "`$local_hook" "`$@" || exit `$?
-fi
+for local_hook in "`$hook_dir/$Name.local" "`$hook_dir/$Name.local."*; do
+  [ -e "`$local_hook" ] || continue
+  if [ -x "`$local_hook" ]; then
+    "`$local_hook" "`$@" || exit `$?
+  elif [ -f "`$local_hook" ]; then
+    sh "`$local_hook" "`$@" || exit `$?
+  fi
+done
 
 repo_root=`$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 tracked_hook="`$repo_root/scripts/.githooks/$Name"


### PR DESCRIPTION
## 变更内容
- 优化 Packwiz Git hook 安装脚本，已有本地 hook 会保留为 `.local` 或带时间戳备份。
- `.git/hooks` shim 会串联本地 hook 备份，再调用仓库内 `scripts/.githooks`。
- tracked hook 使用仓库绝对路径调用 `sync-packwiz-assets.ps1 -IfGitChanged`，减少对 Git hook 当前目录的依赖。

## 验证
- `./scripts/install-git-hooks.ps1` 连续运行两次
- `git hook run post-checkout --ignore-missing -- HEAD HEAD 1`
- `./scripts/sync-packwiz-assets.ps1 -IfGitChanged -HookName test-noop -OldRev HEAD -NewRev HEAD -DryRun`
- 历史 Packwiz 变更 dry run 命中检查
- `./scripts/validate-knowledge-base.ps1`
- `git diff --check`
