### PR TITLE
[fix] 移除带宁为玉碎效果的 Tetra 材料

### DIFF
--- a/kubejs/data/createdelight/tags/items/disabled_mmt_fragile_materials.json
+++ b/kubejs/data/createdelight/tags/items/disabled_mmt_fragile_materials.json
@@ -1,0 +1,4 @@
+{
+  "replace": true,
+  "values": []
+}

--- a/kubejs/data/tetra/materials/metal/more_mod_tetra/ae2_silicon.json
+++ b/kubejs/data/tetra/materials/metal/more_mod_tetra/ae2_silicon.json
@@ -1,0 +1,34 @@
+{
+  "replace": true,
+  "key": "ae2_silicon",
+  "category": "misc",
+  "primary": 5,
+  "secondary": 0.5,
+  "tertiary": 0.2,
+  "durability": 200,
+  "integrityCost": 1,
+  "integrityGain": 4,
+  "magicCapacity": 0,
+  "toolLevel": "minecraft:iron",
+  "toolEfficiency": 1,
+  "tints": {
+    "glyph": "726b6e",
+    "texture": "726b6e"
+  },
+  "textures": [
+    "shiny",
+    "crude"
+  ],
+  "material": {
+    "tag": "createdelight:disabled_mmt_fragile_materials"
+  },
+  "requiredTools": {
+    "hammer_dig": "minecraft:wood"
+  },
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "ae2"
+    }
+  ]
+}

--- a/kubejs/data/tetra/materials/metal/more_mod_tetra/glass_shard.json
+++ b/kubejs/data/tetra/materials/metal/more_mod_tetra/glass_shard.json
@@ -1,0 +1,25 @@
+{
+  "replace": true,
+  "key": "glass_shard",
+  "category": "misc",
+  "primary": 2,
+  "secondary": 1,
+  "tertiary": 0.5,
+  "durability": 150,
+  "integrityCost": 1,
+  "integrityGain": 4,
+  "magicCapacity": 0,
+  "toolLevel": "minecraft:iron",
+  "toolEfficiency": 1,
+  "tints": {
+    "glyph": "a8d0d9",
+    "texture": "a8d0d9"
+  },
+  "textures": [
+    "shiny",
+    "crude"
+  ],
+  "material": {
+    "tag": "createdelight:disabled_mmt_fragile_materials"
+  }
+}

--- a/kubejs/data/tetra/materials/metal/more_mod_tetra/quark/quark_clear_shard.json
+++ b/kubejs/data/tetra/materials/metal/more_mod_tetra/quark/quark_clear_shard.json
@@ -1,0 +1,31 @@
+{
+  "replace": true,
+  "key": "quark_clear_shard",
+  "category": "misc",
+  "primary": 2,
+  "secondary": 1,
+  "tertiary": 0.5,
+  "durability": 150,
+  "integrityCost": 1,
+  "integrityGain": 4,
+  "magicCapacity": 0,
+  "toolLevel": "minecraft:iron",
+  "toolEfficiency": 1,
+  "tints": {
+    "glyph": "a8d0d9",
+    "texture": "a8d0d9"
+  },
+  "textures": [
+    "shiny",
+    "crude"
+  ],
+  "material": {
+    "tag": "createdelight:disabled_mmt_fragile_materials"
+  },
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "quark"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

- 禁用 MMT 中所有携带“宁为玉碎”效果的 Tetra 材料。
- 覆盖 AE2 硅、MMT 玻璃碎片和 Quark 透明玻璃碎片三项材料定义。
- 保留对应物品本身，仅阻止它们继续作为 Tetra 加工材料使用。

## 实现

- 材料覆盖使用 `replace: true`，避免 Tetra `MergingDataStore` 将 MMT JAR 原定义重新合并。
- 三项材料的输入统一指向永久空的 `createdelight:disabled_mmt_fragile_materials` 物品标签。
- 覆盖定义不再携带 `more_mod_tetra:fragile` 效果。

## 验证

- 对照 MMT `2.4.15` JAR，确认携带 `more_mod_tetra:fragile` 的材料只有这三项，且均有对应覆盖。
- 四个新增 JSON 均通过解析。
- `git diff --check origin/main...HEAD` 通过。

## 待回归

- 尚未进游戏执行 `/reload`，需要确认三项材料不再出现在 Tetra 加工台材料选择中。
