### PR TITLE
[dev] 禁止 agent 自行合并 PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ CD-master-dev/
 - PR title/body use Chinese by default because reviewers and release notes are Chinese-first.
 - For multiline PR bodies from PowerShell, use a here-string or `--body-file`; `\n` is literal and renders broken Markdown on GitHub.
 - ❌ Never commit directly on `main`; create a feature branch and merge through PR because remote `main` is protected.
+- ❌ Never merge PRs yourself (`gh pr merge`, GitHub web/API merge, or auto-merge). Create PRs and wait for the user to manually merge unless the user explicitly asks you in the current conversation to merge a specific PR.
 - ❌ Never commit on merged feature branches
 - ❌ Never force push to main
 


### PR DESCRIPTION
## 变更内容

- 在根 `AGENTS.md` 的 Git Workflow 中新增常驻约束：agent 不得自行合并 PR。
- 明确禁止 `gh pr merge`、GitHub web/API merge 和 auto-merge。
- 只有用户在当前对话中明确要求合并某个具体 PR 时，agent 才能执行合并。

## 原因

之前 agent 在没有用户明确授权的情况下合并了 PR。该约束应成为所有 PR 工作流的默认规则，而不是只存在于 release skill。

## 验证

- `AGENTS.md` 行数为 111，低于 150 行限制。
- 已运行 `scripts/validate-knowledge-base.ps1`，但因既有 `CDC-mod-src/AGENTS.md` 行数超限和 release 指南重复告警失败；非本次改动引入。
