### PR TITLE
[dev] 发布产物上传移动到github action里，提升速度；[dev] hotai校验优化

### DIFF
--- a/.agents/skills/hotai/SKILL.md
+++ b/.agents/skills/hotai/SKILL.md
@@ -25,7 +25,7 @@ description: 维护、分析、迁移或验证 Create-Delight Remake 的 `hotai/
 2. 从 `.badiff` 相对路径推导目标 class internal name；例如 `hotai/a/b/C.badiff` 对应 `a/b/C`。
 3. 更新或分析补丁后，运行 `scripts/update-hotai-docs.ps1` 刷新 `HOTAI_STATUS` 区块。不要手改该区块。
 4. 在 `badiff-details.md` 的生成区块外记录方法级语义和证据；在 `patch-map.md` 只更新领域级摘要与跨目录依赖。
-5. 运行 `scripts/update-hotai-docs.ps1 -Check`；需要完整知识库校验时再运行 `scripts/validate-knowledge-base.ps1`。
+5. 运行 `scripts/update-hotai-docs.ps1 -Check`，它只校验受版本控制的 `.badiff` 路径与目标 class 映射；需要复核某一参考运行环境的 JAR/日志状态时，运行 `scripts/update-hotai-docs.ps1 -Check -StrictRuntimeStatus`。通用 `scripts/validate-knowledge-base.ps1` 默认不读取本地 JAR 或日志；仅传入 `-CheckHotaiRuntimeStatus` 时才执行严格运行时状态校验。
 
 ## 状态判定
 

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -5,7 +5,7 @@ description: 管理 Create-Delight Remake 整合包的正式版或测试版发�
 
 # Create-Delight Remake 发布
 
-发布脚本负责 Git 分支、版本写入、标签、CI、产物、Release、公告 PR 和重试。agent 只判断发布意图与玩家可读的文案。
+发布脚本负责 Git 分支、版本写入、标签、CI 等待、说明、公开 Release、公告 PR 和重试；标签 CI 的 `release-assets` job 负责下载同一次运行的 artifact、压缩并上传 Release 资产。agent 只判断发布意图与玩家可读的文案。
 
 ## 先生成只读计划
 

--- a/.agents/skills/release/release-publish.ps1
+++ b/.agents/skills/release/release-publish.ps1
@@ -5,12 +5,9 @@
 .DESCRIPTION
     Handles the full release pipeline after PR merge:
     - Tags the target branch and pushes the tag
-    - Waits for GitHub Actions CI to complete
-    - Downloads build artifacts (Client, Server, and optionally Patch)
-    - Re-compresses artifacts into zip files
-    - Copies to bracket-free paths (PowerShell [] glob workaround)
+    - Waits for GitHub Actions CI to build and upload release assets
     - Generates release notes from git log
-    - Creates GitHub Release with artifacts
+    - Updates and publishes the GitHub Release
     - Verifies all assets uploaded
 
 .PARAMETER Version
@@ -222,15 +219,12 @@ if ($WhatIf) {
     Write-Host ""
     Write-Host "   Would:"
     Write-Host "   A. Create tag $Version on $TargetBranch and push"
-    Write-Host "   B. Wait for CI (timeout: $CITimeoutMinutes min)"
-    Write-Host "   C. Download artifacts (Client, Server$(if($ReleaseType -eq '正式'){', ClientPatch, ServerPatch'}))"
-    Write-Host "   D. Compress and prepare for upload"
-    Write-Host "   E. Generate release notes from $PreviousVersion..$Version"
-    Write-Host "   F. Create draft GitHub release"
-    Write-Host "   G. Upload assets one by one with retries, then publish"
-    Write-Host "   H. Verify assets"
+    Write-Host "   B. Wait for CI to prepare and upload release assets (timeout: $CITimeoutMinutes min)"
+    Write-Host "   C. Generate release notes from $PreviousVersion..$Version"
+    Write-Host "   D. Update and publish the draft release"
+    Write-Host "   E. Verify assets"
     if ($ReleaseType -eq "正式") {
-        Write-Host "   I. Create announcement PR to main"
+        Write-Host "   F. Create announcement PR to main"
     }
     exit 0
 }
@@ -335,15 +329,15 @@ $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 $RunId = $null
 
 # Wait for the workflow run triggered by our tag to appear.
-# Match by workflow name AND head_sha to avoid picking up a previous run.
+# Match by workflow name, tag name, and head SHA to avoid its branch-push run.
 # Use single quotes for --jq to avoid PowerShell string interpolation issues.
 $workflowName = "发布版本"
 while ($stopwatch.Elapsed -lt $timeout) {
     # First get all runs, then filter in PowerShell to avoid jq quoting hell
-    $allRuns = gh run list --repo $repo --limit 10 --json databaseId,status,conclusion,name,headSha 2>$null
+    $allRuns = gh run list --repo $repo --limit 10 --json databaseId,status,conclusion,name,headBranch,headSha 2>$null
     if ($LASTEXITCODE -eq 0 -and $allRuns) {
         $runs = $allRuns | ConvertFrom-Json -ErrorAction SilentlyContinue
-        $matchingRun = $runs | Where-Object { $_.name -eq $workflowName -and $_.headSha -eq $commitSha } | Select-Object -First 1
+        $matchingRun = $runs | Where-Object { $_.name -eq $workflowName -and $_.headBranch -eq $Version -and $_.headSha -eq $commitSha } | Select-Object -First 1
         if ($matchingRun -and $matchingRun.databaseId) {
             $RunId = $matchingRun.databaseId
             break
@@ -391,9 +385,10 @@ if ($stopwatch.Elapsed -ge $timeout) {
 }
 
 # ============================================================
-# Phase C: Download Artifacts
+# Phase C: CI asset transfer
 # ============================================================
-Write-Host "📥 Phase C: Downloading artifacts"
+Write-Host "📦 Phase C: Release assets are prepared and uploaded by GitHub Actions"
+<# Artifact download, compression, and upload moved to the release-assets CI job.
 
 $tmpDir = Join-Path $env:TEMP "opencode\$Version"
 New-Item -ItemType Directory -Path "$tmpDir\client" -Force | Out-Null
@@ -714,6 +709,7 @@ if ($ReleaseType -eq "正式") {
 }
 
 Write-Host "✅ Bracket-free copies created in $uploadDir"
+#>
 
 # ============================================================
 # Phase F: Generate Release Notes
@@ -876,10 +872,8 @@ Write-Host "🚀 Phase G: Creating GitHub Release"
 
 if ($ReleaseType -eq "正式") {
     $title = "$Version 正式版"
-    $uploadAssets = @($uploadClient, $uploadClientPatch, $uploadServer, $uploadServerPatch)
 } else {
     $title = "$Version 测试版"
-    $uploadAssets = @($uploadClient, $uploadServer)
 }
 
 $notesFile = Join-Path $env:TEMP "opencode\release-notes-$Version.md"
@@ -917,6 +911,7 @@ if ($LASTEXITCODE -eq 0 -and $releaseViewJson) {
 Remove-Item $notesFile -Force -ErrorAction SilentlyContinue
 Write-Host "✅ Draft release ready: $title"
 
+<# Release asset upload moved to the release-assets CI job.
 function Get-ReleaseForUpload {
     $releaseListJson = gh api "repos/$repo/releases" --paginate 2>$null
     if ($LASTEXITCODE -ne 0 -or -not $releaseListJson) {
@@ -1079,6 +1074,7 @@ foreach ($asset in $uploadAssets) {
 }
 
 Write-Host "✅ Release assets uploaded"
+#>
 
 if ($ReleaseType -eq "正式") {
     gh release edit $Version --repo $repo --draft=false --prerelease=false
@@ -1239,4 +1235,3 @@ Write-Host "🔗 $releaseUrl"
 if ($announcementPrUrl) {
     Write-Host "📢 Announcement PR: $announcementPrUrl"
 }
-Write-Host "📁 Temp directory preserved: $tmpDir"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,8 @@ jobs:
   patch-tasks:
     needs: [common-steps, client-tasks]
     runs-on: ubuntu-latest
+    outputs:
+      previous_version: ${{ steps.read-previous-tag.outputs.latest_tag }}
     env:
       MODPACK_NAME: ${{ needs.common-steps.outputs.modpack_name }}
       MODPACK_VERSION: ${{ needs.common-steps.outputs.modpack_ver }}
@@ -259,6 +261,7 @@ jobs:
       - name: 安装 Packwiz
         uses: ./.github/actions/setup-packwiz
       - name: 获取最近的tag并配置环境变量
+        id: read-previous-tag
         run: |
           set -euo pipefail
           if git describe --tags --exact-match >/dev/null 2>&1; then
@@ -268,6 +271,7 @@ jobs:
           fi
           echo "最近的tag是: $latest_tag"
           echo "LATEST_TAG=$latest_tag" >> $GITHUB_ENV
+          echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
       - name: 更新整合包配置与版本信息
         uses: ./.github/actions/update-modpack-config
         with:
@@ -339,3 +343,118 @@ jobs:
             deploy-patch.sh
             deploy-patch.bat
             patch/
+
+  # 标签构建直接将同一次运行的 artifact 压缩并上传至草稿 Release。
+  # release-publish.ps1 保留发布说明、公开发布与公告 PR 的控制权。
+  release-assets:
+    needs: [common-steps, client-tasks, server-tasks, patch-tasks]
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
+    env:
+      MODPACK_NAME: ${{ needs.common-steps.outputs.modpack_name }}
+      MODPACK_VERSION: ${{ needs.common-steps.outputs.modpack_ver }}
+      PREVIOUS_VERSION: ${{ needs.patch-tasks.outputs.previous_version }}
+      IS_STABLE_RELEASE: ${{ needs.common-steps.outputs.is_stable_release }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: 创建或确认草稿 Release
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft >/dev/null 2>&1; then
+            is_draft=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+            if [[ "$is_draft" != "true" ]]; then
+              echo "Release $GITHUB_REF_NAME is already public" >&2
+              exit 1
+            fi
+            exit 0
+          fi
+
+          title="$GITHUB_REF_NAME 正式版"
+          prerelease_args=()
+          if [[ "$IS_STABLE_RELEASE" != "true" ]]; then
+            title="$GITHUB_REF_NAME 测试版"
+            prerelease_args=(--prerelease)
+          fi
+          gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --title "$title" --draft "${prerelease_args[@]}"
+      - name: 下载客户端包 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "[Client]${{ env.MODPACK_NAME }}-${{ env.MODPACK_VERSION }}"
+          path: release-artifacts/client
+      - name: 下载服务端包 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "Server-${{ env.MODPACK_NAME }}-${{ env.MODPACK_VERSION }}"
+          path: release-artifacts/server
+      - name: 下载客户端补丁 artifact
+        if: env.IS_STABLE_RELEASE == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: "[ClientPatch]${{ env.MODPACK_NAME }}-${{ env.PREVIOUS_VERSION }}-to-${{ env.MODPACK_VERSION }}"
+          path: release-artifacts/clientpatch
+      - name: 下载服务端补丁 artifact
+        if: env.IS_STABLE_RELEASE == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: "[ServerPatch]${{ env.MODPACK_NAME }}-${{ env.PREVIOUS_VERSION }}-to-${{ env.MODPACK_VERSION }}"
+          path: release-artifacts/serverpatch
+      - name: 压缩 Release 文件
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+
+          package_directory() {
+            local source_dir="$1"
+            local destination_name="$2"
+            if [[ ! -d "$source_dir" ]]; then
+              echo "Missing artifact directory: $source_dir" >&2
+              exit 1
+            fi
+            (
+              cd "$source_dir"
+              zip -rq "$GITHUB_WORKSPACE/release-assets/$destination_name" .
+            )
+          }
+
+          package_directory release-artifacts/client "Client-${MODPACK_NAME}-${MODPACK_VERSION}.zip"
+          package_directory release-artifacts/server "Server-${MODPACK_NAME}-${MODPACK_VERSION}.zip"
+
+          if [[ "$IS_STABLE_RELEASE" == "true" ]]; then
+            package_directory release-artifacts/clientpatch "ClientPatch-${MODPACK_NAME}-${PREVIOUS_VERSION}-to-${MODPACK_VERSION}.zip"
+            package_directory release-artifacts/serverpatch "ServerPatch-${MODPACK_NAME}-${PREVIOUS_VERSION}-to-${MODPACK_VERSION}.zip"
+          fi
+      - name: 上传 Release 资产至草稿
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          assets=(release-assets/*.zip)
+          expected_count=2
+          if [[ "$IS_STABLE_RELEASE" == "true" ]]; then
+            expected_count=4
+          fi
+          if [[ "${#assets[@]}" -ne "$expected_count" ]]; then
+            echo "Expected $expected_count release archives, got ${#assets[@]}" >&2
+            exit 1
+          fi
+
+          for asset in "${assets[@]}"; do
+            uploaded=false
+            for attempt in {1..5}; do
+              echo "Uploading $(basename "$asset") ($attempt/5)"
+              if timeout 3600 gh release upload "$GITHUB_REF_NAME" "$asset" --repo "$GITHUB_REPOSITORY" --clobber; then
+                uploaded=true
+                break
+              fi
+              sleep 15
+            done
+            if [[ "$uploaded" != "true" ]]; then
+              echo "Failed to upload $(basename "$asset")" >&2
+              exit 1
+            fi
+          done

--- a/scripts/update-hotai-docs.ps1
+++ b/scripts/update-hotai-docs.ps1
@@ -1,7 +1,8 @@
 ﻿param(
     [string]$Root = "",
     [string]$DetailsPath = "",
-    [switch]$Check
+    [switch]$Check,
+    [switch]$StrictRuntimeStatus
 )
 
 $ErrorActionPreference = "Stop"
@@ -158,10 +159,36 @@ if ($detailsText.Contains($begin) -and $detailsText.Contains($end)) {
 }
 
 if ($Check) {
-    if ($updatedText -ne $detailsText) {
-        throw "hotai generated documentation is out of date. Run scripts/update-hotai-docs.ps1."
+    if ($StrictRuntimeStatus) {
+        if ($updatedText -ne $detailsText) {
+            throw "hotai runtime status is out of date for the current local JARs and logs. Run scripts/update-hotai-docs.ps1 from the reference runtime."
+        }
+        Write-Host "hotai patch map and current runtime status are up to date." -ForegroundColor Green
+        return
     }
-    Write-Host "hotai generated documentation is up to date." -ForegroundColor Green
+
+    $statusBlockMatch = [regex]::Match($detailsText, "(?s)<!-- HOTAI_STATUS:BEGIN -->.*?<!-- HOTAI_STATUS:END -->")
+    if (-not $statusBlockMatch.Success) {
+        throw "hotai status block is missing from $DetailsPath. Run scripts/update-hotai-docs.ps1."
+    }
+
+    $documentedTargets = @(
+        [regex]::Matches($statusBlockMatch.Value, '(?m)^\|\s*[^|]+\|\s*`([^`]+\.badiff)`\s*\|\s*`([^`]+)`\s*\|') |
+            ForEach-Object { "$($_.Groups[1].Value)|$($_.Groups[2].Value)" } |
+            Sort-Object
+    )
+    $expectedTargets = @(
+        $rows |
+            ForEach-Object { "$($_.BadiffPath)|$($_.InternalName)" } |
+            Sort-Object
+    )
+    $targetDiff = Compare-Object -ReferenceObject $expectedTargets -DifferenceObject $documentedTargets
+    if ($targetDiff) {
+        $diffText = ($targetDiff | ForEach-Object { $_.InputObject }) -join ", "
+        throw "hotai patch map is out of date: $diffText. Run scripts/update-hotai-docs.ps1."
+    }
+
+    Write-Host "hotai patch map is up to date; local runtime status was not compared." -ForegroundColor Green
     return
 }
 

--- a/scripts/validate-knowledge-base.ps1
+++ b/scripts/validate-knowledge-base.ps1
@@ -1,6 +1,7 @@
 param(
     [string]$Root = "",
-    [switch]$StrictWarnings
+    [switch]$StrictWarnings,
+    [switch]$CheckHotaiRuntimeStatus
 )
 
 $ErrorActionPreference = "Stop"
@@ -158,9 +159,9 @@ if (Test-Path -LiteralPath $devKnowledgeDocsPath) {
 }
 
 $hotaiDocScript = Join-Path $Root "scripts/update-hotai-docs.ps1"
-if (Test-Path -LiteralPath $hotaiDocScript) {
+if ($CheckHotaiRuntimeStatus -and (Test-Path -LiteralPath $hotaiDocScript)) {
     try {
-        & $hotaiDocScript -Root $Root -Check
+        & $hotaiDocScript -Root $Root -Check -StrictRuntimeStatus
     } catch {
         Add-Failure $_.Exception.Message
     }


### PR DESCRIPTION
将标签发布的 artifact 压缩和上传迁入 GitHub Actions，保留本地发布说明、公开 Release 与公告 PR；同时将 hotai 默认校验收敛为可复现的补丁映射检查，本机 JAR/日志状态改为显式严格校验。验证：git diff --check、hotai 映射检查、PowerShell 语法解析。