### PR TITLE
[fix] 移除创造模式物品栏中的月球钛矿

### DIFF
--- a/kubejs/startup_scripts/creative_tab/northstar.js
+++ b/kubejs/startup_scripts/creative_tab/northstar.js
@@ -9,3 +9,11 @@ StartupEvents.modifyCreativeTab("northstar:northstar_items", e => {
         'northstar:circuit_engraver', 
         'northstar:electrolysis_machine'])
 })
+
+StartupEvents.modifyCreativeTab("northstar:northstar_blocks", e => {
+    e.remove([
+        // 月球钛矿的世界生成已被移除，避免其在 JEI 中误导玩家。
+        'northstar:moon_titanium_ore',
+        'northstar:moon_deep_titanium_ore',
+    ])
+})


### PR DESCRIPTION
## 修改内容

- 通过 `StartupEvents.modifyCreativeTab` 从 Northstar 方块创造模式物品栏移除月球钛矿与深层月球钛矿。
- 对应月球钛矿世界生成已移除，避免玩家在物品查询中产生误解。

## 验证

- `node --check kubejs/startup_scripts/creative_tab/northstar.js`
- `git diff --check`

Closes #2086