### PR TITLE
[fix] 从发布产物排除 ModDev MCP 与 ProbeJS

### DIFF
--- a/.agents/skills/packwiz-assets/SKILL.md
+++ b/.agents/skills/packwiz-assets/SKILL.md
@@ -18,6 +18,7 @@ Use this workflow for modpack asset operations that touch `mods/`, `resourcepack
 - `pack.toml` and `index.toml` are generated from `modpack.toml`; do not commit them.
 - Shaderpack files containing `Clrwl` are generated locally and must not be tracked.
 - Set `side = "client"` or `side = "server"` explicitly for client-only or server-only mods.
+- Set top-level `release = false` for development-only assets that must remain available to local Packwiz sync but must be removed from Client, Server, integrity manifests, and release patches. Release workflows must pass the release-pruning mode; ordinary `sync-packwiz-assets.ps1` runs must not.
 - Do not refresh GitHub Pages mod classification data (`docs/mods-data.js`) as part of normal asset changes; it is an expensive manual task and requires an explicit user request.
 
 ## Add Or Update Assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           pip install requests
           python .github/workflows/scripts/update_credits.py --mode real --download-images
       - name: 生成模组列表完整性清单
-        run: python3 scripts/generate-pack-integrity-manifest.py
+        run: python3 scripts/generate-pack-integrity-manifest.py --release
       - name: 生成不带mod本体的包
         run: |
           bash .github/workflows/scripts/export_curseforge_pack.sh ../lite-release.zip 8083
@@ -257,7 +257,7 @@ jobs:
           modpack_version: ${{ env.MODPACK_VERSION }}
           mode: patch
       - name: 生成模组列表完整性清单
-        run: python3 scripts/generate-pack-integrity-manifest.py
+        run: python3 scripts/generate-pack-integrity-manifest.py --release
       - name: 准备补丁文件
         run: |
           python3 scripts/build-release-patch.py prepare \

--- a/.github/workflows/scripts/download_mods.sh
+++ b/.github/workflows/scripts/download_mods.sh
@@ -38,9 +38,7 @@ LOCAL_PREFIX="http://127.0.0.1:$PORT/packwiz-files/"
 RAW_PREFIX_REGEX='https://raw\.githubusercontent\.com/Jasons-impart/Create-Delight-Remake/[^"[:space:]]*/packwiz-files/'
 find "$PACK_DIR" -name '*.pw.toml' -exec sed -E -i "s|${RAW_PREFIX_REGEX}|${LOCAL_PREFIX}|g" {} +
 
-if [ "$SIDE" != "all" ]; then
-  python3 scripts/packwiz-side.py prune-metadata --base "$PACK_DIR" --target "$SIDE"
-fi
+python3 scripts/packwiz-side.py prune-metadata --base "$PACK_DIR" --target "$SIDE" --release
 
 # 3. Refresh index in temp directory
 (cd "$PACK_DIR" && "$OLDPWD/packwiz" refresh)

--- a/.github/workflows/scripts/export_curseforge_pack.sh
+++ b/.github/workflows/scripts/export_curseforge_pack.sh
@@ -39,7 +39,7 @@ trap cleanup EXIT
 
 python3 "$repo_root/scripts/generate-packwiz-files.py" --source "$repo_root/modpack.toml" --output-dir "$repo_root"
 side_backup="$(mktemp -d)"
-python3 "$repo_root/scripts/packwiz-side.py" prune-metadata --base "$repo_root" --target client --backup-dir "$side_backup"
+python3 "$repo_root/scripts/packwiz-side.py" prune-metadata --base "$repo_root" --target client --release --backup-dir "$side_backup"
 bash "$script_dir/normalize_packwiz_files_for_curseforge.sh"
 
 mkdir -p "$(dirname "$output")"

--- a/mods/moddev-mcp.pw.toml
+++ b/mods/moddev-mcp.pw.toml
@@ -1,6 +1,7 @@
 name = "ModDev MCP"
 filename = "minecraft-mcp-1.20.1-forge-v0.2.1.jar"
-side = "both"
+side = "client"
+release = false
 
 [download]
 url = "https://raw.githubusercontent.com/Jasons-impart/Create-Delight-Remake/main/packwiz-files/mods/minecraft-mcp-1.20.1-forge-v0.2.1.jar"

--- a/mods/probejs.pw.toml
+++ b/mods/probejs.pw.toml
@@ -1,6 +1,7 @@
 name = "ProbeJS"
 filename = "probejs-6.0.1-forge.jar"
 side = "both"
+release = false
 
 [download]
 hash-format = "sha1"

--- a/scripts/build-release-patch.py
+++ b/scripts/build-release-patch.py
@@ -45,6 +45,10 @@ def read_toml(path):
         return tomllib.load(source)
 
 
+def is_release_enabled(data):
+    return data.get("release", True) is not False
+
+
 def metadata_files(root, asset_dir):
     directory = root / asset_dir
     if directory.is_dir():
@@ -54,6 +58,8 @@ def metadata_files(root, asset_dir):
 def metadata_entries(root, asset_dir):
     for metadata_path in metadata_files(root, asset_dir):
         data = read_toml(metadata_path)
+        if not is_release_enabled(data):
+            continue
         filename = data.get("filename")
         if not filename:
             print(f"::warning::Missing filename in {metadata_path.as_posix()}")
@@ -171,8 +177,29 @@ def move_packwiz_payloads(patch):
     shutil.rmtree(patch / "packwiz-files", ignore_errors=True)
 
 
+def remove_release_disabled_payloads(patch):
+    for metadata_path in metadata_files(Path.cwd(), "mods"):
+        data = read_toml(metadata_path)
+        if is_release_enabled(data):
+            continue
+        filename = data.get("filename")
+        if filename:
+            for candidate in (
+                patch / "mods" / str(filename),
+                patch / "packwiz-files" / "mods" / str(filename),
+            ):
+                if candidate.is_file():
+                    candidate.unlink()
+                    print(f"Removed release-disabled payload: {candidate}")
+        metadata_candidate = patch / metadata_path.relative_to(Path.cwd())
+        if metadata_candidate.is_file():
+            metadata_candidate.unlink()
+            print(f"Removed release-disabled metadata: {metadata_candidate}")
+
+
 def command_server(args):
     patch = Path(args.patch)
+    remove_release_disabled_payloads(patch)
     remove_client_mod_payloads(patch)
     for relative_path in SERVER_EXCLUDED_FILES:
         target = patch / relative_path

--- a/scripts/generate-pack-integrity-manifest.py
+++ b/scripts/generate-pack-integrity-manifest.py
@@ -32,6 +32,8 @@ def read_toml(path):
         value = value.strip()
         if value.startswith('"') and value.endswith('"'):
             value = json.loads(value)
+        elif value.lower() in {"true", "false"}:
+            value = value.lower() == "true"
         section[key] = value
 
     return data
@@ -59,9 +61,18 @@ def get_metadata_side(repo_root, metadata_path, metadata):
     return "common"
 
 
-def get_pack_mod_metadata(repo_root):
+def is_release_enabled(metadata):
+    value = metadata.get("release", True)
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() not in {"false", "0", "no"}
+
+
+def get_pack_mod_metadata(repo_root, release=False):
     for metadata_path in sorted((repo_root / "mods").rglob("*.pw.toml")):
         metadata = read_toml(metadata_path)
+        if release and not is_release_enabled(metadata):
+            continue
         filename = str(metadata.get("filename", "")).strip()
         if not filename:
             continue
@@ -99,8 +110,8 @@ def write_json_if_changed(path, manifest):
     return True
 
 
-def new_manifest(repo_root):
-    metadata_entries = list(get_pack_mod_metadata(repo_root))
+def new_manifest(repo_root, release=False):
+    metadata_entries = list(get_pack_mod_metadata(repo_root, release=release))
     if not metadata_entries:
         raise RuntimeError("No mods/**/*.pw.toml files found; cannot generate integrity manifest.")
 
@@ -139,6 +150,7 @@ def main():
         default="kubejs/config/createdelight_pack_integrity_expected.json",
         help="Manifest output path, relative to repo root unless absolute.",
     )
+    parser.add_argument("--release", action="store_true", help="Exclude metadata with release = false.")
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
@@ -146,7 +158,7 @@ def main():
     if not output.is_absolute():
         output = repo_root / output
 
-    manifest = new_manifest(repo_root)
+    manifest = new_manifest(repo_root, release=args.release)
     write_json_if_changed(output, manifest)
     counts = manifest["expectedFiles"]
     print(f"common={len(counts['common'])}, client={len(counts['client'])}, server={len(counts['server'])}")

--- a/scripts/packwiz-side.py
+++ b/scripts/packwiz-side.py
@@ -51,6 +51,13 @@ def side_for(data):
     return str(data.get("side", "both")).strip().lower()
 
 
+def is_release_enabled(data):
+    value = data.get("release", True)
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() not in {"false", "0", "no"}
+
+
 def is_allowed(side, target):
     if target == "all":
         return True
@@ -84,7 +91,8 @@ def cmd_prune_metadata(args):
     for meta in metadata_files(base, args.roots):
         data = read_toml(meta)
         side = side_for(data)
-        if is_allowed(side, args.target):
+        release_excluded = args.release and not is_release_enabled(data)
+        if is_allowed(side, args.target) and not release_excluded:
             continue
         if backup_dir is not None:
             rel = meta.relative_to(base)
@@ -94,7 +102,8 @@ def cmd_prune_metadata(args):
         meta.unlink()
         count += 1
         if args.verbose:
-            print(f"removed metadata for {args.target}: {meta.relative_to(base).as_posix()}")
+            reason = "release-disabled" if release_excluded else f"not allowed for {args.target}"
+            print(f"removed metadata ({reason}): {meta.relative_to(base).as_posix()}")
     if args.verbose:
         print(f"removed {count} metadata file(s)")
     return 0
@@ -171,6 +180,7 @@ def main():
     prune.add_argument("--base", default=".")
     prune.add_argument("--roots", nargs="+", default=list(DEFAULT_ROOTS))
     prune.add_argument("--target", choices=["client", "server", "all"], required=True)
+    prune.add_argument("--release", action="store_true", help="Also remove metadata with release = false.")
     prune.add_argument("--backup-dir")
     prune.add_argument("--verbose", action="store_true")
     prune.set_defaults(func=cmd_prune_metadata)


### PR DESCRIPTION
## 问题

- ModDev MCP 实际为开发客户端专用模组，但元数据此前标记为 `both`。
- ModDev MCP 与 ProbeJS 都是开发工具，不应进入正式版或测试版的 Client、Server、懒人包、manifest 和补丁。

## 修复

- 将 ModDev MCP 标记为 `side = "client"`。
- 为 ModDev MCP 与 ProbeJS 增加顶层 `release = false`。
- 为发布 side-prune 增加 `--release` 模式，本地 `sync-packwiz-assets.ps1` 仍保留开发模组。
- 发布完整性清单和补丁构建统一排除 `release = false` 资产。
- 更新 `packwiz-assets` 技能中的元数据规则。

## 验证

- 本地语义回归：开发客户端保留两者；开发服务端排除 MCP；发布 Client/Server 均排除两者。
- 发布 manifest 中 `minecraft-mcp` 与 `probejs` 均不存在。
- ServerPatch 回归中两项元数据均被移除。
- 完整 release CI 成功：run 29811738191（Client、Server、ClientPatch、ServerPatch 全绿）。
- 新制品相较修复前 Client/Server 均减少约 3.2 MB。
- 构建日志中未出现两个 JAR；仅保留无害的 `kubejs/config/probejs.json` 配置文件。

当前 `v0.5.0.5-test` 的未发布草稿已删除；本 PR 合并后需将测试标签移动到修复后的 `main` 并重新构建发布。
