### PR TITLE
[feat] v0.5.0.6-test 版本更新

### DIFF
--- a/.agents/skills/packwiz-assets/SKILL.md
+++ b/.agents/skills/packwiz-assets/SKILL.md
@@ -29,6 +29,7 @@ Use this workflow for modpack asset operations that touch `mods/`, `resourcepack
 4. For slow overseas services, retry once with `-Proxy "http://127.0.0.1:7890"`.
 5. Inspect the generated `.pw.toml` plus `packwiz-files` changes before staging, especially that existing `side = "client"` or `side = "server"` entries were not reset to `both`.
 6. Run `./scripts/sync-packwiz-assets.ps1` when local runtime files must match metadata.
+7. When a resource pack should be enabled for new clients by default, add its exact `file/<filename>` entry to `.options.txt` `resourcePacks`; release packaging renames this tracked file to `options.txt`. Verify its `pack.mcmeta` format before adding it to `incompatibleResourcePacks`.
 
 When old and new runtime JARs coexist, `update-packwiz-meta.ps1` selects the preferred newer filename and updates the existing metadata entry instead of creating a duplicate. Missing runtime JARs do not remove metadata by default; remove the `.pw.toml` explicitly, or use `-AllowRemovals` only when bulk removal is intentional and the runtime directory is complete.
 

--- a/.options.txt
+++ b/.options.txt
@@ -42,7 +42,7 @@ ao:true
 prioritizeChunkUpdates:0
 biomeBlendRadius:2
 renderClouds:"true"
-resourcePacks:["vanilla","tacz_resources","mod_resources","Moonlight Mods Dynamic Assets","file/Squareful v3.15forMC1.20.1.zip","file/Squareful-Create_Delight_Remake.zip","file/XK Highlight Block.zip","netherexp:jne_emissive","netherexp:jne_retextures","file/Torchmaster Remaster.zip","file/LCVP_CreateStyle_v1.7.zip","eclipticseasons.extra_snow","generated/fragmentum_layer"]
+resourcePacks:["vanilla","tacz_resources","mod_resources","Moonlight Mods Dynamic Assets","file/Squareful v3.15forMC1.20.1.zip","file/Squareful-Create_Delight_Remake.zip","file/BC Particle Enhancement (1.20.1) (1.0).zip","file/create-functional-storage-1.20.1-v1.0.0.zip","file/XK Highlight Block.zip","netherexp:jne_emissive","netherexp:jne_retextures","file/Torchmaster Remaster.zip","file/LCVP_CreateStyle_v1.7.zip","eclipticseasons.extra_snow","generated/fragmentum_layer"]
 incompatibleResourcePacks:["file/Torchmaster Remaster.zip","file/LCVP_CreateStyle_v1.7.zip"]
 lastServer:
 lang:zh_cn

--- a/modpack.toml
+++ b/modpack.toml
@@ -1,6 +1,6 @@
 name = "Create-Delight-Remake"
 author = "JSI"
-version = "v0.5.0.5-test"
+version = "v0.5.0.6-test"
 pack-format = "packwiz:1.1.0"
 
 [versions]


### PR DESCRIPTION
版本号更新：`v0.5.0.5-test` → `v0.5.0.6-test`

## 更新内容

- 在默认 `.options.txt` 中启用 BetterCombat Particle Enhancements + Compact
- 在默认 `.options.txt` 中启用 Create Functional Storage（流体抽屉）资源包
- 保留现有资源包顺序与不兼容资源包记录
- 补充 `/packwiz-assets` 流程，要求默认启用的新资源包同步维护 `.options.txt`

## 验证

- 两个启用项均与 `resourcepacks/*.pw.toml` 的 `filename` 完全一致
- 两个资源包均为 Minecraft 1.20.1 对应的 `pack_format: 15`
- 用户已验证本次客户端测试构建能够正常加入对应服务端版本
- `git diff --check` 通过
- 知识库全量校验仍被既有的 `CDC-mod-src/AGENTS.md` 缺失与 hotai 文档过期问题阻塞

## 发布说明

这是测试版发布 PR；合并后将按发布流程生成并发布 Client 与 Server 测试包。