### PR TITLE
[fix] 修复屠宰室多方块部件空值 (#2174)

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -110,6 +110,12 @@ Historical project knowledge: non-obvious bugs, release pitfalls, and workflow d
 
 **Lesson**: Enumerate `data/northstar/recipes/crushing/*zinc*_ore.json` from the active Northstar jar and override every matching ID in KubeJS.
 
+## 2026-08-19 - MBD2 Incomplete Multiblock Null Checks
+
+**Problem**: Issue #2174 showed that an incomplete MBD2 butchery room can return null for its hook or butcher block entity, so its 20-tick callback repeatedly throws when reading `insertedItem`.
+
+**Lesson**: MBD2 scripts must null-check every `getBlockEntity(...)` result before accessing structure-part fields in `onTick`, `onRemoved`, or `onRecipeWorking`, and return safely until the multiblock is complete.
+
 ---
 
 When adding entries, include Problem and Lesson, keep each item short, and remove entries that become common knowledge.

--- a/kubejs/server_scripts/mbd2/butchery_room.js
+++ b/kubejs/server_scripts/mbd2/butchery_room.js
@@ -34,15 +34,25 @@ let carcass_data = [
   ["butchercraft:rabbit_black_head_item", 0],
   ["butchercraft:chicken_carcass", 0]
 ]
-MBDMachineEvents.onTick("createdelight:butchery_room", e => {
-  const {machine} = e.event
-  if (machine.level.time % 20 != 0) return
+
+function getButcheryRoomParts(machine) {
   let pos = machine.pos
   let facing = machine.getFrontFacing().get()
   /**@type {Internal.MeatHookBlockEntity}*/
   let meatHook = machine.level.getBlockEntity(pos.relative(facing.opposite).above().above().above().relative(DirectionUtil.rotation270Direction(facing)))
   /**@type {Internal.ButcherBlockBlockEntity} */
   let butcherBlock = machine.level.getBlockEntity(pos.relative(facing.opposite).above())
+  if (meatHook == null || butcherBlock == null) return null
+  return { meatHook, butcherBlock }
+}
+
+MBDMachineEvents.onTick("createdelight:butchery_room", e => {
+  const {machine} = e.event
+  if (machine.level.time % 20 != 0) return
+  let parts = getButcheryRoomParts(machine)
+  if (parts == null) return
+  let meatHook = parts.meatHook
+  let butcherBlock = parts.butcherBlock
   if(machine.machineStateName != "working") {
     if (meatHook.insertedItem != [] || butcherBlock.insertedItem != []) {
       machine.level.playSound(null, machine.pos.x, machine.pos.y, machine.pos.z, "minecraft:block.slime_block.fall", "blocks", 1, 1)
@@ -98,12 +108,10 @@ MBDMachineEvents.onTick("createdelight:butchery_room", e => {
 })
 MBDMachineEvents.onRemoved("createdelight:butchery_room", e => {
   const {machine} = e.event
-  let pos = machine.pos
-  let facing = machine.getFrontFacing().get()
-  /**@type {Internal.MeatHookBlockEntity}*/
-  let meatHook = machine.level.getBlockEntity(pos.relative(facing.opposite).above().above().above().relative(DirectionUtil.rotation270Direction(facing)))
-  /**@type {Internal.ButcherBlockBlockEntity} */
-  let butcherBlock = machine.level.getBlockEntity(pos.relative(facing.opposite).above())
+  let parts = getButcheryRoomParts(machine)
+  if (parts == null) return
+  let meatHook = parts.meatHook
+  let butcherBlock = parts.butcherBlock
   if(meatHook.insertedItem != [] || butcherBlock.insertedItem != []) {
     // meatHook.stage = 3
     meatHook.finishRecipe()
@@ -112,12 +120,10 @@ MBDMachineEvents.onRemoved("createdelight:butchery_room", e => {
 })
 MBDMachineEvents.onRecipeWorking("createdelight:butchery_room", e => {
   const {machine} = e.event
-  let pos = machine.pos
-  let facing = machine.getFrontFacing().get()
-  /**@type {Internal.MeatHookBlockEntity}*/
-  let meatHook = machine.level.getBlockEntity(pos.relative(facing.opposite).above().above().above().relative(DirectionUtil.rotation270Direction(facing)))
-  /**@type {Internal.ButcherBlockBlockEntity} */
-  let butcherBlock = machine.level.getBlockEntity(pos.relative(facing.opposite).above())
+  let parts = getButcheryRoomParts(machine)
+  if (parts == null) return
+  let meatHook = parts.meatHook
+  let butcherBlock = parts.butcherBlock
   /**@type {String} */
   let itemIds
   if(meatHook.insertedItem == [] && butcherBlock.insertedItem == []) {


### PR DESCRIPTION
## 关联 Issue
Closes #2174

## 修改内容
- 为屠宰室统一获取挂肉钩和案板方块实体。
- 多方块结构未成形时安全退出 onTick、onRemoved 和 onRecipeWorking，避免访问空方块实体。
- 未修改其他 MBD 方块的潜在风险。

## 验证
- node --check kubejs/server_scripts/mbd2/butchery_room.js
- git diff --check
- 未进行游戏内回归测试。
