### PR TITLE
[conf] 移除默认加载的语言包资源包

### DIFF
--- a/.options.txt
+++ b/.options.txt
@@ -42,7 +42,7 @@ ao:true
 prioritizeChunkUpdates:0
 biomeBlendRadius:2
 renderClouds:"true"
-resourcePacks:["file/Minecraft-Mod-Language-Modpack-Converted-1.20.1.zip","vanilla","tacz_resources","mod_resources","Moonlight Mods Dynamic Assets","file/Squareful v3.15forMC1.20.1.zip","file/Squareful-Create_Delight_Remake.zip","file/XK Highlight Block.zip","netherexp:jne_emissive","netherexp:jne_retextures","file/Torchmaster Remaster.zip","file/LCVP_CreateStyle_v1.7.zip","eclipticseasons.extra_snow","generated/fragmentum_layer"]
+resourcePacks:["vanilla","tacz_resources","mod_resources","Moonlight Mods Dynamic Assets","file/Squareful v3.15forMC1.20.1.zip","file/Squareful-Create_Delight_Remake.zip","file/XK Highlight Block.zip","netherexp:jne_emissive","netherexp:jne_retextures","file/Torchmaster Remaster.zip","file/LCVP_CreateStyle_v1.7.zip","eclipticseasons.extra_snow","generated/fragmentum_layer"]
 incompatibleResourcePacks:["file/Torchmaster Remaster.zip","file/LCVP_CreateStyle_v1.7.zip"]
 lastServer:
 lang:zh_cn


### PR DESCRIPTION
## 变更内容
- 从 `.options.txt` 的 `resourcePacks` 默认加载列表中移除 `Minecraft-Mod-Language-Modpack-Converted-1.20.1.zip`
- 保留其它资源包顺序与 `incompatibleResourcePacks` 配置不变

## 验证
- 已检查 `.options.txt` 中不再出现该资源包条目