### PR TITLE
[mod] 添加 MMT 效果适用路径标注

### DIFF
--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/absorption_boost.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/absorption_boost.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/abyssal_curse.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/abyssal_curse.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/abyssal_finish.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/abyssal_finish.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/abyssal_ocean_echo.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/abyssal_ocean_echo.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/aether_inebriation_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/aether_inebriation_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexscaves_deepsight.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexscaves_deepsight.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexscaves_irradiated_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexscaves_irradiated_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexscaves_magnetizing_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexscaves_magnetizing_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexsmobs_bug_pheromones.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexsmobs_bug_pheromones.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexsmobs_clinging.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexsmobs_clinging.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexsmobs_knockback_resistance.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexsmobs_knockback_resistance.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexsmobs_mosquito_repellent.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexsmobs_mosquito_repellent.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexsmobs_soulsteal.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/alexsmobs_soulsteal.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/analysis.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/analysis.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_ahrim.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_ahrim.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_dharok.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_dharok.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_guthan.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_guthan.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_karil.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_karil.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_torag.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_torag.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_verac.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ancient_will_verac.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/apotheosis_bleeding_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/apotheosis_bleeding_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/apotheosis_grievous_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/apotheosis_grievous_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/apotheosis_sundering_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/apotheosis_sundering_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/aqua_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/aqua_arcane_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/aqua_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/aqua_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/aqua_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/aqua_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/arcane_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/arcane_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/archaeology.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/archaeology.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "break_block"
+      ],
+      "stacking": "held_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_complete_form.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_complete_form.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_critical_strike.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_critical_strike.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "unknown"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "unknown"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_final_stand.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_final_stand.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_heal.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_heal.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_last_stand.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_last_stand.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_revival.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_revival.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_sturdy.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_sturdy.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_tenacity.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_tenacity.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_thorns.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/armor_thorns.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ars_mana_regen.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ars_mana_regen.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ars_spell_damage.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ars_spell_damage.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/arthropods_protection.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/arthropods_protection.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/assassinate.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/assassinate.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/attack_glowing_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/attack_glowing_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/awakening_slash.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/awakening_slash.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/azure_magnetizing_pole.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/azure_magnetizing_pole.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ban_heal.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ban_heal.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/beheading.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/beheading.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blazing_absorb.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blazing_absorb.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blazing_brand.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blazing_brand.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blessing_of_amethyst.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blessing_of_amethyst.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blessings_of_water.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blessings_of_water.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blood_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blood_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blood_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blood_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blood_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/blood_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/bokushuu_s_desire.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/bokushuu_s_desire.json
@@ -1,0 +1,34 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/bone_fracture.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/bone_fracture.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/born_in_chaos_v1_bone_fracture_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/born_in_chaos_v1_bone_fracture_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/born_in_chaos_v1_magic_depletion_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/born_in_chaos_v1_magic_depletion_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/born_in_chaos_v1_myiasis_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/born_in_chaos_v1_myiasis_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/born_in_chaos_v1_rotten_smell_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/born_in_chaos_v1_rotten_smell_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/born_in_chaos_v1_soul_stratification.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/born_in_chaos_v1_soul_stratification.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/capturing.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/capturing.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cataclysm_blazing_brand_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cataclysm_blazing_brand_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cataclysm_blessing_of_amethyst.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cataclysm_blessing_of_amethyst.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cataclysm_curse_of_desert_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cataclysm_curse_of_desert_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cataclysm_stun.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cataclysm_stun.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cleansing_serum.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cleansing_serum.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cold_wave.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cold_wave.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/collapsing_fear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/collapsing_fear.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/command_block_book.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/command_block_book.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "unknown"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "unknown"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_blade.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_blade.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_death.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_death.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_element.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_element.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_guard.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_life.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_life.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_order.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_order.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_reverse.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_reverse.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_soul.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_soul.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_substance.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_substance.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_sword.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/concept_of_sword.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/constant_flux.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/constant_flux.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cooldown_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cooldown_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/corrosive_additive.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/corrosive_additive.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_aether_inebriation_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_aether_inebriation_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexscaves_deepsight.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexscaves_deepsight.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexscaves_irradiated_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexscaves_irradiated_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexscaves_magnetizing_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexscaves_magnetizing_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexsmobs_bug_pheromones.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexsmobs_bug_pheromones.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexsmobs_clinging.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexsmobs_clinging.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexsmobs_knockback_resistance.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexsmobs_knockback_resistance.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexsmobs_mosquito_repellent.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexsmobs_mosquito_repellent.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexsmobs_soulsteal.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_alexsmobs_soulsteal.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_all_damage_up.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_all_damage_up.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_apotheosis_bleeding_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_apotheosis_bleeding_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_apotheosis_grievous_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_apotheosis_grievous_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_apotheosis_sundering_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_apotheosis_sundering_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_armor_penetration.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_armor_penetration.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_ars_mana_regen.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_ars_mana_regen.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_ars_spell_damage.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_ars_spell_damage.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_blindness_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_blindness_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_born_in_chaos_v1_myiasis_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_born_in_chaos_v1_myiasis_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_cataclysm_blazing_brand_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_cataclysm_blazing_brand_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_cataclysm_blessing_of_amethyst.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_cataclysm_blessing_of_amethyst.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_cataclysm_curse_of_desert_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_cataclysm_curse_of_desert_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_critical_strike.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_critical_strike.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_darkness_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_darkness_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_feather_falling.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_feather_falling.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_fire_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_fire_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_fire_resistance.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_fire_resistance.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_fly.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_fly.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_bottling.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_bottling.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_burn_hex_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_burn_hex_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_climbing.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_climbing.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_crippled_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_crippled_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_cursed_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_cursed_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_deflective.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_deflective.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_doom_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_doom_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_explosive.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_explosive.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_fiery_aura.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_fiery_aura.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_flame_hands.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_flame_hands.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_fortunate.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_fortunate.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_freezing_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_freezing_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_frog_leg.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_frog_leg.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_frosty_aura.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_frosty_aura.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_gravity_pulse.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_gravity_pulse.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_insight.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_insight.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_leeching.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_leeching.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_photosynthesis.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_photosynthesis.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_plunge_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_plunge_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_radiance.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_radiance.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_rallying.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_rallying.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_repulsive.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_repulsive.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_sapped_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_sapped_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_shielding.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_shielding.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_soul_cost_discount.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_soul_cost_discount.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "use_item"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_soul_focus_potency.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_soul_focus_potency.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_soul_spell_cooldown.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_soul_spell_cooldown.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_swift_swim.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_swift_swim.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_swirling.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_swirling.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_venomous_hands.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_goety_venomous_hands.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_haste.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_haste.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_health_boost.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_health_boost.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_hero_of_the_village.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_hero_of_the_village.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_hunger_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_hunger_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_irons_spellbooks_oakskin.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_irons_spellbooks_oakskin.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_irons_spellbooks_true_invisibility.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_irons_spellbooks_true_invisibility.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_jank.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_jank.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_jump.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_jump.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_jump_boost.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_jump_boost.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_kamui.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_kamui.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_l2complements_curse_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_l2complements_curse_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_l2complements_flame_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_l2complements_flame_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_l2complements_frozen_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_l2complements_frozen_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_levitation_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_levitation_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_luck.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_luck.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_magic_damage_up.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_magic_damage_up.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_magma_walker.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_magma_walker.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "ability"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_materials_effect_invalidation.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_materials_effect_invalidation.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_melee_damage_up.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_melee_damage_up.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_mining_fatigue_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_mining_fatigue_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_night_vision.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_night_vision.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_poison_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_poison_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_projectile_damage_up.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_projectile_damage_up.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_projectile_tracking.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_projectile_tracking.json
@@ -1,0 +1,33 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "projectile"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "projectile"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "projectile"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_protect.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_protect.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_quark_resilience.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_quark_resilience.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_regeneration.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_regeneration.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_resistance.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_resistance.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_saturation.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_saturation.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_slowness_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_slowness_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_speed.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_speed.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_strength.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_strength.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_totem_cooldown.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_totem_cooldown.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "death"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_totem_effect.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_totem_effect.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "death"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_totem_health.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_totem_health.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "death"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_water_breathing.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_water_breathing.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_water_walker.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_water_walker.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "ability"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_weakness_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_weakness_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_wither_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_wither_clear.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_youkaishomecoming_caffeinated.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_youkaishomecoming_caffeinated.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_youkaishomecoming_tea_polyphenols.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_youkaishomecoming_tea_polyphenols.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_youkaishomecoming_unconscious.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_youkaishomecoming_unconscious.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_youkaishomecoming_youkaified.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_youkaishomecoming_youkaified.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_youkaishomecoming_youkaifying.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/curios_youkaishomecoming_youkaifying.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cursed_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cursed_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cursium_chest.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cursium_chest.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "death"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cursium_feet.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cursium_feet.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cursium_head.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cursium_head.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cursium_legs.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/cursium_legs.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/damage_adaptation.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/damage_adaptation.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/damage_buffering.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/damage_buffering.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/deep_dark_fantasy.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/deep_dark_fantasy.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/defeat_demons.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/defeat_demons.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dementor_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dementor_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/despoil_sickle.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/despoil_sickle.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/devouring_stone.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/devouring_stone.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "use_item"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/diamond_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/diamond_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dispell_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dispell_effect_trait.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "unknown"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "unknown"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dolphins_grace_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dolphins_grace_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dominion.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dominion.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dragon_breath_combo.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dragon_breath_combo.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dragon_breath_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dragon_breath_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dragon_breath_proficiency.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dragon_breath_proficiency.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dragon_breath_thorns.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/dragon_breath_thorns.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/duel.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/duel.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eclipse.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eclipse.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eclipse_star_burst_stream.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eclipse_star_burst_stream.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eeeabsmobs_erode_effect.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eeeabsmobs_erode_effect.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eeeabsmobs_frenzy_effect.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eeeabsmobs_frenzy_effect.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eldritch_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eldritch_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eldritch_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eldritch_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eldritch_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eldritch_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/emerald_pillage.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/emerald_pillage.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/emergency_rescue.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/emergency_rescue.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/enchanting_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/enchanting_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ender_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ender_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ender_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ender_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ender_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ender_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/enderference.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/enderference.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/enderman_killer.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/enderman_killer.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/entity_resonance.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/entity_resonance.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/erase.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/erase.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eternium_durability.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/eternium_durability.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "single_piece"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/etherium_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/etherium_guard.json
@@ -1,0 +1,44 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "heal"
+      ],
+      "stacking": "held_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/etherium_ingot_material.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/etherium_ingot_material.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/everything_is_in_everything.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/everything_is_in_everything.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "gain_experience"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/evil_curse.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/evil_curse.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/evil_ingot_material.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/evil_ingot_material.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/evocation_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/evocation_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/evocation_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/evocation_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/evocation_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/evocation_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/exceed_slash.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/exceed_slash.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/exhortation_of_gun_knight_patriot.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/exhortation_of_gun_knight_patriot.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/expanded_cognition.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/expanded_cognition.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/experience_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/experience_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/extinction.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/extinction.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/extra_aquatic_products.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/extra_aquatic_products.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fake_insatiable.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fake_insatiable.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fake_kinetic.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fake_kinetic.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fake_momentum.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fake_momentum.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "mine_block"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fake_tasty.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fake_tasty.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fantasy_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fantasy_arcane_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fantasy_devour.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fantasy_devour.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fantasy_shadow.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fantasy_shadow.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fantasy_trace.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fantasy_trace.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fiery_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fiery_effect_trait.json
@@ -1,0 +1,42 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fiery_palpitation.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fiery_palpitation.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/final_slash.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/final_slash.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_combo.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_combo.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_dragon_blood_coating.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_dragon_blood_coating.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_dragon_power.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_dragon_power.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_dragonsteel_material.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_dragonsteel_material.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_proficiency.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_proficiency.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_resistance_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_resistance_buff.json
@@ -1,0 +1,33 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_thorns.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fire_thorns.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/first_light_heals_the_world.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/first_light_heals_the_world.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "heal"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/flame_killer.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/flame_killer.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/flameless_killer.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/flameless_killer.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/flawless_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/flawless_attack.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    },
+    {
+      "scopes": [
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/flawless_protection.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/flawless_protection.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/food_acquisition.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/food_acquisition.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fragile.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/fragile.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze_combo.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze_combo.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze_proficiency.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze_proficiency.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze_ring.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze_ring.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze_thorns.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freeze_thorns.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freezing_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/freezing_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/frenzy_serum.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/frenzy_serum.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/gather_ore.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/gather_ore.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "break_block"
+      ],
+      "stacking": "held_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ghost_form.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ghost_form.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ghost_sword.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ghost_sword.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/glowing.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/glowing.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_acid_venom.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_acid_venom.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_ally_vex.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_ally_vex.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "unknown"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "unknown"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_bottling.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_bottling.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_burn_hex_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_burn_hex_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_climbing.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_climbing.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_crippled_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_crippled_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_cursed.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_cursed.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_cursed_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_cursed_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_deflective.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_deflective.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_doom_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_doom_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_explosive.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_explosive.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_fiery_aura.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_fiery_aura.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_flame_hands.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_flame_hands.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_fortunate.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_fortunate.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_freezing_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_freezing_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_frog_leg.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_frog_leg.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "unknown"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "unknown"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_frosty_aura.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_frosty_aura.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_gravity_pulse.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_gravity_pulse.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_insight.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_insight.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_leeching.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_leeching.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_photosynthesis.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_photosynthesis.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_plunge_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_plunge_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_radiance.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_radiance.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_rallying.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_rallying.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_repulsive.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_repulsive.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_sapped_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_sapped_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_shielding.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_shielding.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_absorb.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_absorb.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_burst.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_burst.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_cost_discount.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_cost_discount.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "use_item"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_extract.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_extract.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_focus_potency.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_focus_potency.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_repair.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_repair.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "single_piece"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_spell_cooldown.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_soul_spell_cooldown.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "unknown"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "unknown"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_swift_swim.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_swift_swim.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_swirling.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_swirling.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_venomous_hands.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/goety_venomous_hands.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/grenade_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/grenade_effect_trait.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "unknown"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "unknown"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/growing.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/growing.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "use_item"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/haste_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/haste_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/healing_additive.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/healing_additive.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/health_power.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/health_power.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/heavy_chop.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/heavy_chop.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/heavy_hit.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/heavy_hit.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/hero_of_the_village_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/hero_of_the_village_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/hide_blade.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/hide_blade.json
@@ -1,0 +1,43 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/hiding_in_shulker_shell.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/hiding_in_shulker_shell.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/holy_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/holy_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/holy_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/holy_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/holy_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/holy_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/hostility_control.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/hostility_control.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/hunting.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/hunting.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/i_am_storm.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/i_am_storm.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_dragon_blood_coating.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_dragon_blood_coating.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_dragon_power.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_dragon_power.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_dragonsteel_material.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_dragonsteel_material.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ice_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ignite.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ignite.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ignitium_suit.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ignitium_suit.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/immortalers_delight_gas_poison.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/immortalers_delight_gas_poison.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/immortalers_delight_incandescence.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/immortalers_delight_incandescence.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/immortalers_delight_moon_bright.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/immortalers_delight_moon_bright.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/industrial_protection.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/industrial_protection.json
@@ -1,0 +1,34 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/into_bubbled.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/into_bubbled.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/invisibility_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/invisibility_buff.json
@@ -1,0 +1,33 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/invulnerability_blade.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/invulnerability_blade.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/invulnerable_time_down.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/invulnerable_time_down.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/iron_spell_casting.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/iron_spell_casting.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "use_item"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/irons_spellbooks_oakskin.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/irons_spellbooks_oakskin.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/irons_spellbooks_true_invisibility.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/irons_spellbooks_true_invisibility.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/jackpot_for_the_taking.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/jackpot_for_the_taking.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/killaura.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/killaura.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/killer_aura_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/killer_aura_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/l2complements_curse_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/l2complements_curse_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/l2complements_flame_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/l2complements_flame_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/l2complements_frozen_clear.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/l2complements_frozen_clear.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lava_driver.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lava_driver.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lava_mob.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lava_mob.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/legendary_monsters_soul_rage.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/legendary_monsters_soul_rage.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/let_the_people_rejoice.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/let_the_people_rejoice.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "heal"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/levitation.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/levitation.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_combo.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_combo.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_dragon_blood_coating.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_dragon_blood_coating.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_dragon_power.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_dragon_power.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_dragonsteel_material.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_dragonsteel_material.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_proficiency.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_proficiency.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_thorns.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/lightning_thorns.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/luck_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/luck_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magic_combo.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magic_combo.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magic_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magic_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magic_oscillation.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magic_oscillation.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magic_proficiency.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magic_proficiency.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magic_thorns.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magic_thorns.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magnetic_field.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magnetic_field.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magnetizing_metal.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/magnetizing_metal.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/mana_absorption.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/mana_absorption.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/mana_force.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/mana_force.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/mana_regeneration.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/mana_regeneration.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/mana_repair.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/mana_repair.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "single_piece"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/marching_time.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/marching_time.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/melee_attack_combo.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/melee_attack_combo.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/miner_lantern.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/miner_lantern.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/mineral_essence.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/mineral_essence.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "break_block"
+      ],
+      "stacking": "held_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/miracle_and_magic.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/miracle_and_magic.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "unknown"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "unknown"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/monstrous.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/monstrous.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/nature_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/nature_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/nature_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/nature_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/nature_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/nature_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/necrotic.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/necrotic.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/niten_ichiryu_katana.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/niten_ichiryu_katana.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/niten_ichiryu_wakizashi.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/niten_ichiryu_wakizashi.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/nociceptor_inhibition.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/nociceptor_inhibition.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/notes.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/notes.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/obsession_of_warden.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/obsession_of_warden.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ocean_pearl.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ocean_pearl.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ode_to_cyrene.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ode_to_cyrene.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ode_to_passage.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ode_to_passage.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ode_to_trailblaze.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ode_to_trailblaze.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/orders.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/orders.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/organic_compound.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/organic_compound.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/origin_slash.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/origin_slash.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/over_postmortal.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/over_postmortal.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/over_slash.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/over_slash.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/phantom_killer.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/phantom_killer.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/piglin_killer.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/piglin_killer.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/pixie_summon.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/pixie_summon.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/poison.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/poison.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/powerless.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/powerless.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/projectile_tracking.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/projectile_tracking.json
@@ -1,0 +1,33 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "projectile"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "projectile"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "projectile"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/protected_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/protected_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/protection_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/protection_arcane_edge.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "item"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/puncture.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/puncture.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/pure.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/pure.json
@@ -1,0 +1,44 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/pyric_corpus.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/pyric_corpus.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/quark_resilience.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/quark_resilience.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/radiation_absorption.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/radiation_absorption.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/radiation_core.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/radiation_core.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/radioactive_material.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/radioactive_material.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/recovery.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/recovery.json
@@ -1,0 +1,43 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/reflect_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/reflect_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/regenerating_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/regenerating_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/regeneration_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/regeneration_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/repelling_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/repelling_effect_trait.json
@@ -1,0 +1,43 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/resistance_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/resistance_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/reverse_mirror.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/reverse_mirror.json
@@ -1,0 +1,43 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/reversel_smite.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/reversel_smite.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ride_skill.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ride_skill.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ripening_halo.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ripening_halo.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rising_slash.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rising_slash.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ritual_of_exhortation.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ritual_of_exhortation.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ritual_of_holy_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ritual_of_holy_guard.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ruination_time.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ruination_time.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_aliment_cleansing.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_aliment_cleansing.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_fervor.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_fervor.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "mine_block"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_haste.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_haste.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_idle_restoration.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_idle_restoration.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_igneous_solace.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_igneous_solace.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "unknown"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "unknown"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_loyalty.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_loyalty.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_motion.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_motion.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_reactive_shielding.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_reactive_shielding.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_sacrificial_empowerment.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_sacrificial_empowerment.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_aether.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_aether.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_arena.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_arena.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_hells.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_hells.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_heretic.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_heretic.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_seas.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_seas.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_storm.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_the_storm.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_twinned_duration.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_twinned_duration.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_volatile_distortion.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_volatile_distortion.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_warding.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/rune_of_warding.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sacrifice_and_throwing_the_halberd.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sacrifice_and_throwing_the_halberd.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sanctuary_of_mooncocoon.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sanctuary_of_mooncocoon.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "death"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sanity_hurt.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sanity_hurt.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/saturation_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/saturation_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/scarlet_magnetizing_pole.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/scarlet_magnetizing_pole.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shadow_gem.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shadow_gem.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shadow_power.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shadow_power.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shield_skill_automatic_defense.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shield_skill_automatic_defense.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shield_skill_automatic_protection.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shield_skill_automatic_protection.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shield_skill_cooldown_down.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shield_skill_cooldown_down.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shining_power.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shining_power.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shooting_sun.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/shooting_sun.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sirenic_serenade.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sirenic_serenade.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/slow_falling_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/slow_falling_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/slowness.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/slowness.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/small_shulker.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/small_shulker.json
@@ -1,0 +1,43 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/smc_frost.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/smc_frost.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/smc_frost_burst.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/smc_frost_burst.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/soul_burner_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/soul_burner_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/soul_shard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/soul_shard.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sound_arcane_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sound_arcane_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sound_arcane_guard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sound_arcane_guard.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sound_staff_socket.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/sound_staff_socket.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/speed_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/speed_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/speed_force.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/speed_force.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/speedy_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/speedy_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/stabilizing.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/stabilizing.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/stand_tall.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/stand_tall.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/star_burst_stream.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/star_burst_stream.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/stray_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/stray_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/strength_buff.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/strength_buff.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/tanky_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/tanky_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/tears_of_thunder.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/tears_of_thunder.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/terra_ray.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/terra_ray.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/the_century_gate.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/the_century_gate.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "kill_entity"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/though_worlds_apart.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/though_worlds_apart.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/thread_depths.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/thread_depths.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/thread_feather.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/thread_feather.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/thread_heights.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/thread_heights.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/thread_repairing.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/thread_repairing.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/titan_slayer.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/titan_slayer.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/to_evernights_stars.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/to_evernights_stars.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/tool_blocking.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/tool_blocking.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/torch_the_laws_of_old.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/torch_the_laws_of_old.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/true_slash.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/true_slash.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/turning_stone_into_gold.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/turning_stone_into_gold.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "break_block"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/twin_slash.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/twin_slash.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "unknown"
+      ],
+      "stacking": "held_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ultimate_slash.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/ultimate_slash.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/unceasing_storm.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/unceasing_storm.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/undead_hydra.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/undead_hydra.json
@@ -1,0 +1,33 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/undead_protection.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/undead_protection.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/underocean.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/underocean.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/underwater_operations.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/underwater_operations.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/undying_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/undying_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "death"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "death"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/universe_power.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/universe_power.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/unlimited_phantasmal_blade_works.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/unlimited_phantasmal_blade_works.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/unstable_compound.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/unstable_compound.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/vampiric.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/vampiric.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/warden_killer.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/warden_killer.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/water_power.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/water_power.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/weakness_effect_trait.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/weakness_effect_trait.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_sum"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/weakness_realm.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/weakness_realm.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_attributeslib_bleeding_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_attributeslib_bleeding_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_attributeslib_grievous_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_attributeslib_grievous_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_attributeslib_sundering_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_attributeslib_sundering_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_bag.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_bag.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_cataclysm_abyssal_curse_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_cataclysm_abyssal_curse_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_cataclysm_blazing_brand_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_cataclysm_blazing_brand_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_acid_venom_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_acid_venom_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_busted_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_busted_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_cursed_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_cursed_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_ender_ground_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_ender_ground_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_flammable_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_flammable_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_freezing_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_freezing_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_plunge_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_plunge_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_sapped_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_sapped_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_tangled_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_tangled_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_void_touched_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_void_touched_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_wane_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_wane_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_wild_rage_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_goety_wild_rage_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_1_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_1_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_2_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_2_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_3_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_3_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_4_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_4_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_5_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_5_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_6_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_6_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_7_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_7_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_8_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_blight_8_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_10_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_10_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_11_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_11_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_12_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_12_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_13_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_13_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_3_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_3_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_4_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_4_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_5_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_5_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_6_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_6_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_7_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_7_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_8_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_8_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_9_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_irons_spellbooks_rend_9_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_blindness_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_blindness_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_glowing_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_glowing_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_levitation_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_levitation_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_poison_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_poison_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_slowness_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_slowness_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_weakness_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_weakness_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_wither_attack.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_minecraft_wither_attack.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_quiver.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_quiver.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_scabbard.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/white_scabbard.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "curios_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/will_of_gaia.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/will_of_gaia.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither_combo.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither_combo.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither_edge.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither_edge.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither_proficiency.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither_proficiency.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither_realm.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither_realm.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither_thorns.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/wither_thorns.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "armor"
+      ],
+      "triggers": [
+        "receive_hit"
+      ],
+      "stacking": "armor_sum"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/witherite.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/witherite.json
@@ -1,0 +1,25 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "attack"
+      ],
+      "stacking": "held_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/work_work_work.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/work_work_work.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "curios"
+      ],
+      "triggers": [
+        "mine_block"
+      ],
+      "stacking": "curios_max"
+    },
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "mine_block"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/youkaishomecoming_caffeinated.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/youkaishomecoming_caffeinated.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/youkaishomecoming_tea_polyphenols.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/youkaishomecoming_tea_polyphenols.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/youkaishomecoming_unconscious.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/youkaishomecoming_unconscious.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/youkaishomecoming_youkaified.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/youkaishomecoming_youkaified.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/youkaishomecoming_youkaifying.json
+++ b/kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/youkaishomecoming_youkaifying.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "paths": [
+    {
+      "scopes": [
+        "main_hand",
+        "off_hand"
+      ],
+      "triggers": [
+        "wear_passive"
+      ],
+      "stacking": "held_max"
+    }
+  ]
+}

