### PR TITLE
[dev] 自动更新 Crash Assistant 模组基线

### DIFF
--- a/.agents/skills/packwiz-assets/SKILL.md
+++ b/.agents/skills/packwiz-assets/SKILL.md
@@ -58,7 +58,7 @@ When old and new runtime JARs coexist, `update-packwiz-meta.ps1` selects the pre
 
 仅当 Mod 确实可选时才加入脚本白名单；除 `side = "client"` 外，还要检查反向强制依赖及直接脚本/配置集成。白名单应使用与目标 JAR 对应的窄文件名前缀，并同时覆盖新增、移除和更新。文件名不带末尾数字版本段时不能可靠识别为一次版本变化，应保留为独立新增/移除项。
 
-生成流程：
+提交 `mods/**/*.pw.toml` 变动时，已通过 `scripts/install-git-hooks.ps1` 安装的 `pre-commit` hook 会自动重建并暂存该基线；PR 校验会再次生成并检查文件是否已提交。未安装 hook 或明确使用 `--no-verify` 时，手动执行以下流程：
 
 ```powershell
 ./scripts/sync-packwiz-assets.ps1

--- a/.agents/skills/repo-sync/SKILL.md
+++ b/.agents/skills/repo-sync/SKILL.md
@@ -29,10 +29,16 @@ git checkout main
 ```powershell
 git pull --ff-only origin main
 git rebase origin/main
+git diff --quiet $oldHead HEAD -- scripts/install-git-hooks.ps1 scripts/.githooks
+if ($LASTEXITCODE -eq 1) {
+    ./scripts/install-git-hooks.ps1
+}
 ./scripts/sync-packwiz-assets.ps1 -IfGitChanged -OldRev $oldHead -NewRev HEAD -HookName repo-sync
 ```
 
 `-IfGitChanged` checks `mods|resourcepacks|shaderpacks/**/*.pw.toml` and `packwiz-files/**`; it runs the full runtime sync only when needed. Git hooks perform the same check for regular local Git operations, but still run this command here so agent-managed updates have a visible result.
+
+The post-update hook installation only runs when the installer or tracked hooks changed. This makes newly added hooks available immediately, while ordinary repository updates do not rewrite local hook shims.
 
 3. If `CDC-mod-src` changed or `git status` reports the submodule modified after update, run:
 

--- a/.github/workflows/validate-crash-assistant-modlist.yml
+++ b/.github/workflows/validate-crash-assistant-modlist.yml
@@ -1,0 +1,24 @@
+name: Validate Crash Assistant mod list
+
+on:
+  pull_request:
+    paths:
+      - 'mods/**/*.pw.toml'
+      - 'config/modpack_defaults/config/crash_assistant/modlist.json'
+      - 'scripts/generate-crash-assistant-modlist.py'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Regenerate Crash Assistant mod-list baseline
+        run: python3 scripts/generate-crash-assistant-modlist.py
+      - name: Verify generated baseline is committed
+        run: git diff --exit-code -- config/modpack_defaults/config/crash_assistant/modlist.json

--- a/scripts/.githooks/pre-commit
+++ b/scripts/.githooks/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
+
+if ! git diff --cached --name-only --diff-filter=ACMRD -- mods | grep -Eq '^mods/.+\.pw\.toml$'; then
+  exit 0
+fi
+
+if command -v python >/dev/null 2>&1; then
+  python_cmd=python
+elif command -v python3 >/dev/null 2>&1; then
+  python_cmd=python3
+else
+  printf >&2 '%s\n' "Python is required to update the Crash Assistant mod-list baseline."
+  exit 1
+fi
+
+printf '%s\n' "Packwiz mod metadata changed; regenerating Crash Assistant baseline..."
+"$python_cmd" scripts/generate-crash-assistant-modlist.py
+git add -- config/modpack_defaults/config/crash_assistant/modlist.json

--- a/scripts/install-git-hooks.ps1
+++ b/scripts/install-git-hooks.ps1
@@ -124,12 +124,12 @@ if ($null -ne $isWindowsVariable) {
     $isWindowsPlatform = [bool]$isWindowsVariable.Value
 }
 
-foreach ($hookName in @("post-merge", "post-checkout", "post-rewrite")) {
+foreach ($hookName in @("pre-commit", "post-merge", "post-checkout", "post-rewrite")) {
     Install-HookShim -Name $hookName
 }
 
 if (-not $isWindowsPlatform) {
-    Get-ChildItem -LiteralPath $gitHooksPath -File | Where-Object { $_.Name -in @("post-merge", "post-checkout", "post-rewrite") } | ForEach-Object {
+    Get-ChildItem -LiteralPath $gitHooksPath -File | Where-Object { $_.Name -in @("pre-commit", "post-merge", "post-checkout", "post-rewrite") } | ForEach-Object {
         chmod +x $_.FullName
     }
 }


### PR DESCRIPTION
## 变更

- 在暂存 Packwiz 模组元数据时，pre-commit 自动重建并暂存 Crash Assistant 模组基线。
- 增加 PR 工作流，校验基线是否与当前模组清单一致。
- Git 同步后仅在受管 hook 定义发生变化时补装 hooks，使 agent 立即获得新增 hook。
- hook 安装器与 Packwiz 资产工作流说明同步更新。

## 验证

- `py -3.11 scripts/test-packwiz-stable-filter.py`
- 隔离 Git 副本端到端 pre-commit 测试
- `git diff --check`
- hook 变更条件检查