### PR TITLE
[fix] 修复部分食物的序列组装配方冲突

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -19,7 +19,6 @@
 - 所有自定义配方都应该配有有意义的 id，配方id命名空间使用createdelight。
 - 小刀的配方应当使用cutting_2函数增加，其会将tetra的模块化刀的配方一并加入。
 - 需要加入离心机的配方时请考虑使用centrifugation函数，其会加入三种离心机（vintageimprovement，小型，大型）的配方。
-- 序列组装配方在编写时要格外留意冲突问题，从相同初始物开始：未注册中间产物的情况下，N步配方的最后一步不能和其他的配方的第N步完全相同；有中间产物情况下则第一步不能和其他配方第一步相同
 
 ### commit规范
 - 可以参考https://www.conventionalcommits.org/zh-hans/v1.0.0/#%e7%ba%a6%e5%ae%9a%e5%bc%8f%e6%8f%90%e4%ba%a4%e8%a7%84%e8%8c%83

--- a/kubejs/AGENTS.md
+++ b/kubejs/AGENTS.md
@@ -36,7 +36,7 @@ For cross-module conventions, release notes, and safety rules, see root `AGENTS.
 - Keep recipe IDs explicit and meaningful; use `createdelight` namespace for project-defined recipes unless compatibility requires another namespace.
 - Use `cutting_2(e, input, outputs)` for knife recipes because it also registers tetra modular knife support.
 - Use `centrifugation(e, results, ingredients, processingTime, minimalRPM)` when all centrifuge variants should exist.
-- Sequence assembly recipes need conflict checks: recipes sharing the same initial item can conflict when steps match.
+- Sequence assembly recipes need conflict checks: regardless of whether a transitional item is registered, recipes sharing the same initial item must not have the same first step.
 - Registry script changes require a game restart; ordinary server recipe changes can usually use `/kubejs reload server_scripts`.
 
 ## HELPER FUNCTIONS

--- a/kubejs/server_scripts/Alex's Cave/toxic_caves.js
+++ b/kubejs/server_scripts/Alex's Cave/toxic_caves.js
@@ -193,9 +193,9 @@ ServerEvents.recipes(e => {
     {
         let iner = "bakeries:cut_cake_base"
         e.recipes.create.sequenced_assembly('alexscaves:spelunkie', iner, [
+            e.recipes.create.pressing(iner, iner),
             e.recipes.create.deploying(iner, [iner, "alexscaves:sulfur_dust"]),
-            e.recipes.create.filling(iner, [iner, Fluid.of("cosmopolitan:cream", 250)]),
-            e.recipes.create.pressing(iner, iner)
+            e.recipes.create.filling(iner, [iner, Fluid.of("cosmopolitan:cream", 250)])
         ])
             .loops(1)
             .transitionalItem(iner)

--- a/kubejs/server_scripts/Bakeries/recipe.js
+++ b/kubejs/server_scripts/Bakeries/recipe.js
@@ -345,8 +345,8 @@ ServerEvents.recipes(e => {
         let iner = "bakeries:round_bread_dough"
         create.sequenced_assembly('bakeries:brown_sugar_roll_dough', iner,
             [
-                create.deploying(iner, [iner, 'createdelight:butter']),
-                create.deploying(iner, [iner, "bakeries:brown_sugar_cube"])
+                create.deploying(iner, [iner, "bakeries:brown_sugar_cube"]),
+                create.deploying(iner, [iner, 'createdelight:butter'])
             ]
         )
             .loops(1)

--- a/kubejs/server_scripts/Casualness Delight/cheese.js
+++ b/kubejs/server_scripts/Casualness Delight/cheese.js
@@ -39,8 +39,8 @@ ServerEvents.recipes(e => {
     e.replaceInput({ id: "corn_delight:cooking/nachos_block" }, "#forge:milk", "#forge:cheese")
     combination(e, [
         "create:dough",
-        "trailandtales_delight:cheese_slice",
         "minecraft:carrot",
+        "trailandtales_delight:cheese_slice",
         "minecraft:beetroot",
         "minecraft:potato"
     ], "refurbished_furniture:raw_vegetable_pizza", 1)

--- a/kubejs/server_scripts/Cosmopolitan/recipe.js
+++ b/kubejs/server_scripts/Cosmopolitan/recipe.js
@@ -29,8 +29,8 @@ ServerEvents.recipes(e => {
     {
         let iner = "minecraft:bowl"
         create.sequenced_assembly("cosmopolitan:seasonal_ice_cream", iner, [
-            create.deploying(iner, [iner, 'youkaishomecoming:ice_cube']),
             create.filling(iner, [iner, Fluid.of("cosmopolitan:sweet_berry_ice_cream", 250)]),
+            create.deploying(iner, [iner, 'youkaishomecoming:ice_cube']),
             create.filling(iner, [iner, Fluid.of("cosmopolitan:beetroot_ice_cream", 250)]),
             create.filling(iner, [iner, Fluid.of("cosmopolitan:pumpkin_ice_cream", 250)])
         ])
@@ -41,8 +41,8 @@ ServerEvents.recipes(e => {
     {
         let iner = "minecraft:bowl"
         create.sequenced_assembly("neapolitan:neapolitan_ice_cream", iner, [
-            create.deploying(iner, [iner, 'youkaishomecoming:ice_cube']),
             create.filling(iner, [iner, Fluid.of("cosmopolitan:chocolate_ice_cream", 250)]),
+            create.deploying(iner, [iner, 'youkaishomecoming:ice_cube']),
             create.filling(iner, [iner, Fluid.of("cosmopolitan:strawberry_ice_cream", 250)]),
             create.filling(iner, [iner, Fluid.of("cosmopolitan:vanilla_ice_cream", 250)])
         ])

--- a/kubejs/server_scripts/Custom/food/roll.js
+++ b/kubejs/server_scripts/Custom/food/roll.js
@@ -188,8 +188,8 @@ ServerEvents.recipes(e => {
     {
         let iner = "youkaishomecoming:roe_california_roll"
         e.recipes.create.sequenced_assembly('youkaishomecoming:rainbow_roll', iner, [
-            e.recipes.create.deploying(iner, [iner, '#forge:raw_fishes/salmon']),
             e.recipes.create.deploying(iner, [iner, '#forge:raw_fishes/cod']),
+            e.recipes.create.deploying(iner, [iner, '#forge:raw_fishes/salmon']),
             e.recipes.create.deploying(iner, [iner, '#forge:raw_fishes/tuna']),
         ])
             .transitionalItem(iner)

--- a/kubejs/server_scripts/Nether Exp/recipe.js
+++ b/kubejs/server_scripts/Nether Exp/recipe.js
@@ -23,8 +23,8 @@ ServerEvents.recipes(e => {
 
     combination(e, [
         "create:dough",
-        "trailandtales_delight:cheese_slice",
         "mynethersdelight:hoglin_loin",
+        "trailandtales_delight:cheese_slice",
         "netherexp:warped_wart",
         "minecraft:nether_wart"
     ], "netherexp:nether_pizza", 1)


### PR DESCRIPTION
## 变更

- 修正序列组装冲突规则文档，并将规则迁移到 `kubejs/AGENTS.md`。
- 修复 6 组、14 条序列组装配方的首步冲突，保留原有材料和产物。
- 补充 Cosmopolitan jelly roll 与 chocolate roll 的首步区分。

## 验证

- `node --check`：修改后的 KubeJS 文件通过。
- `git diff --check` 通过。