--- a/scripts/generate-mmt-effect-applicability.py
+++ b/scripts/generate-mmt-effect-applicability.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Generate Tetra Insight applicability resources from decompiled More Mod Tetra sources."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+
+FIELD_PATTERN = re.compile(
+    r'ItemEffect\s+(\w+)\s*=\s*ItemEffect\.get\("(more_mod_tetra:[^"]+)"\)'
+)
+METHOD_PATTERN = re.compile(
+    r'(?:public|private|protected)\s+(?:static\s+)?[^;{}]+?\s+(\w+)\s*\(([^)]*)\)\s*\{'
+)
+FIELD_REFERENCE_PATTERN = re.compile(r"EffectGuiStats\.(\w+)")
+EVENT_PATTERN = re.compile(r"\b([A-Za-z0-9_]+Event)\b")
+HELPER_PATTERN = re.compile(
+    r"\.(get(?:Main|Off|All|Head|Chest|Legs|Feet|Curios)[A-Za-z0-9_]*|hasCuriosEffectLevel)\s*\("
+)
+
+
+HELPER_PATHS = {
+    "getMainHandEffectLevel": (("main_hand",), "item"),
+    "getMainHandEffectEfficiency": (("main_hand",), "item"),
+    "getOffHandEffectLevel": (("off_hand",), "item"),
+    "getOffHandEffectEfficiency": (("off_hand",), "item"),
+    "getMainOffHandMaxEffectLevel": (("main_hand", "off_hand"), "held_max"),
+    "getMainOffHandMaxEffectEfficiency": (("main_hand", "off_hand"), "held_max"),
+    "getMainOffHandSumEffectLevel": (("main_hand", "off_hand"), "held_sum"),
+    "getMainOffHandSumEffectEfficiency": (("main_hand", "off_hand"), "held_sum"),
+    "getHeadArmorEffectLevel": (("helmet",), "single_piece"),
+    "getHeadArmorEffectEfficiency": (("helmet",), "single_piece"),
+    "getChestArmorEffectLevel": (("armor",), "single_piece"),
+    "getChestArmorEffectEfficiency": (("armor",), "single_piece"),
+    "getLegsArmorEffectLevel": (("armor",), "single_piece"),
+    "getLegsArmorEffectEfficiency": (("armor",), "single_piece"),
+    "getFeetArmorEffectLevel": (("armor",), "single_piece"),
+    "getFeetArmorEffectEfficiency": (("armor",), "single_piece"),
+    "getAllArmorSumEffectLevel": (("armor",), "armor_sum"),
+    "getAllArmorSumEffectEfficiency": (("armor",), "armor_sum"),
+    "getAllArmorMaxEffectLevel": (("armor",), "armor_max"),
+    "getAllArmorMaxEffectEfficiency": (("armor",), "armor_max"),
+    "getCuriosEffectLevel": (("curios",), "curios_sum"),
+    "getCuriosEffectEfficiency": (("curios",), "curios_sum"),
+    "getCuriosEffectMaxLevel": (("curios",), "curios_max"),
+    "getCuriosEffectMaxEfficiency": (("curios",), "curios_max"),
+    "hasCuriosEffectLevel": (("curios",), "curios_max"),
+}
+
+ALL_EFFECT_HELPERS = {
+    "getAllEffectLevel",
+    "getAllEffectEfficiency",
+}
+
+GUI_ONLY_METHODS = {"init", "tooltip"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source_root", type=Path)
+    parser.add_argument("output_root", type=Path)
+    return parser.parse_args()
+
+
+def statement_window(text: str, start: int, end: int) -> str:
+    left = max(text.rfind(";", max(0, start - 800), start), text.rfind("{", max(0, start - 800), start))
+    right = text.find(";", end, min(len(text), end + 800))
+    if right < 0:
+        right = min(len(text), end + 800)
+    return text[left + 1 : right + 1]
+
+
+def trigger_for(events: set[str], method: str, relative_path: str, key: str, scopes: tuple[str, ...]) -> str:
+    if "LivingExperienceDropEvent" in events:
+        return "gain_experience"
+    if "LivingDropsEvent" in events:
+        return "kill_entity"
+    if "BreakEvent" in events:
+        return "break_block"
+    if "BreakSpeed" in events:
+        return "mine_block"
+    if "CriticalHitEvent" in events:
+        return "attack"
+    if "LivingHealEvent" in events:
+        return "heal"
+    if "EntityJoinLevelEvent" in events:
+        return "projectile"
+    if "MMTFluidCollisionEvent" in events:
+        return "ability"
+    if "LivingTickEvent" in events or "PlayerTickEvent" in events:
+        return "wear_passive"
+    if "LivingDeathEvent" in events:
+        defensive = (
+            "armor" in scopes
+            or key.endswith("_revival")
+            or key.endswith("_final_stand")
+            or "undying" in key
+            or "over_postmortal" in key
+            or "sanctuary" in key
+            or "totem" in key
+        )
+        return "death" if defensive else "kill_entity"
+    if "LivingDamageEvent" in events:
+        return "receive_hit"
+    if "EffectLevelEvent" in events or "LivingHurtEvent" in events:
+        defensive = (
+            "armor" in scopes
+            or "GuardEffect" in relative_path
+            or key.endswith("_guard")
+            or key.endswith("_protection")
+            or key.startswith("more_mod_tetra:armor_")
+            or key.endswith("_thorns")
+        )
+        return "receive_hit" if defensive else "attack"
+    if method in {"drop", "entityKilled", "killEvent", "LivingDeathVampire"}:
+        return "kill_entity"
+    if method in {"tick", "curioTick", "onEquip", "getLevelsMixin"}:
+        return "wear_passive"
+    if method in {"use", "SoulUse"}:
+        return "use_item"
+    if method == "onRightClickBlock":
+        return "right_click"
+    if method == "pointGet":
+        return "break_block"
+    if method in {"cri", "onLivingAttack"}:
+        return "attack"
+    if method == "heal":
+        return "heal"
+    if method in {"onLivingDamage", "takeDamageEvent"}:
+        return "receive_hit"
+    if method == "hurt":
+        return "receive_hit" if "armor" in scopes else "attack"
+    return "unknown"
+
+
+def fallback_paths(
+    relative_path: str,
+    key: str,
+    method: str,
+    method_text: str,
+    implements_curio: bool = False,
+) -> list[tuple[tuple[str, ...], str]]:
+    if method == "processArmorPart":
+        return [(('armor',), 'single_piece')]
+    if method == "handleModularItem":
+        return [(('main_hand', 'off_hand'), 'item')]
+    if key.startswith("more_mod_tetra:curios_") or key.startswith("more_mod_tetra:white_"):
+        return [(('curios',), 'curios_max')]
+    if key in {
+        "more_mod_tetra:white_bag",
+        "more_mod_tetra:white_quiver",
+        "more_mod_tetra:white_scabbard",
+    }:
+        return [(('curios',), 'curios_max')]
+    if "ModularMMTBow" in relative_path:
+        return [(('bow',), 'item')]
+    if "/Curios/" in relative_path or method == "curioTick" or implements_curio:
+        return [(('curios',), 'curios_sum')]
+    if relative_path.startswith("ArmorEffect/"):
+        return [(('armor',), 'armor_sum')]
+    if key.endswith("_arcane_guard"):
+        return [
+            (("main_hand", "off_hand"), "held_max"),
+            (("armor",), "armor_sum"),
+        ]
+    if key.endswith("_staff_socket"):
+        return [(("main_hand", "off_hand"), "held_max")]
+    if key in {
+        "more_mod_tetra:twin_slash",
+        "more_mod_tetra:star_burst_stream",
+        "more_mod_tetra:eclipse",
+        "more_mod_tetra:eclipse_star_burst_stream",
+    }:
+        return [(("main_hand", "off_hand"), "held_sum")]
+    if "getEffectLevel" in method_text or "getEffectEfficiency" in method_text:
+        return [(("main_hand", "off_hand"), "held_max")]
+    return [(('unknown',), 'unknown')]
+
+
+def add_path(paths: dict[str, set[tuple[tuple[str, ...], str, str]]], key: str, scopes: tuple[str, ...], stacking: str, trigger: str) -> None:
+    paths[key].add((tuple(scopes), trigger, stacking))
+
+
+def main() -> None:
+    args = parse_args()
+    stats_path = args.source_root / "Effect" / "EffectGuiStats.java"
+    stats = stats_path.read_text(encoding="utf-8")
+    field_to_key = dict(FIELD_PATTERN.findall(stats))
+    paths: dict[str, set[tuple[tuple[str, ...], str, str]]] = defaultdict(set)
+
+    for source_path in args.source_root.rglob("*.java"):
+        if source_path == stats_path:
+            continue
+        text = source_path.read_text(encoding="utf-8", errors="replace")
+        methods = list(METHOD_PATTERN.finditer(text))
+        relative_path = source_path.relative_to(args.source_root).as_posix()
+        implements_curio = bool(
+            re.search(r"\bimplements\b[^\{]+\bICurioItem\b", text)
+        )
+
+        for reference in FIELD_REFERENCE_PATTERN.finditer(text):
+            field = reference.group(1)
+            key = field_to_key.get(field)
+            if key is None:
+                continue
+            previous_methods = [method for method in methods if method.start() < reference.start()]
+            if not previous_methods:
+                continue
+            method_match = previous_methods[-1]
+            method = method_match.group(1)
+            if method in GUI_ONLY_METHODS:
+                continue
+            next_method_start = next(
+                (candidate.start() for candidate in methods if candidate.start() > method_match.start()),
+                len(text),
+            )
+            method_text = text[method_match.start() : next_method_start]
+            events = set(EVENT_PATTERN.findall(method_match.group(2)))
+            if not events:
+                events.update(EVENT_PATTERN.findall(text))
+            if "BreakSpeed" in method_match.group(2) or "BreakSpeed" in text:
+                events.add("BreakSpeed")
+            window = statement_window(text, reference.start(), reference.end())
+            helpers = set(HELPER_PATTERN.findall(window))
+            candidates: list[tuple[tuple[str, ...], str]] = []
+
+            for helper in sorted(helpers):
+                if helper in ALL_EFFECT_HELPERS:
+                    candidates.extend(
+                        [
+                            (("main_hand", "off_hand"), "held_max"),
+                            (("armor",), "armor_sum"),
+                        ]
+                    )
+                elif helper in HELPER_PATHS:
+                    candidates.append(HELPER_PATHS[helper])
+
+            if not candidates and "getCuriosEffects" in method_text and "effects.contains" in window:
+                candidates.append((("curios",), "curios_max"))
+            if not candidates:
+                candidates.extend(
+                    fallback_paths(
+                        relative_path,
+                        key,
+                        method,
+                        method_text,
+                        implements_curio,
+                    )
+                )
+
+            for scopes, stacking in candidates:
+                trigger = trigger_for(events, method, relative_path, key, scopes)
+                add_path(paths, key, scopes, stacking, trigger)
+
+    for key in field_to_key.values():
+        if key not in paths:
+            fallback = fallback_paths("", key, "", "")
+            for scopes, stacking in fallback:
+                add_path(paths, key, scopes, stacking, "unknown")
+
+    for key, entries in paths.items():
+        known_signatures = {
+            (scopes, stacking)
+            for scopes, trigger, stacking in entries
+            if trigger != "unknown"
+        }
+        paths[key] = {
+            entry
+            for entry in entries
+            if entry[1] != "unknown"
+            or (entry[0], entry[2]) not in known_signatures
+        }
+
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    for key in sorted(field_to_key.values()):
+        effect_path = key.split(":", 1)[1]
+        definitions = [
+            {
+                "scopes": list(scopes),
+                "triggers": [trigger],
+                "stacking": stacking,
+            }
+            for scopes, trigger, stacking in sorted(paths[key], key=lambda entry: (entry[0], entry[1], entry[2]))
+        ]
+        payload = {"replace": False, "paths": definitions}
+        output_path = args.output_root / f"{effect_path}.json"
+        output_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    unknown = sum(
+        1
+        for entries in paths.values()
+        if all(scopes == ("unknown",) for scopes, _, _ in entries)
+    )
+    print(f"generated={len(field_to_key)} unknown_only={unknown} output={args.output_root}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 变更内容

- 为 Tetra Insight 添加 576 个 More Mod Tetra 效果适用路径资源。
- 记录手持、护甲、弓、Curios 等独立消费路径，共 711 条。
- 添加可从精确反编译 MMT 源码重新生成资源的脚本。
- 对 9 个缺少可靠运行时消费者的效果保留 `unknown`，避免误判。

## 验证

- JSON 文件数：576
- 独立路径数：711
- 仅 `unknown`：9
- Python AST 与 JSON schema/枚举校验通过
- `scripts/validate-knowledge-base.ps1` 通过

## 未验证

- 尚未部署新版 Tetra Insight JAR。
- 尚未执行 CDR 客户端资源重载与游戏内回归。