### PR TITLE
[mod] 更新序列组装样板供应器至 0.3.2

### DIFF
--- a/mods/sequenced-pattern-provider.pw.toml
+++ b/mods/sequenced-pattern-provider.pw.toml
@@ -1,13 +1,13 @@
 name = "Sequenced Pattern Provider"
-filename = "sequenced_pattern_provider-1.20.1-0.3.1.jar"
+filename = "sequenced_pattern_provider-1.20.1-0.3.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "2d2a96c4343d76b056ce4e3d300aa2f14c8a751d"
+hash = "fdbfb87d6774e85f43b731ecc63d666315a5f984"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8533565
+file-id = 8535779
 project-id = 1607551


### PR DESCRIPTION
## 变更内容

- 将 Sequenced Pattern Provider 从 `0.3.1` 更新至 `0.3.2`
- 同步 CurseForge 文件 ID、文件名与 SHA-1
- 保持 `side = "both"`，客户端和服务端均加载

## 上游修复

- 修复多个同配方任务或多条同类型产线并行时，中间工件可能无法被主控认领的问题
- 修复子供应器无法通过 AE2 石英切割刀正确改名的问题

## 验证

- CurseForge Release 文件：`8535779`
- Packwiz 元数据已通过定向检查
- 本地同步后的 JAR 与发布产物 SHA-256 一致
- PR 仅包含 `mods/sequenced-pattern-provider.pw.toml`

CurseForge：https://www.curseforge.com/minecraft/mc-mods/sequenced-pattern-provider/files/8535779
