### PR TITLE
[mod] 更新 ZSTDNET 至 1.4.7 与 TrueUUID 至 1.1.2

### DIFF
--- a/.agents/skills/packwiz-assets/SKILL.md
+++ b/.agents/skills/packwiz-assets/SKILL.md
@@ -26,6 +26,12 @@ Use this workflow for modpack asset operations that touch `mods/`, `resourcepack
 4. Inspect the generated `.pw.toml` plus `packwiz-files` changes before staging.
 5. Run `./scripts/sync-packwiz-assets.ps1` when local runtime files must match metadata.
 
+### 短期 PR 分支上的 CurseForge 定向更新
+
+1. 不要在仓库根目录直接运行 `packwiz update`，因为 `pack.toml` 和 `index.toml` 是生成文件且通常不存在。
+2. 用 `scripts/generate-packwiz-files.py --source modpack.toml --output-dir <temp>` 生成临时 pack，复制目标 `.pw.toml` 到相同相对路径，再在临时目录运行 `packwiz refresh` 和 `packwiz update <slug> --yes`。
+3. 只把目标 `.pw.toml` 回写仓库，并确认没有生成文件或无关元数据改动后运行 `scripts/sync-packwiz-assets.ps1`。
+
 ## Remove Assets
 
 1. On `main`, remove an asset by deleting its `.pw.toml` metadata.

--- a/mods/trueuuid.pw.toml
+++ b/mods/trueuuid.pw.toml
@@ -1,13 +1,13 @@
-name = "trueuuid"
-filename = "trueuuid-1.0.9-forge1.20.1.jar"
+name = "TrueUUID"
+filename = "trueuuid-1.1.2-forge1.20.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "3673e1f824d825cc09a363e3b29ffc48d136d3bb"
+hash = "683ce839e5b537318ab1a9ee1da4f906be4fb542"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8152309
+file-id = 8422478
 project-id = 1539688

--- a/mods/zstdnet.pw.toml
+++ b/mods/zstdnet.pw.toml
@@ -1,13 +1,13 @@
 name = "ZSTDNET"
-filename = "zstdnet-1.20.1-forge-1.4.5.jar"
+filename = "zstdnet-1.20.1-forge-1.4.7.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "baf23674bcb75967ac6f141206e3dae77523a3c3"
+hash = "68f97118c6a71333f2e131ab0a99fd8a4ed73a64"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8327561
+file-id = 8443118
 project-id = 1506928


### PR DESCRIPTION
## 变更

- 更新 ZSTDNET Forge 1.20.1：`1.4.5` → `1.4.7`
- 更新 TrueUUID Forge 1.20.1：`1.0.9` → `1.1.2`
- 更新对应 CurseForge file ID 与 SHA-1 元数据
- 补充短期 PR 分支上的 CurseForge 定向更新流程

## 文件信息

- ZSTDNET：CurseForge file ID `8443118`
- TrueUUID：CurseForge file ID `8422478`

## 验证

- Packwiz 定向更新成功解析两个审核文件
- `scripts/sync-packwiz-assets.ps1` 同步成功
- 运行时 JAR SHA-1 与 `.pw.toml` 元数据一致
- 知识库校验未新增失败项；现有 `CDC-mod-src/AGENTS.md` 超行问题仍由上游处理
