### PR TITLE
[fix] 规范测试版 -test 标记

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -140,6 +140,21 @@ Note: `-PreviousVersion` is now optional. It auto-detects from the previous git 
 
 Output: Release URL
 
+### Transitional Test Tag Only
+
+For the current one-off transition where the pack version in `modpack.toml` is already correct but the GitHub test release must be discoverable by the README badge, skip Phase 1 and publish a `-test` tag directly from the target branch:
+
+```powershell
+.\.agents\skills\release\release-publish.ps1 `
+    -Version "v0.5.0.4-test" `
+    -TargetBranch "main" `
+    -PreviousVersion "v0.5.0.3" `
+    -ReleaseType "测试" `
+    -Proxy "http://127.0.0.1:7890"
+```
+
+Do not edit generated `pack.toml`. The release workflow uses the `v*-test` tag name for artifact names and release metadata, while `modpack.toml` can remain on the base pack version for this transition only. Do not use this as the long-term release model; future test release prepare PRs should use the `-test` version consistently.
+
 For test releases, publish the same `-test` tag and keep `-ReleaseType "测试"`:
 
 ```powershell

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -50,7 +50,7 @@ git log -1 --name-only | grep modpack.toml
 ### Decision 2: Release Type
 
 - 正式版 → 4 artifacts (Client + ClientPatch + Server + ServerPatch)
-- 测试版 → 2 artifacts (Client + Server only, no patches), no `docs/announcement.md` update
+- 测试版 → 2 artifacts (Client + Server only, no patches), no `docs/announcement.md` update; version/tag must end with `-test` and the GitHub release must be marked prerelease
 
 ### Decision 3: Announcement Content (Stable Only)
 
@@ -101,6 +101,16 @@ When the sub-version's **first stable release** is being published (e.g. v0.4.8.
 
 Output: PR URL
 
+For test releases, pass `-ReleaseType "测试"` and use a `-test` version/tag:
+
+```powershell
+.\.agents\skills\release\release-prepare.ps1 `
+    -Version "v0.4.7.15-test" `
+    -TargetBranch "release-v047x" `
+    -ReleaseType "测试" `
+    -Proxy "http://127.0.0.1:7890"
+```
+
 ### ⚠️ Human Gate: Merge the PR
 
 **Must wait for user to manually merge the PR.** Never auto-merge.
@@ -130,13 +140,24 @@ Note: `-PreviousVersion` is now optional. It auto-detects from the previous git 
 
 Output: Release URL
 
