### PR TITLE
修复服务端包误包含客户端模组

### DIFF
--- a/.agents/skills/packwiz-assets/SKILL.md
+++ b/.agents/skills/packwiz-assets/SKILL.md
@@ -23,14 +23,15 @@ Use this workflow for modpack asset operations that touch `mods/`, `resourcepack
 1. Put custom or restricted payloads under the matching `packwiz-files/<category>/` directory.
 2. Run `./scripts/update-packwiz-meta.ps1 -Category mods|resourcepacks|shaderpacks` only on `main` or a long-lived LTS/release-maintenance branch.
 3. For slow overseas services, retry once with `-Proxy "http://127.0.0.1:7890"`.
-4. Inspect the generated `.pw.toml` plus `packwiz-files` changes before staging.
+4. Inspect the generated `.pw.toml` plus `packwiz-files` changes before staging, especially that existing `side = "client"` or `side = "server"` entries were not reset to `both`.
 5. Run `./scripts/sync-packwiz-assets.ps1` when local runtime files must match metadata.
 
 ### 短期 PR 分支上的 CurseForge 定向更新
 
 1. 不要在仓库根目录直接运行 `packwiz update`，因为 `pack.toml` 和 `index.toml` 是生成文件且通常不存在。
-2. 用 `scripts/generate-packwiz-files.py --source modpack.toml --output-dir <temp>` 生成临时 pack，复制目标 `.pw.toml` 到相同相对路径，再在临时目录运行 `packwiz refresh` 和 `packwiz update <slug> --yes`。
-3. 只把目标 `.pw.toml` 回写仓库，并确认没有生成文件或无关元数据改动后运行 `scripts/sync-packwiz-assets.ps1`。
+2. 运行 `./scripts/update-packwiz-target.ps1 -Category mods|resourcepacks|shaderpacks -Slug <metadata-name>`，或用 `-Path <relative .pw.toml path>` 精确指定目标。
+3. 该脚本会生成临时 pack、只回写目标 `.pw.toml`、保留原始 `side`，并默认运行 `scripts/sync-packwiz-assets.ps1`；仅在明确不需要同步运行态文件时使用 `-SkipSync`，需要无网络预检时使用 `-DryRun`。
+4. 检查 diff，确认没有生成文件、无关元数据改动，且没有把 `client` 或 `server` 退回 `both`。
 
 ## Remove Assets
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -438,3 +438,10 @@ gh pr create --body '... `ad_astra:xxx` ...'
 
 - **Problem**: `terralith:dispenser_alt` outputs `minecraft:dispenser` with `#minecraft:stone_crafting_materials`; the vanilla tag already contains `minecraft:cobblestone`, and Terralith appends extra stone variants with `replace: false`, so keeping `minecraft:dispenser` leaves duplicate recipes.
 - **Fix/Lesson**: Remove the vanilla `minecraft:dispenser` recipe ID in KubeJS and keep Terralith's broader recipe.
+
+## Client-only mods must not enter server artifacts
+
+**Date**: 2026-07-18
+
+- **Problem**: The `v0.5.0.3` server artifact crashed during Forge `CONSTRUCT` because `ExtraHoloPage` loaded `net.minecraft.client.Options` and `ShoulderSurfing` mixed into Create's `ContraptionHandlerClient` on `DEDICATED_SERVER`.
+- **Fix/Lesson**: Mark client-only Packwiz metadata such as `mods/ExtraHoloPage.pw.toml` and `mods/ShoulderSurfing.pw.toml` with `side = "client"` and smoke-test the server artifact until it reaches `Done`.

--- a/mods/ExtraHoloPage.pw.toml
+++ b/mods/ExtraHoloPage.pw.toml
@@ -1,6 +1,6 @@
 name = "ExtraHoloPage"
 filename = "ExtraHoloPage-6.9.0-1.2.16.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/ShoulderSurfing.pw.toml
