### PR TITLE
[conf] 扩展悚陵火星生成群系

### DIFF
--- a/config/iceandfire/mausoleum_biomes.json
+++ b/config/iceandfire/mausoleum_biomes.json
@@ -10,6 +10,13 @@
     [
       {
         "type": "REGISTRY_NAME",
+        "negate": false,
+        "value": "northstar:martian_highlands"
+      }
+    ],
+    [
+      {
+        "type": "REGISTRY_NAME",
         "negate": true,
         "value": "terralith:wintry_lowlands"
       }

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -9,6 +9,7 @@ Use one file per implementation topic, for example:
 - `tetra-material-edits.md`
 - `custom-loot-and-tags.md`
 - `resource-overlays.md`
+- `worldgen-structure-edits.md`
 
 ## Template
 

--- a/docs/technical/worldgen-structure-edits.md
+++ b/docs/technical/worldgen-structure-edits.md
@@ -1,0 +1,40 @@
+# Worldgen Structure Edits
+
+## Use When
+
+Use this reference when changing structure generation, biome allowlists, or modded structure replacements.
+
+## Approach
+
+Check whether the active structure is the original mod structure or a replacement from another structure mod before editing biome config.
+
+For Ice and Fire mausoleums, IDAS currently replaces the active player-facing target:
+
+- `config/idas.toml` has `"Disable Ice and Fire Structures" = true`.
+- With that flag enabled, IDAS disables `iceandfire:mausoleum`, `iceandfire:gorgon_temple`, and `iceandfire:graveyard`.
+- IDAS directs players from `iceandfire:mausoleum` to `idas:iceandfire/dread_citadel`.
+- These two structures do not share biome config.
+
+## Reference Implementations
+
+- `config/iceandfire/mausoleum_biomes.json`
+- `kubejs/data/idas/tags/worldgen/biome/has_structure/dread_citadel_biomes.json`
+- `config/idas.toml`
+
+## Steps
+
+1. Confirm the structure ID players or quests actually locate.
+2. For current Dread Citadel generation, edit `kubejs/data/idas/tags/worldgen/biome/has_structure/dread_citadel_biomes.json`.
+3. Keep `config/iceandfire/mausoleum_biomes.json` only as future-proofing in case IDAS is removed or `"Disable Ice and Fire Structures"` is turned off.
+4. If biome expansion is not enough, adjust the relevant structure-set data. IDAS Dread Citadel belongs to the `idas_rare` structure set by default.
+
+## Validation
+
+- Validate edited JSON with a parser.
+- Use `/locate structure idas:iceandfire/dread_citadel` for the active IDAS structure.
+- Use `/locate structure iceandfire:mausoleum` only when IDAS no longer disables Ice and Fire structures.
+
+## Notes
+
+- Expanding `config/iceandfire/mausoleum_biomes.json` does not affect `idas:iceandfire/dread_citadel`.
+- Expanding `dread_citadel_biomes.json` does not affect the original `iceandfire:mausoleum`.

--- a/kubejs/data/idas/tags/worldgen/biome/has_structure/dread_citadel_biomes.json
+++ b/kubejs/data/idas/tags/worldgen/biome/has_structure/dread_citadel_biomes.json
@@ -4,6 +4,10 @@
     {
       "id": "northstar:martian_peaks",
       "required": false
+    },
+    {
+      "id": "northstar:martian_highlands",
+      "required": false
     }
   ]
 }


### PR DESCRIPTION
## 变更内容
- 将 IDAS 悚陵 `idas:iceandfire/dread_citadel` 的生成群系扩展到 `northstar:martian_highlands`
- 保留并同步原版 `iceandfire:mausoleum` 的火星高地配置，作为未来移除 IDAS 或关闭替换时的备用规则
- 新增结构生成技术说明，记录 Ice and Fire 原版陵墓与 IDAS 悚陵的配置边界

## 验证
- 已用 JSON 解析校验相关配置文件
- 已检查 staged diff