### PR TITLE
[fix] 修正 Alex 洞穴星体入口提示 (#2022)

### DIFF
--- a/config/ftbquests/quests/chapters/Valley_of_Eerie_Silence.snbt
+++ b/config/ftbquests/quests/chapters/Valley_of_Eerie_Silence.snbt
@@ -9,9 +9,10 @@
 	quest_links: [ ]
 	quests: [
 		{
+			dependencies: ["1F6B56E6DE97C1D7"]
 			description: [
 				"异寂空谷以恐怖的黑暗和诡谲的黑魔法为主题。这里的生物多为发生了异变的诡异生物，而这里的居民都是不欢迎外来者的邪教徒。此处被深邃的黑暗笼罩着，玩家在这里的视野会被缩短，同时光源放出的光也会变得更加微弱。往远处看，玩家只能看到一个个猩红的眼球。危险悄然潜伏于黑暗之中......"
-				"&4进入方法：使用&e泥胚&4搭建传送门框架，使用恶意碎片激活。"
+				"&4进入方法：解锁并乘火箭前往&b月背异常区&4，异寂空谷位于其地下深处。"
 			]
 			icon: {
 				Count: 1
@@ -27,7 +28,7 @@
 				advancement: "alexscaves:alexscaves/discover_forlorn_hollows"
 				criterion: ""
 				id: "258831EFD983106F"
-				title: "前往黑暗世界"
+				title: "抵达异寂空谷"
 				type: "advancement"
 			}]
 			x: 0.0d

--- a/kubejs/AGENTS.md
+++ b/kubejs/AGENTS.md
@@ -48,7 +48,7 @@ config/             # KubeJS config files
 - Startup scripts include a legacy misspelling (`registery_*`); search both `registry` and `registery`.
 - KJS `Java.loadClass` facades are per script domain (`CDStartupJavaClasses`, `CDServerJavaClasses`, `CDClientJavaClasses`); startup is not a shared replacement for server/client because each domain has distinct load timing and side safety.
 - Business scripts should access facade members directly, e.g. `global.CDServerJavaClasses.$ModularItem`; top-level aliases still share Rhino scope and can redeclare across files.
-- Alex's Caves placement is split: magnetic caves are in `data/northstar/dimension/moon.json`, toxic caves are in `data/northstar/dimension/venus.json`, other caves are independent dimensions in `data/createdelight/dimension/`, and `../config/alexscaves_biome_generation/*.json` is disabled so do not infer placement from it.
+- Alex's Caves placement is split: magnetic caves are in `data/northstar/dimension/moon.json`, toxic caves are in `data/northstar/dimension/venus.json`, abyssal chasm is in `data/northstar/dimension/europa.json`, forlorn hollows is in `data/createdelight/dimension/lunar_farside.json`; only primordial caves and candy cavity remain independent dimensions, and `../config/alexscaves_biome_generation/*.json` is disabled so do not infer placement from it.
 
 ## UNIQUE STYLES
 

--- a/kubejs/assets/createdelight/lang/zh_cn.json
+++ b/kubejs/assets/createdelight/lang/zh_cn.json
@@ -753,7 +753,7 @@
     "createdelight.tip.dragon_spawn": "火龙在火星、水星与金星, 电龙在金星, 冰龙在火星山峰与高地。",
     "createdelight.tip.dread_update_smithing_template": "悚怖锻造模板可以在悚陵中的\"悚怖女皇\"所在层数的四个箱子中获取。",
     "createdelight.tip.ender_reverb": "附近有小黑时被传送？看看你手上的工具有没有用末地烛作手柄。",
-    "createdelight.tip.enter_alexscaves_dimension": "Alex洞穴中, 磁力洞穴在月球, 剧毒洞穴在金星; 其余洞穴为独立维度, 进入方法请参见任务。",
+    "createdelight.tip.enter_alexscaves_dimension": "Alex洞穴中，磁力洞穴在月球，剧毒洞穴在金星，渊海陷窟在木卫二，异寂空谷在月背异常区；其余洞穴为独立维度，进入方法请参见任务。",
     "createdelight.tip.fasten_letios_compost": "将忘魂肥料放在灵魂沙峡谷会加速其忘却速度。",
     "createdelight.tip.faucet": "水龙头搭配水源方块能够提供取之不尽的水。这在搭建锅炉时会很有用!",
     "createdelight.tip.forged_ruin_collect": "你需要使用精准采集的锤子才能将锻造仪器的东西带走。",


### PR DESCRIPTION
## 摘要

- 补全 Alex 洞穴加载提示中的星体分布：渊海陷窟位于木卫二，异寂空谷位于月背异常区。
- 将异寂空谷任务改为依赖月背异常区解锁，并引导玩家乘火箭前往。
- 同步更新 KubeJS 的位置说明。

## 验证

- JSON 解析通过。
- `git diff --check` 通过。
- Packwiz 资源同步成功。

## 关联

- Fixes #2022