### PR TITLE
[mod] 更新序列组装样板供应器至 0.3.1

### DIFF
--- a/kubejs/config/createdelight_pack_integrity_expected.json
+++ b/kubejs/config/createdelight_pack_integrity_expected.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-07-28T15:12:03Z",
+  "generatedAt": "2026-07-29T14:15:25Z",
   "generatedBy": "scripts/generate-pack-integrity-manifest.py",
   "expectedFiles": {
     "common": [
@@ -269,7 +269,7 @@
       "searchables-forge-1.20.1-1.0.3.jar",
       "seasonals-1.20.1-5.0.2.jar",
       "seasonhud-forge-1.20.1-2.0.6.jar",
-      "sequenced_pattern_provider-1.20.1-0.2.1.jar",
+      "sequenced_pattern_provider-1.20.1-0.3.1.jar",
       "servercore-forge-1.5.2+1.20.1.jar",
       "shadowizardlib-1.20.1-1.3.1.jar",
       "silentsdelight-forge-1.0.1-1.20.1.jar",
@@ -2065,7 +2065,7 @@
     {
       "side": "common",
       "metadata": "mods/sequenced-pattern-provider.pw.toml",
-      "filename": "sequenced_pattern_provider-1.20.1-0.2.1.jar"
+      "filename": "sequenced_pattern_provider-1.20.1-0.3.1.jar"
     },
     {
       "side": "common",

--- a/mods/sequenced-pattern-provider.pw.toml
+++ b/mods/sequenced-pattern-provider.pw.toml
@@ -1,13 +1,13 @@
 name = "Sequenced Pattern Provider"
-filename = "sequenced_pattern_provider-1.20.1-0.2.1.jar"
+filename = "sequenced_pattern_provider-1.20.1-0.3.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "1fc39e2d256a54e1c1170f3c5f580cb403535f72"
+hash = "2d2a96c4343d76b056ce4e3d300aa2f14c8a751d"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8423252
+file-id = 8533565
 project-id = 1607551


### PR DESCRIPTION
## 变更内容

- 将 Sequenced Pattern Provider 从 `0.2.1` 更新至 `0.3.1`
- 更新 CurseForge 文件 ID 为 `8533565`
- 同步完整性清单中的 SPP 文件名
- 保持 `side = "both"`，供客户端与服务端共同加载

## 校验

- Packwiz SHA-1：`2d2a96c4343d76b056ce4e3d300aa2f14c8a751d`
- 本地运行时 JAR SHA-1 与元数据一致
- 本地运行时 JAR SHA-256：`b3c0f2e487bdec5b3826b2f5bcb7167ba4e214e1a784fe22c010dbcf89fe7063`
- 用户已完成游戏内基础回归

## 影响范围

仅更新 SPP Packwiz 元数据及对应的整合包完整性清单，不包含当前工作区的其他开发内容。
