### PR TITLE
升级机械动力懒惰刻至 2.5.21

### DIFF
--- a/config/modpack_defaults/config/crash_assistant/modlist.json
+++ b/config/modpack_defaults/config/crash_assistant/modlist.json
@@ -564,10 +564,10 @@
     "name": "Create: Improved Display Link Experience",
     "version": "1.20.1-1.3"
   },
-  "CreateLazyTick-2.5.15-6.0.x-forge-1.20.1.jar": {
+  "CreateLazyTick-2.5.21-6.0.x-forge-1.20.1.jar": {
     "modId": "createlazytick",
     "name": "Create:LazyTick",
-    "version": "2.5.15-6.0.x-forge-1.20.1"
+    "version": "2.5.21-6.0.x-forge-1.20.1"
   },
   "createliquidfuel-2.1.1-1.20.1.jar": {
     "modId": "createliquidfuel",

--- a/mods/CreateLazyTick.pw.toml
+++ b/mods/CreateLazyTick.pw.toml
@@ -1,13 +1,13 @@
 name = "Create:LazyTick"
-filename = "CreateLazyTick-2.5.15-6.0.x-forge-1.20.1.jar"
+filename = "CreateLazyTick-2.5.21-6.0.x-forge-1.20.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "cf33e5d065adef78ea8386b40da8fb4912345efa"
+hash = "829e7b61fb90bf06d75f0e27dd6ced2f78d77f04"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8520489
+file-id = 8640395
 project-id = 1409401


### PR DESCRIPTION
## 变更

- 将 Create:LazyTick 从 2.5.15 升级至 2.5.21
- 更新 CurseForge 文件 ID 至 8640395，并同步 SHA-1
- 更新 Crash Assistant 模组版本基线

## 验证

- CurseForge 定向更新成功
- Packwiz 本地运行态同步成功
- 本地 JAR SHA-1 校验一致
- git diff --check 通过