### PR TITLE
[fix] 修复 Cosmopolitan 蛋糕卷序列冲突

### DIFF
--- a/kubejs/server_scripts/Cosmopolitan/recipe.js
+++ b/kubejs/server_scripts/Cosmopolitan/recipe.js
@@ -224,8 +224,8 @@ ServerEvents.recipes(e => {
     {
         let iner = "bakeries:cut_cake_base"
         create.sequenced_assembly('cosmopolitan:jelly_roll', iner, [
-            create.pressing(iner, iner),
             create.filling(iner, [iner, Fluid.of("cosmopolitan:berry_syrup", 250)]),
+            create.pressing(iner, iner),
         ])
             .loops(1)
             .transitionalItem(iner)
@@ -241,8 +241,8 @@ ServerEvents.recipes(e => {
     {
         let iner = "bakeries:cut_cake_base"
         create.sequenced_assembly('cosmopolitan:chocolate_roll', iner, [
-            create.pressing(iner, iner),
             create.filling(iner, [iner, Fluid.of("create:chocolate", 250)]),
+            create.pressing(iner, iner),
         ])
             .loops(1)
             .transitionalItem(iner)


### PR DESCRIPTION
## 变更

- 修复 `bakeries:cut_cake_base` 上 jelly roll 与 chocolate roll 首步相同的问题。
- 分别让两条配方先灌注不同流体，保留原有材料和产物。

## 验证

- `node --check kubejs/server_scripts/Cosmopolitan/recipe.js` 通过。
- `git diff --check` 通过。