### PR TITLE
[mod] 更新多项模组版本

### DIFF
--- a/kubejs/config/createdelight_pack_integrity_expected.json
+++ b/kubejs/config/createdelight_pack_integrity_expected.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-07-29T14:15:25Z",
+  "generatedAt": "2026-07-29T18:07:25Z",
   "generatedBy": "scripts/generate-pack-integrity-manifest.py",
   "expectedFiles": {
     "common": [
@@ -22,7 +22,7 @@
       "apotheosis-1.20.1-7.4.8.jar",
       "apothicattributes-1.20.1-1.3.7.jar",
       "appleskin-forge-mc1.20.1-2.5.1.jar",
-      "appliedcreate-1.20.1-1.1.5.jar",
+      "appliedcreate-1.20.1-1.1.6.jar",
       "appliedenergistics2-forge-15.4.10.jar",
       "architectury-9.2.14-forge.jar",
       "attributefix-forge-1.20.1-21.0.5.jar",
@@ -48,7 +48,7 @@
       "cave-delight-1.20.1-2.0.1.jar",
       "centralvintage-1.2.1.jar",
       "charmofundying-forge-6.5.0+1.20.1.jar",
-      "chat_heads-0.15.2-forge-1.20.jar",
+      "chat_heads-0.15.3-forge-1.20.jar",
       "chefsdelight-1.0.4-forge-1.20.1.jar",
       "citadel-2.6.3-1.20.1.jar",
       "cloth-config-11.1.136-forge.jar",
@@ -113,7 +113,7 @@
       "createredstonelinkgui-1.20.1-1.9.1.jar",
       "createsolar-1.2.6-1.20.1.jar",
       "createstockbridge-1.20-0.2.0.jar",
-      "createtransmission-1.1.0+forge-create6-1.20.1.jar",
+      "createtransmission-1.2.1+forge-create6-1.20.1.jar",
       "createultimine-1.20.1-forge-1.3.1.jar",
       "creativecore_forge_v2.12.35_mc1.20.1.jar",
       "creeperoverhaul-3.0.2-forge.jar",
@@ -237,7 +237,7 @@
       "neruina-3.3.3+1.20.1-forge.jar",
       "netmusic-1.5.1-forge+mc1.20.1.jar",
       "nochatreports-forge-1.20.1-v2.2.2.jar",
-      "northstar-0.6.1+1.20.1.jar",
+      "northstar-0.6.4+1.20.1.jar",
       "northstar-curios-compat-1.3.1.jar",
       "observable-4.4.2.jar",
       "oceanic_delight-1.0.3-forge-1.20.1.jar",
@@ -282,9 +282,9 @@
       "solardimensionaddon-1.2.0.jar",
       "solcarrot-1.20.1-1.15.1.jar",
       "some-assembly-required-1.20.1-4.2.3.jar",
-      "sophisticatedbackpacks-1.20.1-3.24.60.1982.jar",
+      "sophisticatedbackpacks-1.20.1-3.24.62.2017.jar",
       "sophisticatedbackpackscreateintegration-1.20.1-0.1.8.116.jar",
-      "sophisticatedcore-1.20.1-1.3.71.2181.jar",
+      "sophisticatedcore-1.20.1-1.3.73.2192.jar",
       "soul-fire-d-forge-1.20.1-4.0.11.jar",
       "spark-1.10.53-forge.jar",
       "sqlite-jdbc-3.36.0.3+20211227-all.jar",
@@ -312,8 +312,8 @@
       "traderefresh-2.5.2.jar",
       "trailandtales_delight-1.7-all.jar",
       "trashcans-1.0.18b-forge-mc1.20.jar",
-      "trashslot-forge-1.20.1-15.1.4.jar",
-      "trueuuid-1.1.2-forge1.20.1.jar",
+      "trashslot-forge-1.20.1-15.1.5.jar",
+      "trueuuid-1.2.0-forge-1.20.1.jar",
       "vintage_kubejs-1.20.1-1.0.0rc-2.jar",
       "vintagedelight-0.1.6.jar",
       "vintageimprovements-1.20.1-0.3.7.8.jar",
@@ -321,9 +321,9 @@
       "watut-forge-1.20.1-1.2.3.jar",
       "waystones-forge-1.20.1-14.1.20.jar",
       "world_preview-forge-1.20.1-1.3.1.jar",
-      "xaerominimap-forge-1.20.1-26.1.0.jar",
+      "xaerominimap-forge-1.20.1-26.4.2.jar",
       "xaeros_waystones_compatibility-1.1 - 1.20.1.jar",
-      "xaeroworldmap-forge-1.20.1-1.41.2.jar",
+      "xaeroworldmap-forge-1.20.1-1.44.2.jar",
       "yet_another_config_lib_v3-3.6.6+1.20.1-forge.jar",
       "youkaishomecoming-2.7.0.jar",
       "youkaishomecoming_curios-0.03.jar",
@@ -369,7 +369,7 @@
       "iris_shader_folder-1.3.3-forge.jar",
       "itemborders-1.20.1-forge-1.2.2.jar",
       "itemphysiclite_forge_v1.6.6_mc1.20.1.jar",
-      "ixeris-4.5.2+1.20.1-forge.jar",
+      "ixeris-4.6.0+1.20.1-forge.jar",
       "jecharacters-1.20.1-forge-4.6.4.jar",
       "jeed-1.20-2.2.5.jar",
       "lucent-1.20.1-1.5.5.jar",
@@ -470,7 +470,7 @@
     {
       "side": "client",
       "metadata": "mods/ixeris.pw.toml",
-      "filename": "Ixeris-4.5.2+1.20.1-forge.jar"
+      "filename": "Ixeris-4.6.0+1.20.1-forge.jar"
     },
     {
       "side": "client",
@@ -920,7 +920,7 @@
     {
       "side": "common",
       "metadata": "mods/northstar.pw.toml",
-      "filename": "Northstar-0.6.1+1.20.1.jar"
+      "filename": "Northstar-0.6.4+1.20.1.jar"
     },
     {
       "side": "common",
@@ -1105,7 +1105,7 @@
     {
       "side": "common",
       "metadata": "mods/appliedcreate.pw.toml",
-      "filename": "appliedcreate-1.20.1-1.1.5.jar"
+      "filename": "appliedcreate-1.20.1-1.1.6.jar"
     },
     {
       "side": "common",
@@ -1200,7 +1200,7 @@
     {
       "side": "common",
       "metadata": "mods/chat_heads.pw.toml",
-      "filename": "chat_heads-0.15.2-forge-1.20.jar"
+      "filename": "chat_heads-0.15.3-forge-1.20.jar"
     },
     {
       "side": "common",
@@ -1485,7 +1485,7 @@
     {
       "side": "common",
       "metadata": "mods/createtransmission.pw.toml",
-      "filename": "createtransmission-1.1.0+forge-create6-1.20.1.jar"
+      "filename": "createtransmission-1.2.1+forge-create6-1.20.1.jar"
     },
     {
       "side": "common",
@@ -2125,7 +2125,7 @@
     {
       "side": "common",
       "metadata": "mods/sophisticatedbackpacks.pw.toml",
-      "filename": "sophisticatedbackpacks-1.20.1-3.24.60.1982.jar"
+      "filename": "sophisticatedbackpacks-1.20.1-3.24.62.2017.jar"
     },
     {
       "side": "common",
@@ -2135,7 +2135,7 @@
     {
       "side": "common",
       "metadata": "mods/sophisticatedcore.pw.toml",
-      "filename": "sophisticatedcore-1.20.1-1.3.71.2181.jar"
+      "filename": "sophisticatedcore-1.20.1-1.3.73.2192.jar"
     },
     {
       "side": "common",
@@ -2245,12 +2245,12 @@
     {
       "side": "common",
       "metadata": "mods/trashslot.pw.toml",
-      "filename": "trashslot-forge-1.20.1-15.1.4.jar"
+      "filename": "trashslot-forge-1.20.1-15.1.5.jar"
     },
     {
       "side": "common",
       "metadata": "mods/trueuuid.pw.toml",
-      "filename": "trueuuid-1.1.2-forge1.20.1.jar"
+      "filename": "trueuuid-1.2.0-forge-1.20.1.jar"
     },
     {
       "side": "common",
@@ -2290,7 +2290,7 @@
     {
       "side": "common",
       "metadata": "mods/xaerominimap.pw.toml",
-      "filename": "xaerominimap-forge-1.20.1-26.1.0.jar"
+      "filename": "xaerominimap-forge-1.20.1-26.4.2.jar"
     },
     {
       "side": "common",
@@ -2300,7 +2300,7 @@
     {
       "side": "common",
       "metadata": "mods/xaeroworldmap.pw.toml",
-      "filename": "xaeroworldmap-forge-1.20.1-1.41.2.jar"
+      "filename": "xaeroworldmap-forge-1.20.1-1.44.2.jar"
     },
     {
       "side": "common",

--- a/mods/appliedcreate.pw.toml
+++ b/mods/appliedcreate.pw.toml
@@ -1,13 +1,13 @@
 name = "Applied Create"
-filename = "appliedcreate-1.20.1-1.1.5.jar"
+filename = "appliedcreate-1.20.1-1.1.6.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "bc2fd74442ea49c7b48bd51857ac516af81100b6"
+hash = "4c5b21838cf2702ac033e117f9107e0e2dd041b1"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7945852
+file-id = 8424672
 project-id = 1474758

--- a/mods/chat_heads.pw.toml
+++ b/mods/chat_heads.pw.toml
@@ -1,13 +1,13 @@
 name = "Chat Heads"
-filename = "chat_heads-0.15.2-forge-1.20.jar"
+filename = "chat_heads-0.15.3-forge-1.20.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "fe49c0f42f21f4c0ea71c3cda7757914cb875ae7"
+hash = "5068015885175bee8f8829e74fb62feb97538b2e"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8244416
+file-id = 8486523
 project-id = 407206

--- a/mods/createtransmission.pw.toml
+++ b/mods/createtransmission.pw.toml
@@ -1,13 +1,13 @@
 name = "Create: Transmission!"
-filename = "createtransmission-1.1.0+forge-create6-1.20.1.jar"
+filename = "createtransmission-1.2.1+forge-create6-1.20.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "ceed3e17aadc6aec47b9e730c744f3c1723828c4"
+hash = "8e1e41c92f70712b0600358543537494166b43f6"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7724941
+file-id = 8186081
 project-id = 1354280

--- a/mods/ixeris.pw.toml
+++ b/mods/ixeris.pw.toml
@@ -1,13 +1,13 @@
 name = "Ixeris"
-filename = "Ixeris-4.5.2+1.20.1-forge.jar"
+filename = "Ixeris-4.6.0+1.20.1-forge.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "46ab8a65c0aa2aa9dbb85461096e553476c08bc1"
+hash = "a07f62b4c0e17cf703a59b36226ff7eb3ddca610"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8385042
+file-id = 8513437
 project-id = 1285307

--- a/mods/northstar.pw.toml
+++ b/mods/northstar.pw.toml
@@ -1,13 +1,13 @@
 name = "Create: Northstar - Redux"
-filename = "Northstar-0.6.1+1.20.1.jar"
+filename = "Northstar-0.6.4+1.20.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "4cfa6c4f4bbc773da7e6ecf848fcface8f4a755b"
+hash = "e576a31d02f2201983da464736daffd1a655c8e5"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8307384
+file-id = 8486123
 project-id = 1318310

--- a/mods/sophisticatedbackpacks.pw.toml
+++ b/mods/sophisticatedbackpacks.pw.toml
@@ -1,13 +1,13 @@
 name = "Sophisticated Backpacks"
-filename = "sophisticatedbackpacks-1.20.1-3.24.60.1982.jar"
+filename = "sophisticatedbackpacks-1.20.1-3.24.62.2017.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "b7f99abc0cafba9fc6dfa9ced3bae4d0bed3b3db"
+hash = "fe4b90ab03b61ac0901125ce36a65cd188ea9c15"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8434160
+file-id = 8503063
 project-id = 422301

--- a/mods/sophisticatedcore.pw.toml
+++ b/mods/sophisticatedcore.pw.toml
@@ -1,13 +1,13 @@
 name = "Sophisticated Core"
-filename = "sophisticatedcore-1.20.1-1.3.71.2181.jar"
+filename = "sophisticatedcore-1.20.1-1.3.73.2192.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "611af67b621f6b7ded4eaea5cb04fcf4d7921b32"
+hash = "ec4403509162632bbad7f6c7be382a3fa6381a30"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8467444
+file-id = 8503031
 project-id = 618298

--- a/mods/trashslot.pw.toml
+++ b/mods/trashslot.pw.toml
@@ -1,13 +1,13 @@
 name = "TrashSlot"
-filename = "trashslot-forge-1.20.1-15.1.4.jar"
+filename = "trashslot-forge-1.20.1-15.1.5.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "c50867bb2222066ab36b251ab7fe7348f6c5a162"
+hash = "80cb7633f57f485ccf10b4e9248ee6ce02d0e69e"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7772364
+file-id = 8019497
 project-id = 235577

--- a/mods/trueuuid.pw.toml
+++ b/mods/trueuuid.pw.toml
@@ -1,13 +1,13 @@
 name = "TrueUUID"
-filename = "trueuuid-1.1.2-forge1.20.1.jar"
+filename = "trueuuid-1.2.0-forge-1.20.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "683ce839e5b537318ab1a9ee1da4f906be4fb542"
+hash = "2e2515f4c8304518c30723bffee75da895674d82"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8422478
+file-id = 8490645
 project-id = 1539688

--- a/mods/xaerominimap.pw.toml
+++ b/mods/xaerominimap.pw.toml
@@ -1,13 +1,13 @@
 name = "Xaero's Minimap"
-filename = "xaerominimap-forge-1.20.1-26.1.0.jar"
+filename = "xaerominimap-forge-1.20.1-26.4.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "5b2be59a71add73676596d0d3350b832552bac70"
+hash = "8f5f747a33e787aaa3827b00eb0ad098966499ff"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8231196
+file-id = 8449808
 project-id = 263420

--- a/mods/xaeroworldmap.pw.toml
+++ b/mods/xaeroworldmap.pw.toml
@@ -1,13 +1,13 @@
 name = "Xaero's World Map"
-filename = "xaeroworldmap-forge-1.20.1-1.41.2.jar"
+filename = "xaeroworldmap-forge-1.20.1-1.44.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "a60d4c8e04a65ffe82f1ac89ab28a52f357fbbf2"
+hash = "d7cd24554d9c361b2d8d3efac2cb1408f118917d"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8298683
+file-id = 8449908
 project-id = 317780


### PR DESCRIPTION
## 变更内容

- 更新 Applied Create、Chat Heads、Create: Transmission 与 Northstar 等 11 个现有模组版本
- 保留 Ixeris 的客户端侧标记及其余模组原有侧别
- 重新生成整合包完整性清单，使受管 JAR 文件名与新版本一致
- 排除全量扫描额外发现的新模组、CDC 本地开发包及其他未提交改动

## 验证

- `packwiz refresh` 成功
- `createdelight_pack_integrity_expected.json` JSON 解析成功
- `git diff --check` 通过