### PR TITLE
[dev] 规范 KubeJS 与 CDC 职责边界

### DIFF
--- a/kubejs/AGENTS.md
+++ b/kubejs/AGENTS.md
@@ -38,7 +38,7 @@ config/             # KubeJS config files
 ## CONVENTIONS
 
 - Recipe ID namespace: `createdelight`; recipe folders use display names with spaces/apostrophes, so quote paths in shell commands.
-- **职责边界**：KubeJS 是内容配置层，仅新增或调整配方、标签、战利品表、简单物品移除/隐藏及其必要的兼容数据；不要在此实现新的游戏机制。
+- **职责边界**：KubeJS 是内容配置层，仅新增或调整配方、标签、战利品表、简单物品移除/隐藏及其必要的兼容数据；可实现无状态的轻量交互（如单次鼠标右键效果）和纯客户端展示（如 tooltip、JEI 信息），不要在此实现新的游戏机制。
 - **CDC 优先**：自定义方块/物品的行为、机器或菜单、能力与持久化状态、命令、网络包、服务端/客户端联动、实体/方块交互、tick 逻辑、渲染和跨模组运行时兼容，默认在 `CDC-mod-src/` 的 Create Delight Core 中实现。KubeJS 只引用 CDC 提供的稳定数据或 API 来配置内容。
 - **例外处理**：若上游限制使运行时逻辑暂时不能迁入 CDC，必须在 KubeJS 文件中说明原因并关联跟踪 issue；不要新增无迁移计划的事件处理器、Java 反射桥接或客户端网络逻辑。
 - Use `cutting_2()` for knife recipes (includes tetra module)

--- a/kubejs/AGENTS.md
+++ b/kubejs/AGENTS.md
@@ -38,6 +38,9 @@ config/             # KubeJS config files
 ## CONVENTIONS
 
 - Recipe ID namespace: `createdelight`; recipe folders use display names with spaces/apostrophes, so quote paths in shell commands.
+- **职责边界**：KubeJS 是内容配置层，仅新增或调整配方、标签、战利品表、简单物品移除/隐藏及其必要的兼容数据；不要在此实现新的游戏机制。
+- **CDC 优先**：自定义方块/物品的行为、机器或菜单、能力与持久化状态、命令、网络包、服务端/客户端联动、实体/方块交互、tick 逻辑、渲染和跨模组运行时兼容，默认在 `CDC-mod-src/` 的 Create Delight Core 中实现。KubeJS 只引用 CDC 提供的稳定数据或 API 来配置内容。
+- **例外处理**：若上游限制使运行时逻辑暂时不能迁入 CDC，必须在 KubeJS 文件中说明原因并关联跟踪 issue；不要新增无迁移计划的事件处理器、Java 反射桥接或客户端网络逻辑。
 - Use `cutting_2()` for knife recipes (includes tetra module)
 - Use `centrifugation()` for centrifuge recipes (handles 3 variants)
 - Delete recipes via `remove_recipes_id(e, [...])` - NOT `e.remove()` or `e.removeById()`
@@ -65,10 +68,7 @@ config/             # KubeJS config files
 - `make_cake(e, input, output)` - Cake deploying recipe
 
 **Other Utils**:
-- `util/metallurgy.js` - Metallurgy helpers
-- `util/ratatouille.js` - Ratatouille integration
-- `util/loot.js` - Loot table utilities
-- `util/trade.js` - Villager trade modifications
+- `util/metallurgy.js`, `util/ratatouille.js`, `util/loot.js`, `util/trade.js` - metallurgy, Ratatouille integration, loot tables and villager trades
 - `mbd2_recipes/proxy_recipe/centrifugation.js` - Centrifugation helper
 
 ## COMMANDS


### PR DESCRIPTION
## 摘要

- 在 kubejs/AGENTS.md 明确 KubeJS 仅承担内容配置，新的游戏机制默认由 CDC 实现。
- 列出 CDC 优先承载的机制类型，以及无法迁移时必须关联跟踪 issue 的例外要求。
- 合并同类工具说明，保持模块 AGENTS 文档 80 行上限。

## 验证

- git diff --check
- kubejs/AGENTS.md 行数：80

Closes #2084
