### PR TITLE
[fix] 修复 Packwiz 资源包识别并补充 BC Particle

### DIFF
--- a/.agents/skills/packwiz-assets/SKILL.md
+++ b/.agents/skills/packwiz-assets/SKILL.md
@@ -23,9 +23,9 @@ Use this workflow for modpack asset operations that touch `mods/`, `resourcepack
 
 ## Add Or Update Assets
 
-1. For one known CurseForge project/file, run `./scripts/add-packwiz-target.ps1 -CurseForgeUrl <project-or-file-URL> -Category mods|resourcepacks|shaderpacks -Side client|server|both`. It generates and validates one temporary metadata file, refuses to overwrite an existing target, and synchronizes local runtime assets by default.
+1. For one known CurseForge project/file, run `./scripts/add-packwiz-target.ps1 -CurseForgeUrl <project-or-file-URL> -Category mods|resourcepacks|shaderpacks -Side client|server|both`. It identifies the requested project's metadata even when Packwiz also generates temporary dependency entries, refuses to overwrite an existing target, and synchronizes local runtime assets by default. Resourcepack and shaderpack probes ignore the pack's mod-loader filter.
 2. For an existing CurseForge metadata file, run `./scripts/update-packwiz-target.ps1 -Category mods|resourcepacks|shaderpacks -Slug <metadata-name>`, or use `-Path <relative .pw.toml path>`.
-3. Put custom/restricted payloads under the matching `packwiz-files/<category>/` directory. To inventory local JARs, reconcile many changed assets, or repair metadata drift, run `./scripts/update-packwiz-meta.ps1 -Category mods|resourcepacks|shaderpacks -FullReconcile` only on `main` or a long-lived LTS/release-maintenance branch.
+3. Put custom/restricted payloads under the matching `packwiz-files/<category>/` directory. To inventory local JARs, reconcile many changed assets, or repair metadata drift, run `./scripts/update-packwiz-meta.ps1 -Category mods|resourcepacks|shaderpacks -FullReconcile` only on `main` or a long-lived LTS/release-maintenance branch. Non-mod reconciliation removes loader filtering, strips trailing parenthesized version suffixes when searching CurseForge, and defaults new metadata to `side = "client"`.
 4. For slow overseas services, retry once with `-Proxy "http://127.0.0.1:7890"`.
 5. Inspect the generated `.pw.toml` plus `packwiz-files` changes before staging, especially that existing `side = "client"` or `side = "server"` entries were not reset to `both`.
 6. Run `./scripts/sync-packwiz-assets.ps1` when local runtime files must match metadata.

--- a/kubejs/config/createdelight_pack_integrity_expected.json
+++ b/kubejs/config/createdelight_pack_integrity_expected.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-07-29T18:07:25Z",
+  "generatedAt": "2026-07-30T04:22:02Z",
   "generatedBy": "scripts/generate-pack-integrity-manifest.py",
   "expectedFiles": {
     "common": [
@@ -28,6 +28,7 @@
       "attributefix-forge-1.20.1-21.0.5.jar",
       "bakeries-1.20.1-forge-1.2.5.jar",
       "balm-forge-1.20.1-7.3.41-all.jar",
+      "bc_particle-0.0.6-forge-1.20.1.jar",
       "beefix-1.20-1.0.7.jar",
       "bettercombat-forge-1.9.0+1.20.1.jar",
       "bettercompatibilitychecker-3.0.1-build.58+mc1.20.jar",
@@ -269,7 +270,7 @@
       "searchables-forge-1.20.1-1.0.3.jar",
       "seasonals-1.20.1-5.0.2.jar",
       "seasonhud-forge-1.20.1-2.0.6.jar",
-      "sequenced_pattern_provider-1.20.1-0.3.1.jar",
+      "sequenced_pattern_provider-1.20.1-0.3.2.jar",
       "servercore-forge-1.5.2+1.20.1.jar",
       "shadowizardlib-1.20.1-1.3.1.jar",
       "silentsdelight-forge-1.0.1-1.20.1.jar",
@@ -349,7 +350,7 @@
       "controlling-forge-1.20.1-12.0.2.jar",
       "createcybergoggles-1.20.1-7.2.2-forge.jar",
       "culllessleaves-reforged-1.20.1-1.0.5.jar",
-      "customskinloader_forgev2-14.28.jar",
+      "customskinloader_universal-15.0.1.jar",
       "drippyloadingscreen_forge_3.1.2_mc_1.20.1.jar",
       "dynamic-fps-3.11.4+minecraft-1.20.0-forge.jar",
       "dynamiccrosshair-9.10+1.20.1-forge.jar",
@@ -424,8 +425,8 @@
     },
     {
       "side": "client",
-      "metadata": "mods/CustomSkinLoader_ForgeV2.pw.toml",
-      "filename": "CustomSkinLoader_ForgeV2-14.28.jar"
+      "metadata": "mods/customskinloader-bootstrap.pw.toml",
+      "filename": "CustomSkinLoader_Universal-15.0.1.jar"
     },
     {
       "side": "client",
@@ -1126,6 +1127,11 @@
       "side": "common",
       "metadata": "mods/balm.pw.toml",
       "filename": "balm-forge-1.20.1-7.3.41-all.jar"
+    },
+    {
+      "side": "common",
+      "metadata": "mods/bc-particle.pw.toml",
+      "filename": "bc_particle-0.0.6-forge-1.20.1.jar"
     },
     {
       "side": "common",
@@ -2065,7 +2071,7 @@
     {
       "side": "common",
       "metadata": "mods/sequenced-pattern-provider.pw.toml",
-      "filename": "sequenced_pattern_provider-1.20.1-0.3.1.jar"
+      "filename": "sequenced_pattern_provider-1.20.1-0.3.2.jar"
     },
     {
       "side": "common",

--- a/mods/bc-particle.pw.toml
+++ b/mods/bc-particle.pw.toml
@@ -1,0 +1,13 @@
+name = "Better Combat Particle"
+filename = "bc_particle-0.0.6-forge-1.20.1.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "3d309df955df5e936524dce787bb833aead4e415"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 7855256
+project-id = 1372768

--- a/mods/customskinloader-bootstrap.pw.toml
+++ b/mods/customskinloader-bootstrap.pw.toml
@@ -1,13 +1,13 @@
 name = "CustomSkinLoader"
-filename = "CustomSkinLoader_ForgeV2-14.28.jar"
+filename = "CustomSkinLoader_Universal-15.0.1.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "c7e87169bd8b59a9414620dd0fd63ca5a17c235d"
+hash = "ab8dd841cafc3b4ecbf0250d3f5aee8a1fdb506a"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7822525
+file-id = 8291183
 project-id = 286924

--- a/resourcepacks/bc-particle-enhancement.pw.toml
+++ b/resourcepacks/bc-particle-enhancement.pw.toml
@@ -1,0 +1,13 @@
+name = "BetterCombat Particle Enhancements + Compact"
+filename = "BC Particle Enhancement (1.20.1) (1.0).zip"
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "5bedcf55305fe9466ea7e2b983f3cfe5cd63a32c"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8289057
+project-id = 1538952

--- a/scripts/add-packwiz-target.ps1
+++ b/scripts/add-packwiz-target.ps1
@@ -90,6 +90,58 @@ function Set-PwTomlSide {
     throw "packwiz metadata is missing a filename field."
 }
 
+function Remove-PackwizLoaderVersions {
+    param([string]$PackFilePath)
+
+    $lines = @(Get-Content -LiteralPath $PackFilePath)
+    $updatedLines = [System.Collections.Generic.List[string]]::new()
+    $inVersions = $false
+    $changed = $false
+
+    foreach ($line in $lines) {
+        if ($line -match '^\s*\[([^]]+)\]\s*$') {
+            $inVersions = ($Matches[1] -eq "versions")
+            $updatedLines.Add($line) | Out-Null
+            continue
+        }
+
+        if ($inVersions -and $line -match '^\s*(forge|neoforge|fabric|quilt|liteloader)\s*=') {
+            $changed = $true
+            continue
+        }
+
+        $updatedLines.Add($line) | Out-Null
+    }
+
+    if ($changed) {
+        Write-Utf8NoBomFile -LiteralPath $PackFilePath -Content (($updatedLines -join "`n") + "`n")
+    }
+}
+
+function Get-AddedProjectFilename {
+    param([object[]]$Output)
+
+    foreach ($line in $Output) {
+        $text = [string]$line
+        if ($text -match '^Project ".+" successfully added! \((.+)\)$') {
+            return $Matches[1]
+        }
+    }
+
+    return $null
+}
+
+function Get-PwTomlFilename {
+    param([string]$Path)
+
+    $content = Get-Content -LiteralPath $Path -Raw
+    if ($content -match '(?m)^filename\s*=\s*"(.+)"\s*$') {
+        return $Matches[1]
+    }
+
+    return $null
+}
+
 function Invoke-WithProxy {
     param([scriptblock]$Script)
 
@@ -131,9 +183,18 @@ function Invoke-Packwiz {
 
     Push-Location $WorkingDirectory
     try {
-        Invoke-WithProxy { & $PackwizExe @Arguments }
-        if ($LASTEXITCODE -ne 0) {
-            throw "packwiz $($Arguments -join ' ') exited with code $LASTEXITCODE."
+        $output = @(Invoke-WithProxy { & $PackwizExe @Arguments 2>&1 })
+        $exitCode = $LASTEXITCODE
+        foreach ($line in $output) {
+            Write-Host ([string]$line)
+        }
+        if ($exitCode -ne 0) {
+            throw "packwiz $($Arguments -join ' ') exited with code $exitCode."
+        }
+
+        return [pscustomobject]@{
+            ExitCode = $exitCode
+            Output = $output
         }
     }
     finally {
@@ -146,10 +207,14 @@ New-Item -ItemType Directory -Force -Path $WorkRoot | Out-Null
 try {
     Write-Status "Generating temporary packwiz pack..."
     Invoke-GeneratePackwizFiles -OutputDir $WorkRoot
+    if ($Category -ne "mods") {
+        Write-Status "Removing mod-loader filters from the temporary $Category pack..."
+        Remove-PackwizLoaderVersions -PackFilePath (Join-Path $WorkRoot "pack.toml")
+    }
     Ensure-Tool -Url $PackwizUrl -Destination $PackwizExe
 
     Write-Status "Adding the requested CurseForge file in the temporary pack..."
-    Invoke-Packwiz -Arguments @(
+    $addResult = Invoke-Packwiz -Arguments @(
         "curseforge", "add", $CurseForgeUrl,
         "--meta-folder", $Category,
         "--meta-folder-base", ".",
@@ -158,19 +223,27 @@ try {
 
     $tempCategoryRoot = Join-Path $WorkRoot $Category
     $generatedMetadata = @(Get-ChildItem -LiteralPath $tempCategoryRoot -Filter "*.pw.toml" -File -ErrorAction SilentlyContinue)
-    if ($generatedMetadata.Count -ne 1) {
-        throw "Expected exactly one generated $Category metadata file, found $($generatedMetadata.Count)."
+    $mainProjectFilename = Get-AddedProjectFilename -Output $addResult.Output
+    if (-not $mainProjectFilename) {
+        throw "Packwiz did not report the requested project's generated filename."
     }
 
-    $tempTargetPath = $generatedMetadata[0].FullName
+    $targetMetadata = @(
+        $generatedMetadata | Where-Object { (Get-PwTomlFilename -Path $_.FullName) -eq $mainProjectFilename }
+    )
+    if ($targetMetadata.Count -ne 1) {
+        throw "Expected exactly one metadata file for '$mainProjectFilename', found $($targetMetadata.Count)."
+    }
+
+    $tempTargetPath = $targetMetadata[0].FullName
     $content = Get-Content -LiteralPath $tempTargetPath -Raw
     $content = Set-PwTomlSide -Content $content -Side $Side
     Write-Utf8NoBomFile -LiteralPath $tempTargetPath -Content $content
 
     Write-Status "Refreshing the temporary pack..."
-    Invoke-Packwiz -Arguments @("refresh") -WorkingDirectory $WorkRoot
+    $null = Invoke-Packwiz -Arguments @("refresh") -WorkingDirectory $WorkRoot
 
-    $targetPath = Join-Path (Join-Path $RepoRoot $Category) $generatedMetadata[0].Name
+    $targetPath = Join-Path (Join-Path $RepoRoot $Category) $targetMetadata[0].Name
     if (Test-Path -LiteralPath $targetPath) {
         if ($DryRun) {
             Write-Status "Dry run: metadata is valid, but $targetPath already exists and would not be replaced."
@@ -180,12 +253,12 @@ try {
     }
 
     if ($DryRun) {
-        Write-Status "Dry run: would add $($generatedMetadata[0].Name) with side = `"$Side`"."
+        Write-Status "Dry run: would add $($targetMetadata[0].Name) with side = `"$Side`"."
         return
     }
 
     Write-Utf8NoBomFile -LiteralPath $targetPath -Content $content
-    Write-Status "Added $Category/$($generatedMetadata[0].Name) with side = `"$Side`"."
+    Write-Status "Added $Category/$($targetMetadata[0].Name) with side = `"$Side`"."
 }
 finally {
     if (Test-Path -LiteralPath $WorkRoot) {

--- a/scripts/update-packwiz-meta.ps1
+++ b/scripts/update-packwiz-meta.ps1
@@ -183,6 +183,34 @@ function Invoke-GeneratePackwizFiles {
     }
 }
 
+function Remove-PackwizLoaderVersions {
+    param([string]$PackFilePath)
+
+    $lines = @(Get-Content -LiteralPath $PackFilePath)
+    $updatedLines = [System.Collections.Generic.List[string]]::new()
+    $inVersions = $false
+    $changed = $false
+
+    foreach ($line in $lines) {
+        if ($line -match '^\s*\[([^]]+)\]\s*$') {
+            $inVersions = ($Matches[1] -eq "versions")
+            $updatedLines.Add($line) | Out-Null
+            continue
+        }
+
+        if ($inVersions -and $line -match '^\s*(forge|neoforge|fabric|quilt|liteloader)\s*=') {
+            $changed = $true
+            continue
+        }
+
+        $updatedLines.Add($line) | Out-Null
+    }
+
+    if ($changed) {
+        Write-Utf8NoBomFile -Path $PackFilePath -Content (($updatedLines -join "`n") + "`n")
+    }
+}
+
 function Get-AssetFiles {
     param(
         [string]$Directory,
@@ -202,12 +230,27 @@ function Get-AssetFiles {
     return $files
 }
 
+function Remove-FilenameVersionSuffix {
+    param([string]$Value)
+
+    if (-not $Value) { return "" }
+
+    $result = $Value.Trim()
+    while ($true) {
+        $suffixMatch = [regex]::Match($result, '(?i)\s*[\(\[]\s*(?:mc\s*)?v?\d[^\)\]]*[\)\]]\s*$')
+        if (-not $suffixMatch.Success) { break }
+        $result = $result.Substring(0, $suffixMatch.Index).TrimEnd()
+    }
+
+    return $result
+}
+
 function Derive-BaseName {
     param([string]$Filename)
 
     if (-not $Filename) { return "" }
 
-    $name = [IO.Path]::GetFileNameWithoutExtension($Filename)
+    $name = Remove-FilenameVersionSuffix -Value ([IO.Path]::GetFileNameWithoutExtension($Filename))
     $parts = $name -split '[-_]'
     $baseParts = @()
 
@@ -226,7 +269,7 @@ function Get-SearchStemFromFilename {
 
     if (-not $Filename) { return "" }
 
-    $name = [IO.Path]::GetFileNameWithoutExtension($Filename)
+    $name = Remove-FilenameVersionSuffix -Value ([IO.Path]::GetFileNameWithoutExtension($Filename))
     $parts = $name -split '[-_]'
     $kept = @()
 
@@ -421,6 +464,13 @@ function Normalize-PwSide {
     $normalized = $Side.Trim().ToLowerInvariant()
     if (@("both", "client", "server") -contains $normalized) { return $normalized }
     return "both"
+}
+
+function Get-DefaultPwSideForCategory {
+    param([string]$Value)
+
+    if ($Value -eq "mods") { return "both" }
+    return "client"
 }
 
 function Set-PwTomlSide {
@@ -928,11 +978,17 @@ function Get-CurseForgeCandidates {
 }
 
 function New-DetectionWorkspace {
-    param([string]$MetadataFolder = "mods")
+    param(
+        [string]$MetadataFolder = "mods",
+        [switch]$IgnoreModLoader
+    )
 
     $workspace = Join-Path $TempDetectRoot ([guid]::NewGuid().Guid)
     New-Item -ItemType Directory -Force -Path (Join-Path $workspace $MetadataFolder) | Out-Null
     Invoke-GeneratePackwizFiles -OutputDir $workspace
+    if ($IgnoreModLoader) {
+        Remove-PackwizLoaderVersions -PackFilePath (Join-Path $workspace "pack.toml")
+    }
     return $workspace
 }
 
@@ -976,7 +1032,7 @@ function Try-ResolveCurseForgeMetadata {
     $bestMismatch = $null
     $cfCategory = Get-CurseForgeCategorySlug -Value $Category
     foreach ($candidate in $Candidates) {
-        $workspace = New-DetectionWorkspace -MetadataFolder $Category
+        $workspace = New-DetectionWorkspace -MetadataFolder $Category -IgnoreModLoader:($Category -ne "mods")
         try {
             $arguments = @("curseforge", "add", $candidate, "--yes", "--meta-folder", $Category)
             if ($cfCategory) {
@@ -1103,6 +1159,9 @@ function Add-PackwizFilesMetadata {
     if (-not $Side -and $PwTomlPath -and (Test-Path $PwTomlPath)) {
         $existingData = Parse-PwToml -Path $PwTomlPath
         $Side = Get-TomlVal -Data $existingData -Key 'Side'
+    }
+    if (-not $Side) {
+        $Side = Get-DefaultPwSideForCategory -Value $Category
     }
     $sideValue = Normalize-PwSide -Side $Side
 
@@ -1617,7 +1676,8 @@ try {
 
             $metaName = Get-UniqueMetaName -PreferredName $preferredMetaName -Directory $modsDir
             $pwTomlPath = Join-Path $modsDir ($metaName + ".pw.toml")
-            Write-Utf8NoBomFile -Path $pwTomlPath -Content (Set-PwTomlSide -Content $cfMetadata.Content -Side "both")
+            $defaultSide = Get-DefaultPwSideForCategory -Value $Category
+            Write-Utf8NoBomFile -Path $pwTomlPath -Content (Set-PwTomlSide -Content $cfMetadata.Content -Side $defaultSide)
             Write-Status "  ~ Added (CurseForge): $($cfMetadata.Name)"
             $addedCurseForgeCount++
             continue


### PR DESCRIPTION
## 变更内容

- 修复 `add-packwiz-target.ps1` 与 `update-packwiz-meta.ps1` 在处理资源包、光影包时错误套用 Forge 加载器过滤的问题。
- 清理本地文件名末尾的括号版本后缀，提高 CurseForge 项目匹配成功率。
- 当 Packwiz 同时生成多个依赖元数据时，根据目标项目 ID 选择主项目，避免误取依赖项。
- 添加 Better Combat Particle 本体模组及 BC Particle Enhancement 资源包的 Packwiz 元数据。
- 将 CustomSkinLoader 从 ForgeV2 14.28 更新为 Universal 15.0.1，并重新生成受管模组完整性清单。
- 补充 Packwiz 资产流程文档，明确资源包和光影包探测不使用模组加载器过滤。

## 验证

- PowerShell 脚本语法解析通过。
- `git diff --check main...HEAD` 通过。
- BC Particle、CustomSkinLoader 和增强资源包的本地文件哈希与元数据一致。
- 资源包指定文件 URL、项目页 URL和普通 Forge 模组定向添加 Dry Run 通过。
- 在隔离环境执行 `resourcepacks` 的 `FullReconcile`，可正常生成 CurseForge 元数据，且不会错误回退到 `packwiz-files`。

## 影响范围

- Packwiz 单目标添加与分类级元数据修复流程。
- Better Combat Particle 相关客户端资产。
- CustomSkinLoader 客户端版本。
