### PR TITLE
[fix] 修复屠宰室多方块部件空值

### DIFF
--- a/docs/dev-knowledge/compatibility-patches.md
+++ b/docs/dev-knowledge/compatibility-patches.md
@@ -11,6 +11,8 @@
 
 按一个明确目的汇总一行，不要求每个配方、配置或 JSON 单独立项；同一目标新增文件时更新该行的路径与验证状态即可。
 
+| MBD2 屠宰室未成形时部件空值 | 模组兼容 | 屠宰室多方块未成形或失效时，挂肉钩和案板的 `Level#getBlockEntity` 可能返回 `null`；三个 MBD2 回调继续读取 `insertedItem` 会重复报错。 | `kubejs/server_scripts/mbd2/butchery_room.js` 集中获取两个部件并在任一为空时让 `onTick`、`onRemoved`、`onRecipeWorking` 安全返回。 | `node --check` 与 `git diff --check` 通过；关联 [PR #2176](https://github.com/Jasons-impart/Create-Delight-Remake/pull/2176)，尚未完成游戏内拆机/结构失效回归。 | ButcherCraft 或 MBD2 调整部件坐标、方块实体类型或事件语义时复核；确认上游提供统一安全访问后可移除重复防护。 | 已修复，待游戏内回归 |
+
 | 修复 | 类型 | 问题或根因 | 补丁位置 | 验证与跟踪 | 复核/移除条件 | 状态 |
 |---|---|---|---|---|---|---|
 | Tetra Insight 识别 More Mod Tetra 效果适用路径 | 模组兼容 | `ItemEffect` 本身不携带护甲、手持或 Curios 适用类型；MMT `2.4.15` 的 576 个效果分散在手持、护甲、弓、Curios 与可选联动消费者中，部分注册项还存在无运行时引用或读取错字段，不能仅按名称或 GUI 注册推断。 | Tetra Insight 增加客户端资源规则加载、Curios/死亡/治疗范围与触发支持；CDR 在 `kubejs/assets/more_mod_tetra/tetra_insight/effect_applicability/` 保存 576 个 JSON，并用 `scripts/generate-mmt-effect-applicability.py` 从精确反编译 JAR 重建。 | MMT 注册表与 JSON 文件名 576/576 一致，共 711 条独立路径；UTF-8、scope、trigger、stacking 与非空 paths 校验通过；Tetra Insight `test build` 通过。9 个无可靠消费者的效果保留 `unknown`；CDR 客户端资源重载尚未执行，当前运行 JAR 仍需另行同步。 | MMT 升级、`EffectGuiStats` 注册表或 helper/事件消费者变化时重新反编译并生成；上游修复错字段或补齐消费者后替换对应 `unknown`；Tetra Insight 原生覆盖这些规则后可移除 CDR JSON。 | 静态兼容完成，待新 JAR 部署与客户端资源重载回归 |

--- a/kubejs/server_scripts/mbd2/butchery_room.js
+++ b/kubejs/server_scripts/mbd2/butchery_room.js
@@ -30,15 +30,25 @@ let carcass_data = [
   ["butchercraft:rabbit_black_head_item", 0],
   ["butchercraft:chicken_carcass", 0]
 ]
-MBDMachineEvents.onTick("createdelight:butchery_room", e => {
-  const {machine} = e.event
-  if (machine.level.time % 20 != 0) return
+
+function getButcheryRoomParts(machine) {
   let pos = machine.pos
   let facing = machine.getFrontFacing().get()
   /**@type {Internal.MeatHookBlockEntity}*/
   let meatHook = machine.level.getBlockEntity(pos.relative(facing.opposite).above().above().above().relative(DirectionUtil.rotation270Direction(facing)))
   /**@type {Internal.ButcherBlockBlockEntity} */
   let butcherBlock = machine.level.getBlockEntity(pos.relative(facing.opposite).above())
+  if (meatHook == null || butcherBlock == null) return null
+  return { meatHook, butcherBlock }
+}
+
+MBDMachineEvents.onTick("createdelight:butchery_room", e => {
+  const {machine} = e.event
+  if (machine.level.time % 20 != 0) return
+  let parts = getButcheryRoomParts(machine)
+  if (parts == null) return
+  let meatHook = parts.meatHook
+  let butcherBlock = parts.butcherBlock
   if(machine.machineStateName != "working") {
     if (meatHook.insertedItem != [] || butcherBlock.insertedItem != []) {
       machine.level.playSound(null, machine.pos.x, machine.pos.y, machine.pos.z, "minecraft:block.slime_block.fall", "blocks", 1, 1)
@@ -94,12 +104,10 @@ MBDMachineEvents.onTick("createdelight:butchery_room", e => {
 })
 MBDMachineEvents.onRemoved("createdelight:butchery_room", e => {
   const {machine} = e.event
-  let pos = machine.pos
-  let facing = machine.getFrontFacing().get()
-  /**@type {Internal.MeatHookBlockEntity}*/
-  let meatHook = machine.level.getBlockEntity(pos.relative(facing.opposite).above().above().above().relative(DirectionUtil.rotation270Direction(facing)))
-  /**@type {Internal.ButcherBlockBlockEntity} */
-  let butcherBlock = machine.level.getBlockEntity(pos.relative(facing.opposite).above())
+  let parts = getButcheryRoomParts(machine)
+  if (parts == null) return
+  let meatHook = parts.meatHook
+  let butcherBlock = parts.butcherBlock
   if(meatHook.insertedItem != [] || butcherBlock.insertedItem != []) {
     // meatHook.stage = 3
     meatHook.finishRecipe()
@@ -108,12 +116,10 @@ MBDMachineEvents.onRemoved("createdelight:butchery_room", e => {
 })
 MBDMachineEvents.onRecipeWorking("createdelight:butchery_room", e => {
   const {machine} = e.event
-  let pos = machine.pos
-  let facing = machine.getFrontFacing().get()
-  /**@type {Internal.MeatHookBlockEntity}*/
-  let meatHook = machine.level.getBlockEntity(pos.relative(facing.opposite).above().above().above().relative(DirectionUtil.rotation270Direction(facing)))
-  /**@type {Internal.ButcherBlockBlockEntity} */
-  let butcherBlock = machine.level.getBlockEntity(pos.relative(facing.opposite).above())
+  let parts = getButcheryRoomParts(machine)
+  if (parts == null) return
+  let meatHook = parts.meatHook
+  let butcherBlock = parts.butcherBlock
   /**@type {String} */
   let itemIds
   if(meatHook.insertedItem == [] && butcherBlock.insertedItem == []) {


### PR DESCRIPTION
## 关联

- Closes #2174
- 参考 PR #2176

## 修改内容

- 统一获取屠宰室的挂肉钩和案板方块实体。
- 多方块部件缺失时，让 onTick、onRemoved 和 onRecipeWorking 安全返回。
- 在兼容性台账中记录 MBD2 多方块空值防护和复核条件。

## 验证

- node --check kubejs/server_scripts/mbd2/butchery_room.js
- git diff --check
- 未进行游戏内拆机或结构失效回归。
