### PR TITLE
[fix] 修复按钮无法触发动力合成器（release-v048x）

### DIFF
--- a/config/createlazytick-common.toml
+++ b/config/createlazytick-common.toml
@@ -114,7 +114,7 @@
 	#--------------------------------------------------------------------------
 	#The maximum delay for activating a mechanical crafter via redstone after it has been inactive for a period of time.
 	#Range: > 0
-	crafter_redstone_delay_max = 20
+	crafter_redstone_delay_max = 18
 
 #Mechanical Arm Settings
 [arm]

--- a/config/createlazytick-common.toml
+++ b/config/createlazytick-common.toml
@@ -109,7 +109,7 @@
 	#Note: When this option is enabled, if you attempt to activate a mechanical crafter in a lazy-loaded state via redstone,
 	#you must ensure that the duration of the changed redstone signal is longer than the lazy-loading interval.
 	#A mechanical crafter in an active state can respond immediately without requiring the above conditions.
-	enable_lazy_crafter_redstone = false
+	enable_lazy_crafter_redstone = true
 	#
 	#--------------------------------------------------------------------------
 	#The maximum delay for activating a mechanical crafter via redstone after it has been inactive for a period of time.

--- a/config/createlazytick-common.toml
+++ b/config/createlazytick-common.toml
@@ -109,12 +109,12 @@
 	#Note: When this option is enabled, if you attempt to activate a mechanical crafter in a lazy-loaded state via redstone,
 	#you must ensure that the duration of the changed redstone signal is longer than the lazy-loading interval.
 	#A mechanical crafter in an active state can respond immediately without requiring the above conditions.
-	enable_lazy_crafter_redstone = true
+	enable_lazy_crafter_redstone = false
 	#
 	#--------------------------------------------------------------------------
 	#The maximum delay for activating a mechanical crafter via redstone after it has been inactive for a period of time.
 	#Range: > 0
-	crafter_redstone_delay_max = 60
+	crafter_redstone_delay_max = 20
 
 #Mechanical Arm Settings
 [arm]


### PR DESCRIPTION
参考 PR #2143，将 Create:LazyTick 的机械合成器红石配置回移到 release-v048x。启用 enable_lazy_crafter_redstone，并将 crafter_redstone_delay_max 从 60 调整为 18 tick。验证：git diff --check 通过；提交仅包含 config/createlazytick-common.toml；未进行游戏内回归测试。