### PR TITLE
[fix] 修复按钮无法触发动力合成器

### DIFF
--- a/config/createlazytick-common.toml
+++ b/config/createlazytick-common.toml
@@ -109,12 +109,12 @@
 	#Note: When this option is enabled, if you attempt to activate a mechanical crafter in a lazy-loaded state via redstone,
 	#you must ensure that the duration of the changed redstone signal is longer than the lazy-loading interval.
 	#A mechanical crafter in an active state can respond immediately without requiring the above conditions.
-	enable_lazy_crafter_redstone = true
+	enable_lazy_crafter_redstone = false
 	#
 	#--------------------------------------------------------------------------
 	#The maximum delay for activating a mechanical crafter via redstone after it has been inactive for a period of time.
 	#Range: > 0
-	crafter_redstone_delay_max = 60
+	crafter_redstone_delay_max = 20
 
 #Mechanical Arm Settings
 [arm]


### PR DESCRIPTION
## 摘要

- 关闭 Create:LazyTick 的机械合成器红石懒惰刻。
- 将 crafter_redstone_delay_max 从 60 调整为 20 tick，覆盖石质和黑石按钮的最短 20 tick 红石脉冲。

## 验证

- git diff --check 通过。
- 提交仅包含 config/createlazytick-common.toml。
- 未进行游戏内回归测试。