### PR TITLE
[fix] 补充机械动力附属模组中文翻译

### DIFF
--- a/kubejs/assets/create_confectionery/lang/zh_cn.json
+++ b/kubejs/assets/create_confectionery/lang/zh_cn.json
@@ -100,5 +100,11 @@
   "item.create_confectionery.white_chocolate_glazed_marshmallow": "白巧克力包层棉花糖",
   "itemGroup.tabcreate_confectionery_tab": "机械动力：甜食",
   "item_group.create_confectionery.create_confectionery_tab": "机械动力：甜食",
-  "subtitles.the_bright_side": "The bright side"
+  "subtitles.the_bright_side": "The bright side",
+
+  "item.create_confectionery.candy_cane_hoe": "拐杖糖锄",
+  "item.create_confectionery.candy_cane_sword": "拐杖糖剑",
+  "item.create_confectionery.candy_cane_axe": "拐杖糖斧",
+  "item.create_confectionery.candy_cane_shovel": "拐杖糖锹",
+  "item.create_confectionery.candy_cane_pickaxe": "拐杖糖镐"
 }

--- a/kubejs/assets/create_new_age/lang/zh_cn.json
+++ b/kubejs/assets/create_new_age/lang/zh_cn.json
@@ -120,5 +120,11 @@
 	"block.create_new_age.advanced_motor_extension": "超级电机超频器",
 	"item.create_new_age.copper_circuit": "铜线电路板",
 	"item.create_new_age.blank_circuit": "电路板底板",
-	"tooltip.create_new_age.motor_extension": "需要放在电机后面使用"
+	"tooltip.create_new_age.motor_extension": "需要放在电机后面使用",
+
+	"block.create_new_age.street_light": "路灯",
+	"block.create_new_age.lamp_post": "灯柱",
+	"create.create_new_age.street_light.light_level": "光照等级",
+	"create.tooltip.create_new_age.per_light_level": "每级光照等级",
+	"item.create_new_age.incomplete_reactor_casing": "未完成的反应堆外壳"
 }


### PR DESCRIPTION
- 补充 Create Confectionery 拐杖糖工具的中文名称
- 补充 Create: New Age 路灯、灯柱、光照等级与反应堆外壳翻译
- 统一补齐语言文件末尾换行

验证：
- 两份 zh_cn.json 均通过 JSON 解析
- 翻译键无重复，git diff --check 通过