### PR TITLE
移除重复的发射器配方

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -431,3 +431,10 @@ gh pr create --body '... `ad_astra:xxx` ...'
 
 - **Problem**: QFF treated the third boolean in `KegBlockEntity#fluidExtract(ItemStack, int, boolean, boolean)` as `simulate`, so the GUI path (`extractInGui` passes `true`) skipped quality post-processing while right-click extraction worked.
 - **Fix/Lesson**: Treat that boolean as the in-GUI path flag and still apply tank/container quality on return; only actual `IFluidHandler.FluidAction.SIMULATE` calls should be skipped.
+
+## Terralith dispenser_alt already covers the vanilla dispenser recipe
+
+**Date**: 2026-07-12
+
+- **Problem**: `terralith:dispenser_alt` outputs `minecraft:dispenser` with `#minecraft:stone_crafting_materials`; the vanilla tag already contains `minecraft:cobblestone`, and Terralith appends extra stone variants with `replace: false`, so keeping `minecraft:dispenser` leaves duplicate recipes.
+- **Fix/Lesson**: Remove the vanilla `minecraft:dispenser` recipe ID in KubeJS and keep Terralith's broader recipe.

--- a/kubejs/server_scripts/Custom/remove.js
+++ b/kubejs/server_scripts/Custom/remove.js
@@ -3,6 +3,7 @@ ServerEvents.recipes(e => {
         "create:crafting/materials/rose_quartz",
         "createmetallurgy:belt_grinder",
         "createmetallurgy:sandpaper_belt",
+        "minecraft:dispenser",
         "torchmaster:frozen_pearl",
         "torchmaster:feral_flare_lantern"
     ])


### PR DESCRIPTION
## 变更内容
- 移除原版 `minecraft:dispenser` 配方，保留 Terralith 的 `terralith:dispenser_alt` 扩展配方
- 记录 `#minecraft:stone_crafting_materials` 已包含圆石导致配方重复的经验

## 验证
- `node --check kubejs/server_scripts/Custom/remove.js`
- `scripts/validate-knowledge-base.ps1` 未通过：存在既有 `CDC-mod-src/AGENTS.md` 行数超限和 release workflow 重复警告
