### PR TITLE
启用原版配方书并添加 SaveMyRecipeBook

### DIFF
--- a/config/moestweaks.json
+++ b/config/moestweaks.json
@@ -20,6 +20,6 @@
   "betterKeepInv": false,
   "doubleJump": false,
   "adrenalineEffect": false,
-  "noRecipeBook": true,
+  "noRecipeBook": false,
   "villagerLoveLessCooldown": false
 }

--- a/kubejs/config/createdelight_pack_integrity_expected.json
+++ b/kubejs/config/createdelight_pack_integrity_expected.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-07-25T13:13:25Z",
+  "generatedAt": "2026-07-25T13:30:34Z",
   "generatedBy": "scripts/generate-pack-integrity-manifest.py",
   "expectedFiles": {
     "common": [
@@ -275,6 +275,7 @@
       "simplebackups-1.20.1-3.1.24.jar",
       "simplehats-forge-1.20.1-0.4.0a.jar",
       "skinlayers3d-forge-1.11.2-mc1.20.1.jar",
+      "smrb-1.0.0.jar",
       "smsn-forge-1.4.3-1.20.1.jar",
       "solapplepie-1.20.1-2.3.0.jar",
       "solardimensionaddon-1.2.0.jar",
@@ -2083,6 +2084,11 @@
       "side": "common",
       "metadata": "mods/skinlayers3d.pw.toml",
       "filename": "skinlayers3d-forge-1.11.2-mc1.20.1.jar"
+    },
+    {
+      "side": "common",
+      "metadata": "mods/savemyrecipebook.pw.toml",
+      "filename": "smrb-1.0.0.jar"
     },
     {
       "side": "common",

--- a/mods/savemyrecipebook.pw.toml
+++ b/mods/savemyrecipebook.pw.toml
@@ -1,0 +1,13 @@
+name = "SaveMyRecipeBook"
+filename = "smrb-1.0.0.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "c967849662409ee3e6ff0f8522f52372407d2336"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8479966
+project-id = 1557605


### PR DESCRIPTION
## 改动

- 将 MoesTweaks 的 noRecipeBook 配置设为 false，启用原版配方书
- 添加 SaveMyRecipeBook 1.0.0（CurseForge 文件 8479966）
- 更新客户端完整性清单

## 验证

- python -m json.tool config/moestweaks.json
- Packwiz 资产同步完成
- git diff --check