### PR TITLE
[fix] 修复受限 CurseForge 模组被打入客户端包

### DIFF
--- a/.agents/skills/packwiz-assets/SKILL.md
+++ b/.agents/skills/packwiz-assets/SKILL.md
@@ -11,6 +11,7 @@ Use this workflow for modpack asset operations that touch `mods/`, `resourcepack
 
 - `mods/`, `resourcepacks/`, and `shaderpacks/` contain `.pw.toml` metadata only; do not track runtime jars there.
 - CF-restricted, manual-download, and custom payloads belong in `packwiz-files/{mods,resourcepacks,shaderpacks}/` with matching raw-URL metadata.
+- For a `packwiz-files` mod that also exists on CurseForge, keep its `[release.curseforge]` project/file hint accurate. Client export must convert these hints to `metadata:curseforge` before best-effort detection; a failed hinted conversion is a release error, not permission to bundle the JAR under `overrides/mods`.
 - Add, update, or remove assets through `scripts/update-packwiz-meta.ps1 -Category ...`; avoid manual metadata edits unless repairing generated output.
 - Do not run `scripts/update-packwiz-meta.ps1` on short-lived feature/PR branches because it derives `packwiz-files` raw URLs from the current branch and can rewrite unrelated `.pw.toml` files to branch URLs that disappear after merge.
 - Branch-derived raw URLs are intended only for `main` and long-lived LTS/release-maintenance branches that must serve their own Packwiz payloads.

--- a/.github/workflows/scripts/normalize_packwiz_files_for_curseforge.sh
+++ b/.github/workflows/scripts/normalize_packwiz_files_for_curseforge.sh
@@ -251,6 +251,39 @@ normalize_packwiz_files_for_category() {
   done < <(find "$dir" -name '*.pw.toml' -print0)
 }
 
+# Mod release hints are authoritative for CurseForge exports. Apply them before
+# copying packwiz-files JARs into mods/ for best-effort detection; otherwise
+# restricted CurseForge files can remain direct downloads and be bundled under
+# overrides/mods by `packwiz curseforge export`.
+normalize_release_hinted_mods() {
+  [ -d "mods" ] || return 0
+  [ -d "packwiz-files/mods" ] || return 0
+
+  local failed=0
+  while IFS= read -r -d '' meta; do
+    grep -Fq 'packwiz-files/mods/' "$meta" || continue
+    grep -Eq '^\[release\.curseforge\][[:space:]]*$' "$meta" || continue
+
+    local filename
+    filename="$(read_filename "$meta")"
+    if [ -z "$filename" ]; then
+      echo "::error::Cannot read filename from release-hinted metadata: $meta"
+      failed=1
+      continue
+    fi
+
+    if write_curseforge_metadata_from_release_hint "$meta" "mods" "$filename"; then
+      echo "Converted release-hinted mod metadata to CurseForge metadata: $meta"
+    else
+      echo "::error::Cannot convert release-hinted mod metadata: $meta"
+      failed=1
+    fi
+  done < <(find mods -name '*.pw.toml' -print0)
+
+  return "$failed"
+}
+
+normalize_release_hinted_mods
 copy_packwiz_file_mods_for_detection
 
 if [ -s "$copied_list" ]; then


### PR DESCRIPTION
## 问题

`[Client]` CurseForge 导出包会把已有 `[release.curseforge]` 提示、但禁止第三方下载的模组 JAR 放入 `overrides/mods`。在 build 423 中，16 个内嵌 JAR 里有 11 个本应通过 CurseForge manifest 分发。

根因是模组只依赖 `packwiz curseforge detect`；现有提示转换函数仅用于资源包和光影包，没有在模组自动检测前使用。

## 修复

- 在复制 `packwiz-files` JAR 和执行自动检测前，强制转换带 `[release.curseforge]` 的模组元数据。
- 提示转换失败时直接终止构建，避免静默回退为 `overrides/mods` 内嵌本体。
- 保留无发布提示的自托管模组原有检测和内嵌行为。
- 在 `packwiz-assets` 技能中记录该发布约束。

## 验证

- `bash -n .github/workflows/scripts/normalize_packwiz_files_for_curseforge.sh`
- 独立回归：15/15 个提示模组成功转换，进入 `curseforge detect` 的提示模组为 0；4 个自托管模组仍进入检测。
- GitHub Actions Client build 424 成功：run 29806094748。
- 用户已检查 build 424 Client 制品，确认结果正常。
- 知识库校验仅剩仓库既有问题：release 指引重复警告、`CDC-mod-src/AGENTS.md` 超过 80 行。
