### PR TITLE
修复北极星锌矿粉碎产物错误

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -98,6 +98,12 @@ Historical project knowledge: non-obvious bugs, release pitfalls, and workflow d
 
 **Lesson**: Restore the original release branch with quiet git commands, check `$LASTEXITCODE`, and only throw when the command really failed.
 
+## Northstar Zinc Ore Crushing Variants
+
+**Problem**: Northstar 0.5.4 has eight zinc ore crushing IDs across Moon, Mars, Mercury, and Venus, and each ordinary/deep variant can output iron ingots if only the sample ID is checked.
+
+**Lesson**: Enumerate `data/northstar/recipes/crushing/*zinc*_ore.json` from the active Northstar jar and override every matching ID in KubeJS.
+
 ---
 
 When adding entries, include Problem and Lesson, keep each item short, and remove entries that become common knowledge.

--- a/kubejs/server_scripts/Create Northstar/recipe.js
+++ b/kubejs/server_scripts/Create Northstar/recipe.js
@@ -24,7 +24,15 @@ ServerEvents.recipes(e => {
         "northstar:crafting/titanium_ingot_from_block",
         "northstar:crafting/titanium_nugget_from_ingot",
         "northstar:crafting/titanium_ingot_from_nuggets",
-        "northstar:splashing/crushed_raw_tungsten"
+        "northstar:splashing/crushed_raw_tungsten",
+        "northstar:crushing/mars_deep_zinc_ore",
+        "northstar:crushing/mars_zinc_ore",
+        "northstar:crushing/mercury_deep_zinc_ore",
+        "northstar:crushing/mercury_zinc_ore",
+        "northstar:crushing/moon_deep_zinc_ore",
+        "northstar:crushing/moon_zinc_ore",
+        "northstar:crushing/venus_deep_zinc_ore",
+        "northstar:crushing/venus_zinc_ore"
     ])
     remove_recipes_output(e, [
         "northstar:circuit",
@@ -75,6 +83,29 @@ ServerEvents.recipes(e => {
     e.replaceInput("*", "northstar:hardened_precision_mechanism", "create_sa:heat_engine")
     e.replaceOutput({ id: "northstar:splashing/crushed_raw_tungsten" }, "minecraft:quartz", "minecraft:gold_nugget")
     e.replaceOutput("*", "northstar:raw_titanium_ore", "createdelight:crushed_raw_titanium")
+
+    const northstarZincCrushingFixes = [
+        ["mars_deep_zinc_ore", "mars_deep_stone", 350, 2, 0.25],
+        ["mars_zinc_ore", "mars_stone", 250, 1, 0.75],
+        ["mercury_deep_zinc_ore", "mercury_deep_stone", 350, 2, 0.25],
+        ["mercury_zinc_ore", "mercury_stone", 250, 1, 0.75],
+        ["moon_deep_zinc_ore", "moon_deep_stone", 350, 2, 0.25],
+        ["moon_zinc_ore", "moon_stone", 250, 1, 0.75],
+        ["venus_deep_zinc_ore", "venus_deep_stone", 350, 2, 0.25],
+        ["venus_zinc_ore", "venus_stone", 250, 1, 0.75]
+    ]
+
+    northstarZincCrushingFixes.forEach(([ore, stone, processingTime, primaryCount, bonusChance]) => {
+        create.crushing([
+            Item.of("create:crushed_raw_zinc", primaryCount),
+            Item.of("create:crushed_raw_zinc").withChance(bonusChance),
+            Item.of("create:experience_nugget").withChance(0.75),
+            Item.of(`northstar:${stone}`).withChance(0.125)
+        ], `northstar:${ore}`)
+            .processingTime(processingTime)
+            .id(`northstar:crushing/${ore}`)
+    })
+
     kubejs.shaped('createdelight:electrolyzer', [
         "AEA",
         "BCB",


### PR DESCRIPTION
## 变更
- 移除 Northstar 0.5.4 中 8 个锌矿粉碎原始配方
- 用 KubeJS 按原概率重建为 `create:crushed_raw_zinc` 产物
- 将该类问题的检查经验记录到 `docs/lessons-learned.md`

## 验证
- `node --check "kubejs/server_scripts/Create Northstar/recipe.js"`
- `scripts/validate-knowledge-base.ps1`

Fixes #1943
