### PR TITLE
[conf] 升级 Forge 至 47.4.16

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Create-Delight Remake (齿轮盛宴) is a deep-modded Minecraft 1.20.1 Forge modpack focused on Create, Farmer's Delight, exploration, food systems, and KubeJS-driven progression.
 
-**Core Stack**: Minecraft 1.20.1 | Forge 47.4.10 | KubeJS | Packwiz
+**Core Stack**: Minecraft 1.20.1 | Forge 47.4.16 | KubeJS | Packwiz
 
 > KubeJS details: `kubejs/AGENTS.md`
 > Content knowledge: `docs/content/`

--- a/PCL/Setup.ini
+++ b/PCL/Setup.ini
@@ -1,12 +1,12 @@
 VersionAdvanceJvm:-Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError
 State:6
-Info:正式版 1.20.1, Forge 47.4.10
+Info:正式版 1.20.1, Forge 47.4.16
 VersionFabric:
 VersionOptiFine:
 VersionLiteLoader:False
-VersionForge:47.4.10
+VersionForge:47.4.16
 VersionNeoForge:
-VersionApiCode:47040010
+VersionApiCode:47040016
 VersionOriginal:1.20.1
 VersionOriginalMain:20
 VersionOriginalSub:1

--- a/pack.toml
+++ b/pack.toml
@@ -9,5 +9,5 @@ hash-format = "sha256"
 hash = "0c78e618fc9b3e547a6368984d78e2d5f892563ab23a0df61372c7bd7fa0839f"
 
 [versions]
-forge = "47.4.10"
+forge = "47.4.16"
 minecraft = "1.20.1"


### PR DESCRIPTION
将模组包 Forge 版本升级至 47.4.16，并同步 packwiz 元数据、PCL 启动器配置与项目核心栈文档。

验证：版本引用检查及 Git 差异检查均已通过。