### PR TITLE
[conf] 再次调整懒惰刻配置; [dev] 优化 Git hook 安装流程

### DIFF
--- a/.agents/skills/repo-sync/SKILL.md
+++ b/.agents/skills/repo-sync/SKILL.md
@@ -9,10 +9,10 @@ description: Keep the Create-Delight Remake checkout current and locally runnabl
 
 Use this workflow for repository update tasks before reporting completion.
 
-1. Ensure local Git hook shims are installed, confirm status, and record the pre-update commit:
+1. Ensure local Git hook shims are installed without rewriting existing shims, confirm status, and record the pre-update commit:
 
 ```powershell
-./scripts/install-git-hooks.ps1
+./scripts/install-git-hooks.ps1 -IfUnset -Quiet
 git status --short --branch
 $oldHead = git rev-parse HEAD
 ```
@@ -31,14 +31,14 @@ git pull --ff-only origin main
 git rebase origin/main
 git diff --quiet $oldHead HEAD -- scripts/install-git-hooks.ps1 scripts/.githooks
 if ($LASTEXITCODE -eq 1) {
-    ./scripts/install-git-hooks.ps1
+    ./scripts/install-git-hooks.ps1 -Quiet
 }
 ./scripts/sync-packwiz-assets.ps1 -IfGitChanged -OldRev $oldHead -NewRev HEAD -HookName repo-sync
 ```
 
 `-IfGitChanged` checks `mods|resourcepacks|shaderpacks/**/*.pw.toml` and `packwiz-files/**`; it runs the full runtime sync only when needed. Git hooks perform the same check for regular local Git operations, but still run this command here so agent-managed updates have a visible result.
 
-The post-update hook installation only runs when the installer or tracked hooks changed. This makes newly added hooks available immediately, while ordinary repository updates do not rewrite local hook shims.
+The installer is idempotent: `-IfUnset` exits when all four shims already exist and are managed, while a full install only rewrites a shim when its generated content differs. The post-update hook installation only runs when the installer or tracked hooks changed. This makes newly added hooks available immediately, while ordinary repository updates do not rewrite local hook shims.
 
 3. If `CDC-mod-src` changed or `git status` reports the submodule modified after update, run:
 

--- a/config/createlazytick-common.toml
+++ b/config/createlazytick-common.toml
@@ -109,12 +109,12 @@
 	#Note: When this option is enabled, if you attempt to activate a mechanical crafter in a lazy-loaded state via redstone,
 	#you must ensure that the duration of the changed redstone signal is longer than the lazy-loading interval.
 	#A mechanical crafter in an active state can respond immediately without requiring the above conditions.
-	enable_lazy_crafter_redstone = false
+	enable_lazy_crafter_redstone = true
 	#
 	#--------------------------------------------------------------------------
 	#The maximum delay for activating a mechanical crafter via redstone after it has been inactive for a period of time.
 	#Range: > 0
-	crafter_redstone_delay_max = 20
+	crafter_redstone_delay_max = 18
 
 #Mechanical Arm Settings
 [arm]

--- a/scripts/install-git-hooks.ps1
+++ b/scripts/install-git-hooks.ps1
@@ -20,6 +20,8 @@ if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoRoot)) {
 
 $repoRoot = $repoRoot.Trim()
 $hooksPath = Join-Path $repoRoot "scripts/.githooks"
+$hookNames = @("pre-commit", "post-merge", "post-checkout", "post-rewrite")
+$marker = "Create-Delight managed hook shim"
 $gitCommonDir = (& git rev-parse --git-common-dir 2>$null)
 if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($gitCommonDir)) {
     throw "Could not resolve Git common directory."
@@ -56,6 +58,27 @@ if (-not (Test-Path -LiteralPath $hooksPath)) {
     throw "Missing tracked hooks directory: $hooksPath"
 }
 
+if ($IfUnset) {
+    $needsInstall = $false
+    foreach ($hookName in $hookNames) {
+        $targetHook = Join-Path $gitHooksPath $hookName
+        if (-not (Test-Path -LiteralPath $targetHook)) {
+            $needsInstall = $true
+            break
+        }
+
+        $existing = Get-Content -LiteralPath $targetHook -Raw -ErrorAction SilentlyContinue
+        if ($existing -notmatch [regex]::Escape($marker)) {
+            $needsInstall = $true
+            break
+        }
+    }
+
+    if (-not $needsInstall) {
+        exit 0
+    }
+}
+
 New-Item -ItemType Directory -Force -Path $gitHooksPath | Out-Null
 
 function Install-HookShim {
@@ -68,29 +91,6 @@ function Install-HookShim {
 
     $targetHook = Join-Path $gitHooksPath $Name
     $localHook = Join-Path $gitHooksPath "$Name.local"
-    $marker = "Create-Delight managed hook shim"
-
-    if (Test-Path -LiteralPath $targetHook) {
-        $existing = Get-Content -LiteralPath $targetHook -Raw -ErrorAction SilentlyContinue
-        if ($existing -notmatch [regex]::Escape($marker)) {
-            if (Test-Path -LiteralPath $localHook) {
-                $timestamp = Get-Date -Format "yyyyMMddHHmmss"
-                $backupHook = Join-Path $gitHooksPath "$Name.local.$timestamp"
-                $suffix = 1
-                while (Test-Path -LiteralPath $backupHook) {
-                    $backupHook = Join-Path $gitHooksPath "$Name.local.$timestamp.$suffix"
-                    $suffix++
-                }
-
-                Move-Item -LiteralPath $targetHook -Destination $backupHook
-                Write-InstallMessage "Preserved existing $Name as $(Split-Path $backupHook -Leaf)"
-            }
-            else {
-                Move-Item -LiteralPath $targetHook -Destination $localHook
-                Write-InstallMessage "Preserved existing $Name as $Name.local"
-            }
-        }
-    }
 
     $shim = @"
 #!/bin/sh
@@ -114,6 +114,32 @@ elif [ -f "`$tracked_hook" ]; then
 fi
 "@
 
+    if (Test-Path -LiteralPath $targetHook) {
+        $existing = Get-Content -LiteralPath $targetHook -Raw -ErrorAction SilentlyContinue
+        if ($existing -eq $shim) {
+            return
+        }
+
+        if ($existing -notmatch [regex]::Escape($marker)) {
+            if (Test-Path -LiteralPath $localHook) {
+                $timestamp = Get-Date -Format "yyyyMMddHHmmss"
+                $backupHook = Join-Path $gitHooksPath "$Name.local.$timestamp"
+                $suffix = 1
+                while (Test-Path -LiteralPath $backupHook) {
+                    $backupHook = Join-Path $gitHooksPath "$Name.local.$timestamp.$suffix"
+                    $suffix++
+                }
+
+                Move-Item -LiteralPath $targetHook -Destination $backupHook
+                Write-InstallMessage "Preserved existing $Name as $(Split-Path $backupHook -Leaf)"
+            }
+            else {
+                Move-Item -LiteralPath $targetHook -Destination $localHook
+                Write-InstallMessage "Preserved existing $Name as $Name.local"
+            }
+        }
+    }
+
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::WriteAllText($targetHook, $shim, $utf8NoBom)
 }
@@ -124,7 +150,7 @@ if ($null -ne $isWindowsVariable) {
     $isWindowsPlatform = [bool]$isWindowsVariable.Value
 }
 
-foreach ($hookName in @("pre-commit", "post-merge", "post-checkout", "post-rewrite")) {
+foreach ($hookName in $hookNames) {
     Install-HookShim -Name $hookName
 }
 
@@ -136,3 +162,4 @@ if (-not $isWindowsPlatform) {
 
 Write-InstallMessage "Git hooks installed in .git/hooks"
 Write-InstallMessage "Packwiz assets will sync automatically after relevant merge, rebase, or branch checkout changes."
+exit 0


### PR DESCRIPTION
## 摘要

- 实现 install-git-hooks.ps1 的 -IfUnset 检查，常规 repo-sync 不再重复安装已有 shim。
- 安装脚本比较生成内容，重复运行不再写入未变化的 .git/hooks 文件。
- 追踪到安装脚本或 Hook 变更时仍执行完整安装，保证新 Hook 可用。
- 对 Agent 和 Git Hook 的行为保持兼容，只减少重复 PowerShell 和文件写入开销。

## 验证

- scripts/validate-knowledge-base.ps1 通过。
- -IfUnset -Quiet 返回 0。
- 完整安装重复执行后，4 个 Hook shim 的 SHA-256 不变。