+++ b/mods/ShoulderSurfing.pw.toml
@@ -1,6 +1,6 @@
 name = "Shoulder Surfing Reloaded"
 filename = "ShoulderSurfing-Forge-1.20.1-5.0.4.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/scripts/update-packwiz-target.ps1
+++ b/scripts/update-packwiz-target.ps1
@@ -1,0 +1,271 @@
+[CmdletBinding(DefaultParameterSetName = "BySlug")]
+param(
+    [Parameter(ParameterSetName = "BySlug")]
+    [ValidateSet("mods", "resourcepacks", "shaderpacks")]
+    [string]$Category = "mods",
+
+    [Parameter(ParameterSetName = "BySlug", Mandatory = $true)]
+    [string]$Slug,
+
+    [Parameter(ParameterSetName = "ByPath", Mandatory = $true)]
+    [string]$Path,
+
+    [string]$PackwizUrl = "https://github.com/Jasons-impart/packwiz/releases/latest/download/packwiz.exe",
+    [string]$Proxy = "",
+    [switch]$SkipSync,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$WorkBaseRoot = Join-Path $RepoRoot ".cache\packwiz-sync\target-update"
+$WorkRoot = Join-Path $WorkBaseRoot ([System.Guid]::NewGuid().ToString("N"))
+$ToolsRoot = Join-Path $RepoRoot ".cache\packwiz-sync\tools"
+$PackwizExe = Join-Path $ToolsRoot "packwiz.exe"
+$GeneratePackwizScript = Join-Path $PSScriptRoot "generate-packwiz-files.py"
+$SyncPackwizAssetsScript = Join-Path $PSScriptRoot "sync-packwiz-assets.ps1"
+
+function Write-Status {
+    param([string]$Message)
+    Write-Host "[target-update] $Message" -ForegroundColor Cyan
+}
+
+function Resolve-PythonCommand {
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if ($pythonCmd) {
+        return $pythonCmd.Source
+    }
+
+    $pythonLauncher = Get-Command py -ErrorAction SilentlyContinue
+    if ($pythonLauncher) {
+        $resolvedPython = & $pythonLauncher.Source -3 -c "import sys; print(sys.executable)"
+        if ($LASTEXITCODE -eq 0 -and $resolvedPython) {
+            return $resolvedPython.Trim()
+        }
+    }
+
+    throw "Python was not found. Install Python so generate-packwiz-files.py can run."
+}
+
+function Ensure-Tool {
+    param(
+        [string]$Url,
+        [string]$Destination
+    )
+
+    if (Test-Path -LiteralPath $Destination) {
+        return
+    }
+
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Destination) | Out-Null
+    Write-Status ("Downloading {0}..." -f (Split-Path -Leaf $Destination))
+    Invoke-WithProxy { Invoke-WebRequest -Uri $Url -OutFile $Destination -UseBasicParsing }
+}
+
+function Write-Utf8NoBomFile {
+    param(
+        [string]$LiteralPath,
+        [string]$Content
+    )
+
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($LiteralPath, $Content, $utf8NoBom)
+}
+
+function Get-RelativeUnixPath {
+    param(
+        [string]$Root,
+        [string]$FilePath
+    )
+
+    $fullRoot = [System.IO.Path]::GetFullPath($Root)
+    $fullPath = [System.IO.Path]::GetFullPath($FilePath)
+    $rootWithSlash = $fullRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    if (-not $fullPath.StartsWith($rootWithSlash, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Path '$FilePath' is outside repo root '$Root'."
+    }
+
+    return $fullPath.Substring($rootWithSlash.Length).Replace('\', '/')
+}
+
+function Get-PwTomlValue {
+    param(
+        [string]$Content,
+        [string]$Key
+    )
+
+    $pattern = '(?m)^{0}\s*=\s*"([^"]*)"\s*$' -f [regex]::Escape($Key)
+    if ($Content -match $pattern) {
+        return $Matches[1]
+    }
+    return $null
+}
+
+function Normalize-PwSide {
+    param([string]$Side)
+
+    if ([string]::IsNullOrWhiteSpace($Side)) { return "both" }
+    $normalized = $Side.Trim().ToLowerInvariant()
+    if (@("both", "client", "server") -contains $normalized) { return $normalized }
+    return "both"
+}
+
+function Set-PwTomlSide {
+    param(
+        [string]$Content,
+        [string]$Side
+    )
+
+    $sideValue = Normalize-PwSide -Side $Side
+    if ($Content -match '(?m)^side\s*=\s*".*"$') {
+        return [regex]::Replace($Content, '(?m)^side\s*=\s*".*"$', "side = `"$sideValue`"", 1)
+    }
+    if ($Content -match '(?m)^filename\s*=') {
+        return [regex]::Replace($Content, '(?m)^(filename\s*=\s*".*"\s*)$', "`$1`nside = `"$sideValue`"", 1)
+    }
+    return "side = `"$sideValue`"`n$Content"
+}
+
+function Invoke-WithProxy {
+    param(
+        [scriptblock]$Script
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Proxy)) {
+        return & $Script
+    }
+
+    $oldHttpProxy = $env:HTTP_PROXY
+    $oldHttpsProxy = $env:HTTPS_PROXY
+    $oldAllProxy = $env:ALL_PROXY
+    try {
+        $env:HTTP_PROXY = $Proxy
+        $env:HTTPS_PROXY = $Proxy
+        $env:ALL_PROXY = $Proxy
+        return & $Script
+    }
+    finally {
+        $env:HTTP_PROXY = $oldHttpProxy
+        $env:HTTPS_PROXY = $oldHttpsProxy
+        $env:ALL_PROXY = $oldAllProxy
+    }
+}
+
+function Invoke-GeneratePackwizFiles {
+    param([string]$OutputDir)
+
+    $pythonExe = Resolve-PythonCommand
+    & $pythonExe $GeneratePackwizScript --source (Join-Path $RepoRoot "modpack.toml") --output-dir $OutputDir
+    if ($LASTEXITCODE -ne 0) {
+        throw "generate-packwiz-files.py exited with code $LASTEXITCODE."
+    }
+}
+
+function Invoke-Packwiz {
+    param(
+        [string[]]$Arguments,
+        [string]$WorkingDirectory
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        Invoke-WithProxy { & $PackwizExe @Arguments }
+        if ($LASTEXITCODE -ne 0) {
+            throw "packwiz $($Arguments -join ' ') exited with code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Resolve-TargetPath {
+    if ($PSCmdlet.ParameterSetName -eq "ByPath") {
+        $candidate = if ([System.IO.Path]::IsPathRooted($Path)) {
+            $Path
+        }
+        else {
+            Join-Path $RepoRoot $Path
+        }
+
+        if (-not (Test-Path -LiteralPath $candidate)) {
+            throw "Target metadata file was not found: $candidate"
+        }
+        return (Resolve-Path -LiteralPath $candidate).Path
+    }
+
+    $categoryRoot = Join-Path $RepoRoot $Category
+    $candidate = Join-Path $categoryRoot $Slug
+    if (-not $candidate.EndsWith(".pw.toml", [System.StringComparison]::OrdinalIgnoreCase)) {
+        $candidate = Join-Path $categoryRoot "$Slug.pw.toml"
+    }
+
+    if (-not (Test-Path -LiteralPath $candidate)) {
+        throw "Target metadata file was not found: $candidate"
+    }
+    return (Resolve-Path -LiteralPath $candidate).Path
+}
+
+$targetPath = Resolve-TargetPath
+$relativeTargetPath = Get-RelativeUnixPath -Root $RepoRoot -FilePath $targetPath
+$originalContent = Get-Content -LiteralPath $targetPath -Raw
+$originalSide = Normalize-PwSide -Side (Get-PwTomlValue -Content $originalContent -Key "side")
+$updateSlug = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetFileNameWithoutExtension($targetPath))
+
+if ($originalContent -notmatch '(?m)^\[update\.curseforge\]\s*$') {
+    throw "Target metadata is not a CurseForge-managed .pw.toml: $relativeTargetPath"
+}
+
+New-Item -ItemType Directory -Force -Path $WorkRoot | Out-Null
+
+try {
+    Write-Status "Generating temporary packwiz pack..."
+    Invoke-GeneratePackwizFiles -OutputDir $WorkRoot
+
+    $tempTargetPath = Join-Path $WorkRoot $relativeTargetPath
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $tempTargetPath) | Out-Null
+    Copy-Item -LiteralPath $targetPath -Destination $tempTargetPath -Force
+
+    if ($DryRun) {
+        Write-Status "Dry run: would update $relativeTargetPath and preserve side = `"$originalSide`"."
+        return
+    }
+
+    Ensure-Tool -Url $PackwizUrl -Destination $PackwizExe
+
+    Write-Status "Refreshing temporary pack..."
+    Invoke-Packwiz -Arguments @("refresh") -WorkingDirectory $WorkRoot
+
+    Write-Status "Updating $updateSlug..."
+    Invoke-Packwiz -Arguments @("update", $updateSlug, "--yes") -WorkingDirectory $WorkRoot
+
+    if (-not (Test-Path -LiteralPath $tempTargetPath)) {
+        throw "packwiz update did not leave the expected target metadata file: $relativeTargetPath"
+    }
+
+    $updatedContent = Get-Content -LiteralPath $tempTargetPath -Raw
+    $updatedContent = Set-PwTomlSide -Content $updatedContent -Side $originalSide
+    $updatedSide = Normalize-PwSide -Side (Get-PwTomlValue -Content $updatedContent -Key "side")
+    if ($updatedSide -ne $originalSide) {
+        throw "Refusing to write $relativeTargetPath because side changed from '$originalSide' to '$updatedSide'."
+    }
+
+    Write-Utf8NoBomFile -LiteralPath $targetPath -Content $updatedContent
+    Write-Status "Updated $relativeTargetPath and preserved side = `"$originalSide`"."
+}
+finally {
+    if (Test-Path -LiteralPath $WorkRoot) {
+        Remove-Item -LiteralPath $WorkRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if (-not $SkipSync) {
+    Write-Status "Syncing local Packwiz assets..."
+    & $SyncPackwizAssetsScript
+    if ($LASTEXITCODE -ne 0) {
+        throw "sync-packwiz-assets.ps1 exited with code $LASTEXITCODE."
+    }
+}


### PR DESCRIPTION
## 变更内容

- 将 ExtraHoloPage 和 Shoulder Surfing Reloaded 的 Packwiz `side` 恢复为 `client`，避免客户端模组进入服务端产物。
- 新增 `scripts/update-packwiz-target.ps1`，封装短期 PR 分支上的单个 CurseForge `.pw.toml` 定向更新流程，并保留原始 `side`。
- 更新 `packwiz-assets` skill 和 `docs/lessons-learned.md`，记录该类回归的检查点和经验。

## 背景

`v0.5.0.3` 服务端启动时在 Forge `CONSTRUCT` 阶段崩溃，根因是两个客户端模组被打入服务端包。回溯发现它们曾在 #1714/#1726 修正为 `client`，但 #1913 更新模组版本时又被 `packwiz update` 产物重置为 `both`。

## 验证

- `git diff --cached --check`
- `./scripts/update-packwiz-target.ps1 -Path mods/ExtraHoloPage.pw.toml -DryRun -SkipSync`
- `./scripts/update-packwiz-target.ps1 -Category mods -Slug ShoulderSurfing -DryRun -SkipSync`
- 服务端产物 smoke test：移除这两个客户端模组后可启动到 `Done` 并正常 `stop`

## 已知问题

- `scripts/validate-knowledge-base.ps1` 仍因既有知识库问题失败：`CDC-mod-src/AGENTS.md` 88 行超过 80 行限制，并提示 release workflow guidance 重复 warning。
