### PR TITLE
[模组更新] 更新懒惰刻并撤回 VI 重复兼容补丁

### DIFF
--- a/docs/dev-knowledge/compatibility-patches.md
+++ b/docs/dev-knowledge/compatibility-patches.md
@@ -13,4 +13,5 @@
 
 | 修复 | 类型 | 问题或根因 | 补丁位置 | 验证与跟踪 | 复核/移除条件 | 状态 |
 |---|---|---|---|---|---|---|
+| LazyTick × Vintage Improvements 压缩机工作盆缓存 | 模组兼容 | LazyTick `2.4.9` 的 Basin 配方缓存不会感知 Vacuum Chamber 继承的配方上下文变化，导致压缩机偶发需移动或重设过滤器后才加工。 | `mods/CreateLazyTick.pw.toml` 更新至 `2.5.15`，使用上游 `VacuumChamberBasinBypassMixin`/`IBasinLazyTickBypass`；`mods/vintageimprovements.pw.toml` 更新至 `0.3.7.8`，撤回 VI 侧临时快照 Mixin。 | 已核对 LazyTick 发布 JAR 包含上游旁路类，VI 发布 JAR 不再包含 LazyTick/`BasinStateSnapshot` Mixin；运行时 JAR SHA-256 分别为 `2416ABA4…BA77AD`、`BF590658…DAE4E`。 | LazyTick 后续移除该上游兼容或 VI 不再继承 Basin 配方路径时重新复核；无需在 VI 侧恢复重复补丁。 | 已同步，待游戏内压缩机回归 |
 | Frycooks Delight 油菜作物模型 | 资源兼容 | Frycooks Delight `1.0.1` 的 8 个油菜阶段仍引用 `farmersdelight:block/crop_cross`；Farmer's Delight `1.3.2` 将通用模板重命名为 `template_crop_cross`，造成紫黑缺失模型。 | `kubejs/assets/farmersdelight/models/block/crop_cross.json`：以旧路径提供与新模板等价的模型。 | 已由用户通过资源重载确认紫黑块消失；[#2007](https://github.com/Jasons-impart/Create-Delight-Remake/issues/2007)。 | Frycooks Delight 更新为引用 `farmersdelight:block/template_crop_cross` 或不再引用旧路径后，移除覆盖并回归油菜 8 个阶段。 | 生效中 |

--- a/kubejs/config/createdelight_pack_integrity_expected.json
+++ b/kubejs/config/createdelight_pack_integrity_expected.json
@@ -104,7 +104,7 @@
       "createfastschematiccannon-1.4.1-6.0.x-forge-1.20.1.jar",
       "createfluidstuffs-1.2.1-all.jar",
       "createidlx-1.20.1-1.3.jar",
-      "createlazytick-2.4.9-6.0.x-forge-1.20.1.jar",
+      "createlazytick-2.5.15-6.0.x-forge-1.20.1.jar",
       "createliquidfuel-2.1.1-1.20.1.jar",
       "createmetallurgy-1.0.1-1.20.1.jar",
       "createoreexcavation-1.20-1.6.5.jar",
@@ -316,7 +316,7 @@
       "trueuuid-1.1.2-forge1.20.1.jar",
       "vintage_kubejs-1.20.1-1.0.0rc-2.jar",
       "vintagedelight-0.1.6.jar",
-      "vintageimprovements-1.20.1-0.3.7.6.jar",
+      "vintageimprovements-1.20.1-0.3.7.8.jar",
       "vvaddon-1.20.1-alpha3.0.1.jar",
       "watut-forge-1.20.1-1.2.3.jar",
       "waystones-forge-1.20.1-14.1.20.jar",
@@ -775,7 +775,7 @@
     {
       "side": "common",
       "metadata": "mods/CreateLazyTick.pw.toml",
-      "filename": "CreateLazyTick-2.4.9-6.0.x-forge-1.20.1.jar"
+      "filename": "CreateLazyTick-2.5.15-6.0.x-forge-1.20.1.jar"
     },
     {
       "side": "common",
@@ -2265,7 +2265,7 @@
     {
       "side": "common",
       "metadata": "mods/vintageimprovements.pw.toml",
-      "filename": "vintageimprovements-1.20.1-0.3.7.6.jar"
+      "filename": "vintageimprovements-1.20.1-0.3.7.8.jar"
     },
     {
       "side": "common",

--- a/mods/CreateLazyTick.pw.toml
+++ b/mods/CreateLazyTick.pw.toml
@@ -1,13 +1,13 @@
 name = "Create:LazyTick"
-filename = "CreateLazyTick-2.4.9-6.0.x-forge-1.20.1.jar"
+filename = "CreateLazyTick-2.5.15-6.0.x-forge-1.20.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "16e2ec18cf81b32f033477c69edf295ed82a1909"
+hash = "cf33e5d065adef78ea8386b40da8fb4912345efa"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7844830
+file-id = 8520489
 project-id = 1409401

--- a/mods/vintageimprovements.pw.toml
+++ b/mods/vintageimprovements.pw.toml
@@ -1,13 +1,13 @@
 name = "Vintage Improvenents - SSW Edition"
-filename = "vintageimprovements-1.20.1-0.3.7.6.jar"
+filename = "vintageimprovements-1.20.1-0.3.7.8.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "1369419bd24398f2995ca3b5e461e405a4da74a0"
+hash = "118c9980f3e3499d935382b8a920902d7d649aa6"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8429738
+file-id = 8522308
 project-id = 1255448


### PR DESCRIPTION
## 变更

- 将 Create: LazyTick 从 `2.4.9` 更新到 `2.5.15`。
- 使用 LazyTick 上游新增的 `VacuumChamberBasinBypassMixin` / `IBasinLazyTickBypass`，让 VI Vacuum Chamber 绕过 Basin 配方缓存。
- 将 Vintage Improvements 从 `0.3.7.6` 更新到 `0.3.7.8`，撤回 VI 侧临时 `BasinStateSnapshot` Mixin，避免两边重复维护兼容逻辑。
- 同步完整性清单，并补充兼容性台账。

## 原因

旧版 LazyTick 的 Basin 配方缓存不会感知 Vacuum Chamber 继承的配方上下文变化，压缩机可能需要移动方块或重新设置过滤器后才开始加工。LazyTick `2.5.15` 已在上游原生兼容 VI，因此整合包应采用上游旁路，并移除 VI fork 中的临时补丁。

## 验证

- `scripts/sync-packwiz-assets.ps1` 成功，CurseForge 元数据和运行时 JAR 已同步。
- LazyTick JAR 包含 `VacuumChamberBasinBypassMixin` 与 `IBasinLazyTickBypass`；SHA-256：`2416ABA430BD7D330F956616AB19B4E72531E43E276D218219E5FEA284BA77AD`。
- VI `0.3.7.8` JAR 不包含 LazyTick / `BasinStateSnapshot` Mixin；SHA-256：`BF5906585A2321918E88FD647479DF8EAB1F354DF712A4F0357DCD9E9DADAE4E`。
- 完整性清单 JSON 解析、`git diff --check` 与知识库校验通过。
- 当前没有运行中的 CDRdev 客户端，尚未完成游戏内压缩机回归；台账已明确标记为待回归。
