### PR TITLE
[feat] 提高野生曼德拉生成概率

### DIFF
--- a/kubejs/data/youkaishomecoming/worldgen/configured_feature/mandrake.json
+++ b/kubejs/data/youkaishomecoming/worldgen/configured_feature/mandrake.json
@@ -1,0 +1,47 @@
+{
+  "type": "minecraft:random_patch",
+  "config": {
+    "feature": {
+      "feature": {
+        "type": "minecraft:simple_block",
+        "config": {
+          "to_place": {
+            "type": "minecraft:simple_state_provider",
+            "state": {
+              "Name": "youkaishomecoming:wild_mandrake"
+            }
+          }
+        }
+      },
+      "placement": [
+        {
+          "type": "minecraft:block_predicate_filter",
+          "predicate": {
+            "type": "minecraft:all_of",
+            "predicates": [
+              {
+                "type": "minecraft:replaceable"
+              },
+              {
+                "type": "minecraft:matching_fluids",
+                "fluids": "minecraft:empty"
+              },
+              {
+                "type": "minecraft:matching_blocks",
+                "blocks": "minecraft:grass_block",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "tries": 24,
+    "xz_spread": 5,
+    "y_spread": 3
+  }
+}

--- a/kubejs/data/youkaishomecoming/worldgen/configured_feature/mandrake.json
+++ b/kubejs/data/youkaishomecoming/worldgen/configured_feature/mandrake.json
@@ -27,20 +27,17 @@
                 "fluids": "minecraft:empty"
               },
               {
-                "type": "minecraft:matching_blocks",
-                "blocks": "minecraft:grass_block",
-                "offset": [
-                  0,
-                  -1,
-                  0
-                ]
+                "type": "minecraft:would_survive",
+                "state": {
+                  "Name": "youkaishomecoming:wild_mandrake"
+                }
               }
             ]
           }
         }
       ]
     },
-    "tries": 24,
+    "tries": 12,
     "xz_spread": 5,
     "y_spread": 3
   }

--- a/kubejs/data/youkaishomecoming/worldgen/placed_feature/mandrake.json
+++ b/kubejs/data/youkaishomecoming/worldgen/placed_feature/mandrake.json
@@ -1,0 +1,19 @@
+{
+  "feature": "youkaishomecoming:mandrake",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 2
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "MOTION_BLOCKING"
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/kubejs/data/youkaishomecoming/worldgen/placed_feature/mandrake.json
+++ b/kubejs/data/youkaishomecoming/worldgen/placed_feature/mandrake.json
@@ -3,14 +3,14 @@
   "placement": [
     {
       "type": "minecraft:rarity_filter",
-      "chance": 2
+      "chance": 6
     },
     {
       "type": "minecraft:in_square"
     },
     {
       "type": "minecraft:heightmap",
-      "heightmap": "MOTION_BLOCKING"
+      "heightmap": "MOTION_BLOCKING_NO_LEAVES"
     },
     {
       "type": "minecraft:biome"

--- a/kubejs/server_scripts/mbd2/butchery_room.js
+++ b/kubejs/server_scripts/mbd2/butchery_room.js
@@ -43,7 +43,7 @@ function getButcheryRoomParts(machine) {
   /**@type {Internal.ButcherBlockBlockEntity} */
   let butcherBlock = machine.level.getBlockEntity(pos.relative(facing.opposite).above())
   if (meatHook == null || butcherBlock == null) return null
-  return { meatHook, butcherBlock }
+  return { meatHook: meatHook, butcherBlock: butcherBlock }
 }
 
 MBDMachineEvents.onTick("createdelight:butchery_room", e => {


### PR DESCRIPTION
## 变更内容

- 保持模组原始生成参数：chance=6、tries=12。
- 将高度图改为 MOTION_BLOCKING_NO_LEAVES，减少树叶树冠对采样位置的干扰。
- 使用 minecraft:would_survive，根据野生曼德拉自身的 BushBlock 生存规则判断可放置位置。

## 验证

- 两个 JSON 文件通过 ConvertFrom-Json 解析。
- 字段断言通过：chance=6、tries=12、MOTION_BLOCKING_NO_LEAVES、minecraft:would_survive。
- git diff --check 通过。
- 尚未启动游戏进行实际世界生成验证。