### PR TITLE
[feat] v0.5.0.7-test 版本更新

### DIFF
--- a/modpack.toml
+++ b/modpack.toml
@@ -1,6 +1,6 @@
 name = "Create-Delight-Remake"
 author = "JSI"
-version = "v0.5.0.6-test"
+version = "v0.5.0.7-test"
 pack-format = "packwiz:1.1.0"
 
 [versions]


### PR DESCRIPTION
版本号更新: → v0.5.0.7-test

**更新内容**:
- [mod] 替换灵钢锭配方中的传送质 (#2110) (#2110)