### PR TITLE
[修复] 修正入门任务的锻造跳转指针

### DIFF
--- a/config/ftbquests/quests/chapters/Introduction.snbt
+++ b/config/ftbquests/quests/chapters/Introduction.snbt
@@ -548,7 +548,7 @@
 			]
 			shape: "pentagon"
 			size: 2.0d
-			subtitle: "{ \"text\": \"锻造之艺，就在其中\", \"underlined\": \"true\", \"color\":\"blue\", \"clickEvent\": { \"action\": \"change_page\", \"value\": \"4745D3F50C44D020\" } }"
+			subtitle: "{ \"text\": \"锻造之艺，就在其中\", \"underlined\": \"true\", \"color\":\"blue\", \"clickEvent\": { \"action\": \"change_page\", \"value\": \"4B6A861104F42DC2\" } }"
 			tasks: [{
 				id: "77549F0D9F837A05"
 				title: "锻造大师"


### PR DESCRIPTION
## 变更说明

- 修正入门章节“锻造之艺，就在其中”的任务书点击跳转，使其指向实际存在的 Those Who Came Before 任务页面。

## 验证

- git diff --check
- 确认点击目标 ID 4B6A861104F42DC2 存在于 Those_Who_Came_Before.snbt