### PR TITLE
[mod] 加入 Tetra Immersion

### DIFF
--- a/config/modpack_defaults/config/crash_assistant/modlist.json
+++ b/config/modpack_defaults/config/crash_assistant/modlist.json
@@ -1749,6 +1749,11 @@
     "name": "Tetra",
     "version": "1.20.1-6.9.0"
   },
+  "tetra_immersion-0.1.1.jar": {
+    "modId": "tetra_immersion",
+    "name": "Tetra Immersion",
+    "version": "0.1.1"
+  },
   "tetra_insight-0.1.2.jar": {
     "modId": "tetra_insight",
     "name": "Tetra Insight",

--- a/mods/tetra-immersion.pw.toml
+++ b/mods/tetra-immersion.pw.toml
@@ -1,0 +1,13 @@
+name = "Tetra Immersion"
+filename = "tetra_immersion-0.1.1.jar"
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "bdce5606f012c2628b2c726b81a11cc9f8d7cc6e"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8574216
+project-id = 1635848


### PR DESCRIPTION
## 内容

- 通过 CurseForge 元数据加入 Tetra Immersion `0.1.1`。
- 模组标记为 `side = client`：它会增强客户端工作台交互，但所有权威变更仍通过 Tetra 原有容器点击和服务端数据包处理。
- 同步 Crash Assistant 模组基线。

## 验证

- 已在 `main` 执行 `scripts/update-packwiz-meta.ps1 -Category mods -FullReconcile`。
- 使用 `add-packwiz-target.ps1` 定向生成官方元数据。
- `packwiz refresh`、`git diff --check` 通过。
- 运行时 `tetra_immersion-0.1.1.jar` SHA-1 与元数据一致：`bdce5606f012c2628b2c726b81a11cc9f8d7cc6e`。

## 范围

本 PR 只有 Tetra Immersion 元数据和 Crash Assistant 基线，不包含 Apotheosis、Fallen、Feywild、Iron's Spells、Quest Giver、Travel Optics、Farmers Spell 或其他冒险模组改动。