### PR TITLE
[fix] 回退 CustomSkinLoader 至 14.28

### DIFF
--- a/config/modpack_defaults/config/crash_assistant/modlist.json
+++ b/config/modpack_defaults/config/crash_assistant/modlist.json
@@ -659,10 +659,10 @@
     "name": "Custom Portal API [Forge]",
     "version": "1.0.1-forge-1.20.1"
   },
-  "CustomSkinLoader_Universal-15.0.1.jar": {
-    "modId": "customskinloader_universal",
+  "CustomSkinLoader_ForgeV2-14.28.jar": {
+    "modId": "customskinloader_forgev2",
     "name": "CustomSkinLoader",
-    "version": "15.0.1"
+    "version": "14.28"
   },
   "damage_trace-1.20.1-0.1.0.jar": {
     "modId": "damage_trace",

--- a/mods/customskinloader-bootstrap.pw.toml
+++ b/mods/customskinloader-bootstrap.pw.toml
@@ -1,13 +1,13 @@
 name = "CustomSkinLoader"
-filename = "CustomSkinLoader_Universal-15.0.1.jar"
+filename = "CustomSkinLoader_ForgeV2-14.28.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "ab8dd841cafc3b4ecbf0250d3f5aee8a1fdb506a"
+hash = "c7e87169bd8b59a9414620dd0fd63ca5a17c235d"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8291183
+file-id = 7822525
 project-id = 286924


### PR DESCRIPTION
## 变更

将 CustomSkinLoader 从 Universal 15.0.1 回退到 ForgeV2 14.28，并同步 Packwiz 元数据。

## 原因

15.0.1 在玩家头颅渲染时出现重复资料加载和大量皮肤源请求，导致手持、放置头颅以及 FTB 界面出现掉帧。14.28 是当前 Minecraft 1.20.1 Forge 实例此前使用的版本，并包含官方 14.23 的玩家头颅重复下载修复。

## 验证

- 14.28 JAR SHA-1：c7e87169bd8b59a9414620dd0fd63ca5a17c235d
- Packwiz 元数据 file-id：7822525
- Crash Assistant modlist 基线已由 pre-commit hook 更新
- 未包含其他工作区改动