+For test releases, publish the same `-test` tag and keep `-ReleaseType "测试"`:
+
+```powershell
+.\.agents\skills\release\release-publish.ps1 `
+    -Version "v0.4.7.15-test" `
+    -TargetBranch "release-v047x" `
+    -PreviousVersion "v0.4.7.14" `
+    -ReleaseType "测试" `
+    -Proxy "http://127.0.0.1:7890"
+```
+
 ## Script Reference
 
 ### release-prepare.ps1
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `-Version` | ✅ | New version string (e.g. "v0.4.7.15") |
+| `-Version` | ✅ | New version string (e.g. "v0.4.7.15" for stable, "v0.4.7.15-test" for test) |
 | `-TargetBranch` | ✅ | Base branch for PR (e.g. "release-v047x") |
 | `-ReleaseType` | ❌ | "正式" (default) or "测试" |
 | `-Announcement` | ❌ | Comma-separated bullet points for stable `announcement.md` and PR body; for test releases, PR body only. Auto-generated from git log if omitted |
@@ -148,7 +169,7 @@ Output: Release URL
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `-Version` | ✅ | Version tag to create (e.g. "v0.4.7.15") |
+| `-Version` | ✅ | Version tag to create (e.g. "v0.4.7.15" for stable, "v0.4.7.15-test" for test) |
 | `-TargetBranch` | ✅ | Branch to tag on (e.g. "release-v047x") |
 | `-PreviousVersion` | ❌ | Previous version for release notes and patch names (e.g. "v0.4.7.14"). Auto-detected via `git describe --tags --abbrev=0 HEAD^` if omitted |
 | `-ReleaseType` | ❌ | "正式" (default, 4 artifacts) or "测试" (2 artifacts, prerelease) |
@@ -162,7 +183,7 @@ Output: Release URL
 
 Both scripts include:
 
-- **Pre-flight validation**: Checks prerequisites (modpack.toml exists, version format, gh auth, TargetBranch exists on remote, no existing release) before any changes. Fails fast with clear error messages.
+- **Pre-flight validation**: Checks prerequisites (modpack.toml exists, release-type-specific version format, gh auth, TargetBranch exists on remote, no existing release) before any changes. Fails fast with clear error messages.
 - **Dry-run mode**: Pass `-WhatIf` to preview what the script would do without making any changes. Useful for validating parameters.
 - **Idempotency**: Scripts handle re-runs gracefully:
   - Existing tags on the correct commit → skipped

--- a/.agents/skills/release/release-prepare.ps1
+++ b/.agents/skills/release/release-prepare.ps1
@@ -28,7 +28,7 @@
     .\release-prepare.ps1 -Version "v0.4.7.16" -TargetBranch "main" -Announcement "修复BUG,新增物品,优化性能"
 
 .EXAMPLE
-    .\release-prepare.ps1 -Version "v0.4.7.16" -TargetBranch "release-v047x" -ReleaseType 测试 -Proxy "http://127.0.0.1:7890"
+    .\release-prepare.ps1 -Version "v0.4.7.16-test" -TargetBranch "release-v047x" -ReleaseType 测试 -Proxy "http://127.0.0.1:7890"
 #>
 [CmdletBinding()]
 param(
@@ -87,8 +87,10 @@ function Test-Prerequisites {
     }
     
     # Check Version format
-    if ($Version -notmatch '^v\d+\.\d+\.\d+\.\d+$') {
-        $errors += "Version format invalid: '$Version'. Expected format: v0.4.8.10"
+    $expectedVersionPattern = if ($ReleaseType -eq "测试") { '^v\d+\.\d+\.\d+\.\d+-test$' } else { '^v\d+\.\d+\.\d+\.\d+$' }
+    $expectedVersionExample = if ($ReleaseType -eq "测试") { 'v0.4.8.10-test' } else { 'v0.4.8.10' }
+    if ($Version -notmatch $expectedVersionPattern) {
+        $errors += "Version format invalid for $ReleaseType release: '$Version'. Expected format: $expectedVersionExample"
     }
     
     # Check gh CLI available
@@ -193,7 +195,7 @@ if ($StatusOutput) {
 Write-Host "📦 Updating modpack.toml version to $Version"
 try {
     $Content = Get-Content "modpack.toml" -Raw
-    $NewContent = $Content -replace 'version = "v[\d.]+"', "version = `"$Version`""
+    $NewContent = $Content -replace 'version = "v[\d.]+(?:-test)?"', "version = `"$Version`""
     if ($NewContent -eq $Content) {
         Write-Error "Failed to update version in modpack.toml - pattern not matched"
         Restore-State

--- a/.agents/skills/release/release-publish.ps1
+++ b/.agents/skills/release/release-publish.ps1
@@ -38,7 +38,7 @@
     .\release-publish.ps1 -Version v0.4.7.15 -TargetBranch release-v047x
 
 .EXAMPLE
-    .\release-publish.ps1 -Version v0.4.7.15 -TargetBranch release-v047x -PreviousVersion v0.4.7.14 -ReleaseType 测试 -Proxy http://127.0.0.1:7890
+    .\release-publish.ps1 -Version v0.4.7.15-test -TargetBranch release-v047x -PreviousVersion v0.4.7.14 -ReleaseType 测试 -Proxy http://127.0.0.1:7890
 #>
 [CmdletBinding()]
 param(
@@ -82,8 +82,10 @@ function Test-Prerequisites {
     $errors = @()
     
     # Check Version format
-    if ($Version -notmatch '^v\d+\.\d+\.\d+\.\d+$') {
-        $errors += "Version format invalid: '$Version'. Expected format: v0.4.8.10"
+    $expectedVersionPattern = if ($ReleaseType -eq "测试") { '^v\d+\.\d+\.\d+\.\d+-test$' } else { '^v\d+\.\d+\.\d+\.\d+$' }
+    $expectedVersionExample = if ($ReleaseType -eq "测试") { 'v0.4.8.10-test' } else { 'v0.4.8.10' }
+    if ($Version -notmatch $expectedVersionPattern) {
+        $errors += "Version format invalid for $ReleaseType release: '$Version'. Expected format: $expectedVersionExample"
     }
     
     # Check modpack.toml exists
@@ -780,7 +782,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # Filter out version bump commits - only filter the specific format used by prepare script
-$commits = $commits | Where-Object { $_ -notmatch '^\[feat\]\s*v\d[\d.]+\s+(正式版|测试版)版本更新$' }
+$commits = $commits | Where-Object { $_ -notmatch '^\[feat\]\s*v\d[\d.]+(?:-test)?\s+(正式版|测试版)版本更新$' }
 
 # Categorize
 $categories = [ordered]@{

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,9 @@ jobs:
         id: generate_modpack_version
         run: |
           VERSION="${{ steps.read-version.outputs.value }}"
-          if [[ "${{ github.ref_name }}" == *test* ]]; then
+          if [[ "${{ github.ref_type }}" == "tag" && "${{ github.ref_name }}" == *-test ]]; then
+            VERSION="${{ github.ref_name }}"
+          elif [[ "${{ github.ref_name }}" == test-* ]]; then
             VERSION="$VERSION-test-build-${{ github.run_number }}"
           fi
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -247,6 +247,6 @@ A Minecraft 1.20.1 Forge Create & Farmer's Delight modpack
 [issues-url]: https://github.com/Jasons-impart/Create-Delight-Remake/issues
 [qqpd-shield]: https://img.shields.io/badge/QQ频道-pd06113710-12B7F3?style=flat-square
 [release-version-shield]: https://img.shields.io/github/v/release/Jasons-impart/Create-Delight-Remake?label=%E6%AD%A3%E5%BC%8F%E7%89%88%E6%9C%AC&color=2CB3A8
-[test-version-shield]: https://img.shields.io/github/v/release/Jasons-impart/Create-Delight-Remake?include_prereleases&label=%E6%B5%8B%E8%AF%95%E7%89%88%E6%9C%AC&color=yellow
+[test-version-shield]: https://img.shields.io/github/v/release/Jasons-impart/Create-Delight-Remake?include_prereleases&sort=date&filter=*-test&label=%E6%B5%8B%E8%AF%95%E7%89%88%E6%9C%AC&color=yellow
 [license-shield]: https://img.shields.io/github/license/JasdewStarfield/Path-of-Truth.svg?style=flat-square
 [license-url]: https://github.com/Jasons-impart/Create-Delight-Remake/blob/readmeupdate/LICENSE


### PR DESCRIPTION
## 变更内容
- 将 README 测试版 badge 改为只匹配 `*-test` release。
- `release-prepare.ps1` / `release-publish.ps1` 按 `ReleaseType` 校验版本格式：正式版用 `vX.Y.Z.N`，测试版用 `vX.Y.Z.N-test`。
- GitHub Actions 在 `v*-test` tag 触发时直接用 tag 名生成 artifact，避免发布脚本按 release tag 下载 artifact 时名称不一致。
- 更新 release skill，记录测试版必须同时使用 `-test` tag 和 GitHub prerelease 标记。
- 补充当前一次性过渡路径：可跳过 prepare，直接用 `release-publish.ps1 -Version v0.5.0.4-test -TargetBranch main -ReleaseType 测试` 创建测试版 tag/release，不改生成的 `pack.toml`，也不引入长期双版本字段。

## 验证
- `release-prepare.ps1 -Version v0.5.0.999-test -TargetBranch main -ReleaseType 测试 -WhatIf`
- `release-publish.ps1 -Version v0.5.0.999-test -TargetBranch main -PreviousVersion v0.5.0.3 -ReleaseType 测试 -WhatIf`
- `git diff --check`
- PowerShell AST 语法解析通过
- README badge URL 可请求，当前因尚无 `*-test` release 显示 `no matching releases found`

## 已知情况
- `scripts/validate-knowledge-base.ps1` 仍失败于既有 `CDC-mod-src/AGENTS.md` 88 行超过 80 行限制；本 PR 未修改该文件。