### PR TITLE
[feat] 通用机械深度融合全套：材料统一、机器阶梯、工厂序列、装备门槛与矿链

### DIFF
--- a/.agents/skills/mekanism-integration/SKILL.md
+++ b/.agents/skills/mekanism-integration/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: mekanism-integration
+description: 在 Create-Delight Remake 新版本中重建通用机械（Mekanism 四件套）深度魔改的设计规范与操作手册。涵盖装包清单、owner 制材料统一、电路/机器阶梯/工厂/升级重铺、Generators 门控、锇铅矿链、AE2 联动、自建配方 Schema 与级联中断防护验证协议；全部代码模板来自已验证的自研实现。
+---
+
+# 通用机械深度魔改（自研版重建手册）
+
+本 skill 是设计事实与可重复流程合一的重建手册：在新版本实例上按章节顺序执行，即可复现整套 Mekanism 融合。所有配方 ID 均经 Mekanism 10.4.16.80 JAR 实测；所有代码块为已运行验证的模板原文。
+
+## 〇、前置条件与血泪教训（必读，跳过会全盘翻车）
+
+1. **级联中断（最高优先级）**：`ServerEvents.recipes` 事件中任一脚本抛出未捕获异常，会**中止其后所有监听器**——监听器按文件系统目录序执行（macOS APFS 为创建序，新文件永远排在后面）。症状：`Loaded script` 正常、无报错、但修改全部不生效。**开工前必须让 `logs/kubejs/server.log` 的配方事件 ERROR 归零**。历史根因：`mbd2_recipes/alloy_electric_furnace.js` 的 `e.recipes.createdelight` undefined——由 `kubejs/data` 未随脚本同步（943 vs 2094 的缺口）导致 MBD2 机器数据缺失。**教训：同步脚本时必须整树同步 `kubejs/`（含 data/）**。
+2. **KubeJS 锁 build.24**（`kubejs-forge-2001.6.5-build.24.jar`，file-id 8010958）。不要用 build.16（行为异常）与 build.26（食物属性回归，#2131）。
+3. **macOS 实例专属**：包内 `acceleratedrendering` 声明要求 OpenGL ≥4.6，mac 上限 4.1 → 启动即崩（NoChatReports NPE 连锁）。处理：移入 `disabled-mods-mac/`。全 mods 扫描 `unzip -p <jar> META-INF/mods.toml | grep -E "^\[features\."` 确认无其他未注释的 OpenGL 声明。
+4. **「Loaded script ≠ 执行成功」**：加载日志只证明扫描与解析。生效验证必须走 §九 的探针协议。
+5. **ID 实测纪律**：所有 Mek 配方 ID 以 JAR 内 `data/mekanism/recipes/` 路径为准（`unzip -l Mekanism-1.20.1-10.4.16.80.jar | grep <关键词>`），不凭记忆拼写。删除用包内 `remove_recipes_id(e, [...])`，禁止裸 `e.remove()`。
+6. **注册类改动需重启**：startup 注册物（过渡物等）改后必须完整重启，`/kubejs reload server_scripts` 不重建注册表。
+
+## 一、装包清单
+
+| 模组 | 版本 | side | 说明 |
+|---|---|---|---|
+| Mekanism | 1.20.1-10.4.16.80 | both | 本体（file 6552911） |
+| Mekanism Generators | 同版本号 | both | 发电与核工业（6552914） |
+| Mekanism Tools | 同版本号 | both | 材料消费出口（6552915） |
+| Mekanism Additions | 同版本号 | both | 塑料/小生物（6552913） |
+| Applied Mekanistics | 1.4.3 | both | AE2 存化学品（§七深绑） |
+| JustEnough Mekanism Multiblocks | 4.10 | client | JEI 看多方块 |
+| mekanismcurios | 1.2.1 | both | 饰品栏 |
+| ~~KubeJS Mekanism UNOFFICIAL~~ | — | — | **不装**，用 §六自建 Schema 替代 |
+
+四件套版本号必须一致。装包走 `add-packwiz-target.ps1`；首版 `stable = false`。
+
+**矿生配置**（`defaultconfigs/Mekanism/world.toml`，键名经 Mekanism 1.20.x `WorldConfig.java` 核实）：
+
+| 矿 | 配置 |
+|---|---|
+| 锡 tin | `shouldGenerate = false`（包内 createdelightcore 是唯一来源） |
+| 铀 uranium | `shouldGenerate = false`（alexscaves 链唯一来源） |
+| 盐 salt | `shouldGenerate = false` |
+| 锇 osmium | 默认（upper 65 / middle 6 / small 8） |
+| 铅 lead | 默认（normal 8） |
+| 萤石 fluorite | 默认（normal 5 / buried 3） |
+
+结构：`[world_generation.<ore>]` 下 `shouldGenerate`，矿脉子节 `[world_generation.<ore>.<small|middle|large|upper|buried|normal>]` 下 `perChunk/maxVeinSize/shouldGenerate`。10.4 的放置器带 `mekanism:disableable`，配置关闭即生效，无需数据包覆盖。
+
+## 二、材料统一（owner 制 + 1:1 互转）
+
+**理念**：包内已有金属保持 owner 地位，通过 forge 标签喂给 Mek 配方；同时提供 1:1 无序互转保证玩家存量 Mek 物品不废。不用 replaceOutput（保留 Mek 物品流通性、JEI 透明）。
+
+| 金属 | owner | Mek 侧处理 |
+|---|---|---|
+| 青铜 | `createdelightcore:bronze_ingot` | 互转配方双向 |
+| 钢 | `createmetallurgy:steel_ingot` | **全链退役**（§二.3），不设互转 |
+| 锡 | `createdelightcore:tin_ingot` / `createdelight:tin_dust` | 锭/粉互转（Mek 锡无生成来源，仅作机器产物形态回收） |
+| 铀 | `alexscaves:uranium` | 单向：alexscaves 铀 → Mek 铀锭（供裂变燃料链取料） |
+| 锇/铅 | `mekanism`（raw/ingot/dust 全系） | 完整双链接入（§七.2） |
+
+**tags.js**（`server_scripts/Mekanism/tags.js`）：
+
+```js
+ServerEvents.tags("minecraft:item", e => {
+    // 锡：包内是唯一来源，挂入常规标签驱动 Mek 青铜等配方
+    e.add("forge:ingots/tin", ["createdelightcore:tin_ingot"])
+    e.add("forge:nuggets/tin", ["createdelightcore:tin_nugget"])
+    e.add("forge:storage_blocks/tin", ["createdelightcore:tin_block"])
+    e.add("forge:raw_materials/tin", ["createdelightcore:raw_tin"])
+    e.add("forge:raw_material_blocks/tin", ["createdelightcore:raw_tin_block"])
+    e.add("forge:ores/tin", ["createdelightcore:tin_ore", "createdelightcore:deepslate_tin_ore"])
+    // createdelight:tin_dust 已在注册时挂 forge:dusts/tin，无需重复
+    // 青铜：owner createdelightcore
+    e.add("forge:ingots/bronze", ["createdelightcore:bronze_ingot"])
+    // 钢：owner createmetallurgy
+    e.add("forge:ingots/steel", ["createmetallurgy:steel_ingot"])
+    // 铀：alexscaves 已挂 forge:ingots/uranium，Mek 铀锭由模组自挂，三向互通
+})
+```
+
+**unification.js**（互转层）：
+
+```js
+ServerEvents.recipes(e => {
+    // 青铜双向
+    e.recipes.kubejs.shapeless("createdelightcore:bronze_ingot", "mekanism:ingot_bronze")
+        .id("createdelight:crafting/mekanism/mek_bronze_2_bronze")
+    e.recipes.kubejs.shapeless("mekanism:ingot_bronze", "createdelightcore:bronze_ingot")
+        .id("createdelight:crafting/mekanism/bronze_2_mek_bronze")
+    // 锡（锭+粉）
+    e.recipes.kubejs.shapeless("createdelightcore:tin_ingot", "mekanism:ingot_tin")
+        .id("createdelight:crafting/mekanism/mek_tin_2_tin")
+    e.recipes.kubejs.shapeless("createdelight:tin_dust", "mekanism:dust_tin")
+        .id("createdelight:crafting/mekanism/mek_tin_dust_2_tin_dust")
+    // 铀单向
+    e.recipes.kubejs.shapeless("mekanism:ingot_uranium", "alexscaves:uranium")
+        .id("createdelight:crafting/mekanism/uranium_2_mek_uranium")
+})
+```
+
+**steel_retire.js**（Mek 钢退役——掐断全部生产）：
+
+```js
+ServerEvents.recipes(e => {
+    remove_recipes_id(e, [
+        "mekanism:processing/steel/enriched_iron_to_dust",   // 钢的诞生点（富集铁→钢粉）
+        "mekanism:processing/steel/ingot/from_block",
+        "mekanism:processing/steel/ingot/from_dust_blasting",
+        "mekanism:processing/steel/ingot/from_dust_smelting",
+        "mekanism:processing/steel/ingot/from_nuggets",
+        "mekanism:processing/steel/ingot_to_dust"
+    ])
+})
+```
+
+## 三、控制电路四级（进度脊柱）
+
+电路是全部 Mek 机器/工厂/QIO 的核心耗材，等级梯度即进度门控；高阶绑定 Create 机械合成与 Northstar。
+
+```js
+ServerEvents.recipes(e => {
+    remove_recipes_id(e, [
+        "mekanism:control_circuit/basic", "mekanism:control_circuit/advanced",
+        "mekanism:control_circuit/elite", "mekanism:control_circuit/ultimate"
+    ])
+    // 基础：黄铜 + 电子管 + 红石（工作台）
+    e.recipes.kubejs.shaped("2x mekanism:basic_control_circuit", ["RBR","BAB","RBR"], {
+        R: "minecraft:redstone", B: "create:brass_ingot", A: "create:electron_tube"
+    }).id("createdelight:crafting/mekanism/basic_control_circuit")
+    // 进阶：精密机构 + 注入合金 + CCA 电容
+    e.recipes.kubejs.shaped("2x mekanism:advanced_control_circuit", ["IPI","PAP","IPI"], {
+        I: "mekanism:alloy_infused", P: "create:precision_mechanism", A: "createaddition:capacitor"
+    }).id("createdelight:crafting/mekanism/advanced_control_circuit")
+    // 精英：4x4 机械合成（northstar 电路 + 强化合金 + 电子管）
+    e.recipes.create.mechanical_crafting("2x mekanism:elite_control_circuit", ["IRRI","REER","REER","IRRI"], {
+        I: "northstar:circuit", R: "mekanism:alloy_reinforced", E: "create:electron_tube"
+    }).id("createdelight:mechanical_crafting/mekanism/elite_control_circuit")
+    // 终极：5x5 机械合成（高级电路 + 原子合金 + 钨 + 精密机构 + 电容）
+    e.recipes.create.mechanical_crafting("2x mekanism:ultimate_control_circuit", ["IAAAI","ATPTA","APCPA","ATPTA","IAAAI"], {
+        I: "northstar:advanced_circuit", A: "mekanism:alloy_atomic",
+        T: "createmetallurgy:tungsten_ingot", P: "create:precision_mechanism",
+        C: "createaddition:capacitor"
+    }).id("createdelight:mechanical_crafting/mekanism/ultimate_control_circuit")
+})
+```
+
+## 四、机器阶梯（machine_tiers.js）
+
+**关键认知**：Mek 机器的等级存在方块 NBT 中，高阶机器不是独立物品——**升级唯一途径是等级安装器（tier_installer）**，因此安装器配方是整个阶梯的核心，做成 Create 序列装配。
+
+三档模板（统一 `basic_machine` / `chemical_machine` / `late_machine` 函数 + 风味核心材料）：
+
+| 档 | 机器（9/8/2 台） | 模板材料 | 风味核心 |
+|---|---|---|---|
+| 基础 | enrichment_chamber / crusher / energized_smelter / precision_sawmill / osmium_compressor / combiner / metallurgic_infuser / purification_chamber / chemical_injection_chamber | 安山合金 + 铜板 + 基础电路 + 安山机壳（AUA/PCP/AKA） | 铁/铜/木板/锇/圆石/红石/铅/锇 |
+| 化学 | electrolytic_separator / chemical_infuser / chemical_oxidizer / chemical_dissolution_chamber / chemical_washer / chemical_crystallizer / rotary_condensentrator / pressurized_reaction_chamber | 黄铜 + 黄铜机壳 + 进阶电路（PUP/BCB/PUP） | 铜线卷/加压管/硫粉/玻璃/流体罐/玫瑰石英/机械泵/螺旋桨 |
+| 后阶 | isotopic_centrifuge / solar_neutron_activator | 冶金钢 + 精英电路（SXS/XCX/SXS） | 强化合金 / CCA 电容 |
+
+**删除注意**：Mek 机器配方是 `mekanism:mek_data` 类型，必须按精确 ID 删除（`remove_recipes_id` + `mekanism:<机器名>`，JAR 路径 `recipes/<机器名>.json` 已逐一核实）。
+
+**等级安装器**（四级全部序列装配；过渡物 `createdelight:incomplete_tier_installer`）：
+
+```js
+function tier_installer(installer, circuit, bond) {
+    let iner = "createdelight:incomplete_tier_installer"
+    e.recipes.create.sequenced_assembly(installer, "create:iron_sheet", [
+        e.recipes.create.deploying(iner, [iner, circuit]),
+        e.recipes.create.pressing(iner, iner),
+        e.recipes.create.deploying(iner, [iner, bond])
+    ]).transitionalItem(iner).loops(1)
+        .id(`createdelight:sequenced_assembly/${installer.split(":")[1]}`)
+}
+tier_installer("mekanism:basic_tier_installer",    "mekanism:basic_control_circuit",    "create:andesite_alloy")
+tier_installer("mekanism:advanced_tier_installer", "mekanism:advanced_control_circuit", "create:brass_ingot")
+tier_installer("mekanism:elite_tier_installer",    "mekanism:elite_control_circuit",    "createmetallurgy:steel_ingot")
+tier_installer("mekanism:ultimate_tier_installer", "mekanism:ultimate_control_circuit", "createmetallurgy:tungsten_ingot")
+```
+
+（删除原版：`mekanism:tier_installer/{basic,advanced,elite,ultimate}`。）
+
+## 五、工厂与升级
+
+**factories.js**——9 种工厂类型（smelting/enriching/crushing/sawing/compressing/combining/infusing/purifying/injecting）× 4 等级全部序列装配，叙事"单机上装配线，机械手逐步加装"。**低阶工厂是高阶的装配基底**（渐进链）：
+
+```js
+// 基础工厂：单机为基底 + 2 单机 + 2 精密机构 + 2 HDPE 板（6 步部署）
+// 进阶工厂：基础工厂为基底 + 2 进阶电路 + 黄铜机壳 + HDPE 板
+// 精英/终极：同模式，基底与阶位材料递进【按模板补全】
+let iner = "createdelight:incomplete_factory"
+// 删除：mekanism:factory/{basic,advanced,elite,ultimate}/{九类型}（Rhino 无 flatMap，双循环拼数组）
+```
+
+**upgrades.js**——选择性 Create 化（只改影响平衡的）：
+
+| 升级 | 处理 | 新配方核心 |
+|---|---|---|
+| speed | 重铺 | 锇锭 + **Create 齿轮** + 红石（动力学超频） |
+| energy | 重铺 | 电子管 + **CCA 电容** + 铜线卷（与包内 FE 体系同源） |
+| gas | 重铺 | 铅锭 + 加压管 + HDPE 板 |
+| filter | 重铺 | 纸 + **Create 过滤网** + 锇锭（接包内造纸链） |
+| muffling / anchor / stone_generator | **保留原版** | 纯 QoL，无平衡影响 |
+
+### 装备门槛（gear_gating.js，范围化 replaceInput 不重排配方）
+
+| 对象 | 门槛 |
+|---|---|
+| jetpack 模块 | mekanism:jetpack → `northstar:lunar_sapphire_shard`（飞行=星际特权） |
+| electrolytic_breathing 模块 | 电解芯 → `createdelight:sturdy_oxygen_tank`（制氧=北极星终点） |
+| gravitational_modulating 模块 | 下界之星 → `alexscaves:occult_gem`（反重力=深渊） |
+| locomotive_boosting 模块 | 钻石护腿 → `northstar:advanced_circuit`（速度=星际科技） |
+| hydraulic_propulsion 模块 | 自由跑鞋 → `#forge:spring/between_500_2_1000`（跳跃=Create 高阶弹簧） |
+| vision_enhancement 模块 | 绿宝石 → 望远镜 |
+| magnetic_attraction 模块 | 铁栏杆 → `alexscaves:magnetron`（磁吸=磁洞） |
+| attack_amplification 模块 | 铁剑 → `iceandfire:dragonbone`（伤害=屠龙） |
+| radiation_shielding 模块 | 不改（原版即铅块门槛） |
+| MekaTool | 原子分解器 → `#more_mod_tetra:over_core`（与命定之门同源）+ 外壳冶金钢 |
+| MekaSuit 本体 ×4 | 外壳→冶金钢、精炼萤石→深渊宝珠 |
+| Mekanism Tools 全装备 | `remove_recipes_mod(e, ["mekanismtools"])` 断获取（配合客户端 JEI 隐藏） |
+
+## 六、@recipes Schema 自建（替代 KubeJS Mekanism 插件）
+
+**版本耦合警告**：`@recipes/` 的 Schema API 由同目录 `prelude.js` 定义，**新旧两版 API 不兼容**。新版语法（`complexKey` 回调收 `k.addKey(...)`）在旧版 prelude 上会在 `StartupEvents.recipeSchemaRegistry` 阶段抛 "Cannot convert ... to RecipeKey[]"，且**中断 forEach 后续全部 schema 注册**（createmetallurgy/createdieselgenerators 等陪葬）并穿透到 FML loadComplete。**旧版实例（如 v0.5.0.7-test zip）上直接省略 mekanism Schema 文件**——当前全部脚本用 `e.recipes.kubejs.*` / `e.recipes.create.*` / `e.recipes.vintageimprovements.*` / `event.custom()`，对 `e.recipes.mekanism.*` 零依赖。仅在实例已整体同步新版 kubejs 树（含新 prelude）时才部署下面的 Schema：
+
+```js
+new Schema("mekanism:crushing")
+    .complexKey("input", true, k => k.addKey("ingredient", "inputItem"))
+    .simpleKey("output", "outputItem")
+new Schema("mekanism:enriching")  // 同构
+new Schema("mekanism:smelting")   // 同构
+new Schema("mekanism:sawing")
+    .complexKey("input", true, k => k.addKey("ingredient", "inputItem"))
+    .simpleKey("mainOutput", "outputItem")
+    .simpleKey("secondaryOutput", "outputItem", null)
+new Schema("mekanism:combining")
+    .complexKey("mainInput", true, k => k.addKey("ingredient", "inputItem"))
+    .complexKey("extraInput", true, k => k.addKey("ingredient", "inputItem"))
+    .simpleKey("output", "outputItem")
+new Schema("mekanism:energy_conversion")
+    .complexKey("input", true, k => k.addKey("ingredient", "inputItem"))
+    .simpleKey("output", "doubleNumber")   // 输出为数值（J）
+```
+
+## 七、Generators 门控、矿链与跨模组联动
+
+### 7.1 generators.js（只门控"改变游戏节奏"的设备，常规发电机保持原版）
+
+| 设备 | 门控设计 |
+|---|---|
+| 燃气发电机 | 冶金钢+铜板+进阶电路+CCA 电容+黄铜机壳（乙烯链发电核心） |
+| **数字矿机** | **5×5 机械合成，核心槽 = `createoreexcavation:extractor`（COE 提取器是它的原型机——叙事门控）** + 精英电路 + HDPE + 钢机壳 |
+| QIO 全家（dashboard/drive_array/importer/exporter/redstone_adapter/portable） | 绑 AE2：仪表盘=基础电路+精密机构；驱动阵列=机械合成+进阶电路+逻辑处理器系【按模板补全】 |
+| 聚变控制器 | 终局门槛，机械合成【按模板补全】 |
+| 裂变端口 + SPS 端口 | 核体系分阶段门槛，机械合成【按模板补全】 |
+
+### 7.2 矿链（锇/铅进包内冶金体系）
+
+- **ore_processing.js**：氟石 `crushing_ore(e, "mekanism:fluorite_ore", "mekanism:fluorite_gem", 5, "minecraft:cobblestone")`（Create 链 5+副产 vs Mek 原生 5-6 宝石）。
+- **Create Ore/recipes.js 扩展**：主世界金属矿簇破碎/振动产物加入 `create:crushed_raw_osmium/lead/uranium` 与 `mekanism:raw_osmium/raw_lead`（withChance 0.25-0.5）；贵金属矿簇加 `mekanism:fluorite_gem`——**锇/铅/铀/氟石并入数字矿机矿簇产物**（保留原配方 id 避免重复注册）。
+- **Custom/metal/osmium.js + lead.js**（完整双链模板）：
+
+```js
+ServerEvents.recipes(e => {
+    // 副产物：锇矿石伴生青金石（铅：伴生硫 0.5）
+    byProductMap.set("mekanism:dust_osmium", ["minecraft:lapis_lazuli", 0.4])
+    // Create 湿法洗练链：脏粉→粉→粉碎矿→粗矿→粒（粉碎矿用 Create 6 自带物品）
+    metal_production_line_5(e, [
+        "mekanism:dirty_dust_osmium", "mekanism:dust_osmium",
+        "create:crushed_raw_osmium", "mekanism:raw_osmium", "mekanism:nugget_osmium"
+    ])
+    // 冶金热熔链：锇块/锭 ↔ 熔融锇（解锁 createmetallurgy:molten_osmium）
+    metal_production_line_7(e, ["mekanism:block_osmium", "mekanism:ingot_osmium",
+        "createmetallurgy:molten_osmium"], "heated", 80)
+})
+```
+
+### 7.3 chemical_chain.js（农业盈余直通乙烯链）
+
+Mek 原生已有 100+ 原版物品→生物燃料的粉碎配方；补包内自创作物与 FD 食材（adzuki_beans_seed / artemisia_argyi_seed / rice / tomato），`event.custom({type:"mekanism:crushing", ...})` 出 `mekanism:bio_fuel` ×2。
+
+### 7.4 Applied Mekanistics 深绑（对齐 AE2 章 processor&cellcasing.js 风格）
+
+- 化学品元件外壳：删 `appmek:chemical_cell_housing`，锇锭走 **VI 压弯**（复用包内 `createdelight:cell_housing_curving_head`，与 AE2 元件外壳同一产线）。
+- 化学品存储元件五级（1k-256k）：删原版，shaped `QCQ/CHC/QCQ`（赛特斯石英粉 + 对应级 Mek 电路：1k/4k=基础、16k=进阶、64k=精英、256k=终极 + 外壳）。
+- 便携元件：对应元件 + HDPE + 能量平板 + 进阶电路。
+
+### 7.5 经济接入
+
+- unified_loot 科技池：tier1 加锇锭/基础电路，tier2 加进阶电路/氟石/alexscaves 铀。
+- `startup/custom/value_data.js` 采矿价值源：`raw_osmium: 3`、`raw_lead: 3`、`fluorite_gem: 2`（价值经配方链自动传导至粉/锭/电路/塑料）。
+
+## 八、客户端脚本
+
+- **info_mekanism.js**：JEI 信息页照包内三元组规范（key + zh + en 同步挂语言）。覆盖物品：等级安装器（右键原地升级说明）、数字矿机（COE 原型机叙事 + 半径/精准/回填）、盖革计数器（辐射机制与 `/mek radiation cure`）、化学品元件外壳。
+- **mekanism_tools_hide.js**：`JEIEvents.hideItems` 隐藏 Mekanism Tools 全部装备（6 材质 × 11 类：sword/pickaxe/axe/shovel/hoe/paxel/shield/四件甲 + 原版材质多用镐 6 件）与 Mek 钢系列 + 富集铁（已退役无获取途径）；**材料物品（锇/青铜/精炼黑曜石/精炼萤石锭等）保留**。
+
+## 九、验证协议（级联防护，每阶段收尾必跑）
+
+1. **静态**：`node --check` 全部新脚本；删除 ID 逐一对照 JAR 路径。
+2. **开工前置门槛**：进一次世界后配方事件 ERROR 数必须为 **0**（alloy 教训——一个错误杀死排序在其后的所有脚本）。
+3. **日志铁律**：KubeJS 的 `server.log` 在初次加载时**不完整**（它自己会警告），配方事件的真实输出（含探针异常与 Added/removed 统计）在 **`logs/latest.log`**——取证一律读 latest.log。
+4. **探针法**（验证「执行」而非「加载」）：投掷型探针读配方管理器状态。两条铁律：
+   - **探针文件必须在所有目标脚本之后创建**——监听器按 APFS 创建序执行，探针先创建就会先执行、读到修改前的假象（本项目曾因此误判整晚）；
+   - 事件中途 `forEachRecipe` 只能查到"删除"效果（原版残留=0 ✓），**查不到刚添加的配方**——新增配方以游戏内 JEI 实见为准。模板：
+
+```js
+ServerEvents.recipes(e => {
+    let n = 0
+    e.forEachRecipe({ id: "mekanism:upgrade/speed" }, r => n++)
+    throw new Error("PROBE 原版速度升级残留=" + n)
+})
+```
+
+5. **JEI 三点抽检**（世界内，非标题界面）：速度升级=锇锭+齿轮+红石；基础控制电路=黄铜+电子管；粉碎机=安山合金机壳模板。
+6. **数字对比**：健康基线为 Added≈2000+/removed≈1000+（本实例实测 2035/1020）；若骤降到几百级（如 616/287）= 存在级联死区。
+7. 探针用后即删。
+
+## 十、边界与后续项
+
+- 装备门槛（§五 gear_gating.js）已实现；剩余后续项仅 OED 数值审查。
+- 不用 hotai 补 Mek；能配置/配方解决的不上字节码，确需算法级改造再评估 CDC 可选依赖。
+- **版本升级核对单**：四件套同步升版本 → 重跑 §一矿生配置 diff → §〇.5 全 ID 走查 → §九全协议 → Crash Assistant 基线重建。
+- 同步脚本到实例时**必须整树同步 `kubejs/`（含 `data/`）**，脚本与数据分离是级联中断的历史根因。

--- a/config/modpack_defaults/config/crash_assistant/modlist.json
+++ b/config/modpack_defaults/config/crash_assistant/modlist.json
@@ -99,6 +99,11 @@
     "name": "AppleSkin",
     "version": "2.5.1"
   },
+  "Applied-Mekanistics-1.4.3.jar": {
+    "modId": "applied-mekanistics",
+    "name": "Applied Mekanistics",
+    "version": "1.4.3"
+  },
   "appliedcreate-1.20.1-1.1.6.jar": {
     "modId": "appliedcreate",
     "name": "Applied Create",
@@ -399,10 +404,10 @@
     "name": "Create Delight Core",
     "version": "1.20.1-dev"
   },
-  "create-enchantment-industry-2.5.0b.jar": {
+  "create-enchantment-industry-2.5.2.jar": {
     "modId": "create-enchantment-industry",
     "name": "Create: Enchantment Industry",
-    "version": "2.5.0b"
+    "version": "2.5.2"
   },
   "create-integrated-farming-1.3.0-1.20.1.jar": {
     "modId": "create-integrated-farming",
@@ -1134,6 +1139,11 @@
     "name": "Just Enough Breeding (JEBr)",
     "version": "1.20.1-3.0.1"
   },
+  "JustEnoughMekanismMultiblocks-1.20.1-4.10.jar": {
+    "modId": "justenoughmekanismmultiblocks",
+    "name": "Just Enough Mekanism Multiblocks",
+    "version": "1.20.1-4.10"
+  },
   "kaleidoscopedoll-1.3.1-forge+mc1.20.1.jar": {
     "modId": "kaleidoscopedoll",
     "name": "Kaleidoscope Doll",
@@ -1263,6 +1273,31 @@
     "modId": "megacells-forge",
     "name": "MEGA Cells",
     "version": "2.4.6-1.20.1"
+  },
+  "Mekanism-1.20.1-10.4.16.80.jar": {
+    "modId": "mekanism",
+    "name": "Mekanism",
+    "version": "1.20.1-10.4.16.80"
+  },
+  "MekanismAdditions-1.20.1-10.4.16.80.jar": {
+    "modId": "mekanismadditions",
+    "name": "Mekanism Additions",
+    "version": "1.20.1-10.4.16.80"
+  },
+  "mekanismcurios-1.20.1-1.2.1.jar": {
+    "modId": "mekanismcurios",
+    "name": "Mekanism Curios",
+    "version": "1.20.1-1.2.1"
+  },
+  "MekanismGenerators-1.20.1-10.4.16.80.jar": {
+    "modId": "mekanismgenerators",
+    "name": "Mekanism Generators",
+    "version": "1.20.1-10.4.16.80"
+  },
+  "MekanismTools-1.20.1-10.4.16.80.jar": {
+    "modId": "mekanismtools",
+    "name": "Mekanism Tools",
+    "version": "1.20.1-10.4.16.80"
   },
   "melody_forge_1.0.3_MC_1.20.1-1.20.4.jar": {
     "modId": "melody_forge",

--- a/defaultconfigs/Mekanism/world.toml
+++ b/defaultconfigs/Mekanism/world.toml
@@ -1,0 +1,13 @@
+# 通用机械世界生成（首启默认；键名对应 Mekanism 10.4 WorldConfig）
+# 锡/铀与包内既有体系统一，关闭生成；盐关闭；锇/铅/萤石保留默认密度。
+
+[world_generation]
+
+	[world_generation.tin]
+		shouldGenerate = false
+
+	[world_generation.uranium]
+		shouldGenerate = false
+
+	[world_generation.salt]
+		shouldGenerate = false

--- a/kubejs/client_scripts/info_mekanism.js
+++ b/kubejs/client_scripts/info_mekanism.js
@@ -1,0 +1,21 @@
+// Mekanism 关键物品的 JEI 信息页（照包内三元组规范：key + zh + en 同步挂语言）
+let mekInfos = [
+    ["mekanism:basic_tier_installer",
+        "§b对机器右键§r即可原地升级，机器内的配方与缓存全部保留。\n§7安装器由装配线序列装配生产，材料取决于目标等级。",
+        "§bRight-click a machine§r to upgrade it in place. Recipes and buffers are kept.\n§7Produced on a Create assembly line; materials depend on target tier."],
+    ["mekanism:digital_miner",
+        "§6数字采矿机§r：配置过滤器后远程采矿（半径最大32），可设精准采集与回填。\n§7它的原型机是 Create 数字矿机（COE）——提取器正是其核心部件。",
+        "§6Digital Miner§r: remote mining with filters (radius up to 32), silk touch and replacement supported.\n§7The COE extractor is its prototype core."],
+    ["mekanism:geiger_counter",
+        "§c辐射警告§r：核废料、钚、钋和熔毁的反应堆会污染环境。\n剂量过高时屏幕出现绿滤镜并开始扣血，无视护甲。\n§7防护：防化服或 MekaSuit 辐射防护模块。可用 /mek radiation cure 治疗。",
+        "§cRadiation warning§r: nuclear waste, plutonium, polonium and reactor meltdowns contaminate the area.\nHigh dosage tints the screen green and deals armor-piercing damage.\n§7Protection: hazmat suit or MekaSuit radiation shielding. Cure: /mek radiation cure."],
+    ["appmek:chemical_cell_housing",
+        "§d化学品元件外壳§r：由锇锭压弯制成，与 AE2 元件外壳同一产线。\n制成的化学品存储元件可让 ME 网络存储气体与浆料。",
+        "§dChemical Cell Housing§r: curved from osmium ingots on the same line as AE2 cell housings.\nChemical cells let the ME network store gases and slurries."],
+]
+
+mekInfos.forEach(([key, zh_cn, en_us]) => {
+    JEIEvents.information(event => event.addItem(key, Text.translate(key)))
+    ClientEvents.lang("zh_cn", e => e.add(key, zh_cn))
+    ClientEvents.lang("en_us", e => e.add(key, en_us))
+})

--- a/kubejs/client_scripts/mekanism_tools_hide.js
+++ b/kubejs/client_scripts/mekanism_tools_hide.js
@@ -1,0 +1,28 @@
+// Mekanism 冗余物品隐藏
+// 1) Mekanism Tools 装备：本包工具体系归 Tetra，Mek 工具盔甲只会污染 JEI
+// 2) Mekanism 钢系列：钢锭唯一 owner 为 createmetallurgy（生产配方已在 steel_retire.js 掐断）
+// 材料物品（锇/青铜/精炼黑曜石/精炼萤石锭等）保留
+
+JEIEvents.hideItems(e => {
+    let hide = []
+
+    // === Mekanism Tools 装备 ===
+    const MATERIALS = ["bronze", "osmium", "steel", "refined_obsidian", "refined_glowstone", "lapis_lazuli"]
+    const GEAR = ["sword", "pickaxe", "axe", "shovel", "hoe", "paxel", "shield",
+        "helmet", "chestplate", "leggings", "boots"]
+    MATERIALS.forEach(mat => GEAR.forEach(type => hide.push(`mekanismtools:${mat}_${type}`)))
+    // 原版材质的多用镐也一并隐藏
+    ;["wood", "stone", "iron", "gold", "diamond", "netherite"].forEach(mat =>
+        hide.push(`mekanismtools:${mat}_paxel`))
+
+    // === Mekanism 钢系列 + 富集铁中间体（已无获取途径） ===
+    hide.push(
+        "mekanism:ingot_steel",
+        "mekanism:dust_steel",
+        "mekanism:nugget_steel",
+        "mekanism:block_steel",
+        "mekanism:enriched_iron"
+    )
+
+    e.hide(hide)
+})

--- a/kubejs/server_scripts/Applied Mekanistics/recipes.js
+++ b/kubejs/server_scripts/Applied Mekanistics/recipes.js
@@ -1,0 +1,59 @@
+// Applied Mekanistics 化学品元件深绑：外壳走包内 AE2 压弯体系，元件按等级吃 Mek 电路
+// 对齐 AE2 章 processor&cellcasing.js 的处理链风格（curving + cell_housing_curving_head）
+
+ServerEvents.recipes(e => {
+    // 化学品元件外壳：锇锭经 VI 压弯（复用 AE2 元件外壳压头）
+    remove_recipes_id(e, ["appmek:chemical_cell_housing"])
+    e.recipes.vintageimprovements.curving("2x appmek:chemical_cell_housing", "mekanism:ingot_osmium")
+        .head("createdelight:cell_housing_curving_head")
+        .id("createdelight:curving/chemical_cell_housing")
+
+    // 化学品存储元件：外壳 + 赛特斯石英 + 对应等级 Mek 电路
+    remove_recipes_id(e, [
+        "appmek:chemical_storage_cell_1k",
+        "appmek:chemical_storage_cell_4k",
+        "appmek:chemical_storage_cell_16k",
+        "appmek:chemical_storage_cell_64k",
+        "appmek:chemical_storage_cell_256k"
+    ])
+    const CELL_TIERS = [
+        ["1k", "mekanism:basic_control_circuit"],
+        ["4k", "mekanism:basic_control_circuit"],
+        ["16k", "mekanism:advanced_control_circuit"],
+        ["64k", "mekanism:elite_control_circuit"],
+        ["256k", "mekanism:ultimate_control_circuit"]
+    ]
+    CELL_TIERS.forEach(([tier, circuit]) => {
+        e.recipes.kubejs.shaped(`appmek:chemical_storage_cell_${tier}`, [
+            "QCQ",
+            "CHC",
+            "QCQ"
+        ], {
+            Q: "ae2:certus_quartz_dust",
+            C: circuit,
+            H: "appmek:chemical_cell_housing"
+        }).id(`createdelight:crafting/mekanism/chemical_storage_cell_${tier}`)
+    })
+
+    // 便携化学品元件：对应元件 + HDPE + 能量平板
+    remove_recipes_id(e, [
+        "appmek:portable_chemical_storage_cell_1k",
+        "appmek:portable_chemical_storage_cell_4k",
+        "appmek:portable_chemical_storage_cell_16k",
+        "appmek:portable_chemical_storage_cell_64k",
+        "appmek:portable_chemical_storage_cell_256k"
+    ])
+    const PORTABLE_TIERS = ["1k", "4k", "16k", "64k", "256k"]
+    PORTABLE_TIERS.forEach(tier => {
+        e.recipes.kubejs.shaped(`appmek:portable_chemical_storage_cell_${tier}`, [
+            " H ",
+            "SCS",
+            " E "
+        ], {
+            H: "appmek:chemical_cell_housing",
+            S: `appmek:chemical_storage_cell_${tier}`,
+            C: "mekanism:advanced_control_circuit",
+            E: "mekanism:energy_tablet"
+        }).id(`createdelight:crafting/mekanism/portable_chemical_storage_cell_${tier}`)
+    })
+})

--- a/kubejs/server_scripts/Create Ore/recipes.js
+++ b/kubejs/server_scripts/Create Ore/recipes.js
@@ -71,7 +71,10 @@ ServerEvents.recipes(e => {
         Item.of("minecraft:coal").withChance(0.6),
         Item.of("create:crushed_raw_iron").withChance(0.5),
         Item.of("create:crushed_raw_zinc").withChance(0.5),
-        Item.of("minecraft:redstone", 4).withChance(0.3)
+        Item.of("minecraft:redstone", 4).withChance(0.3),
+        Item.of("create:crushed_raw_osmium").withChance(0.5),
+        Item.of("create:crushed_raw_lead").withChance(0.4),
+        Item.of("create:crushed_raw_uranium").withChance(0.25)
     ],
         ["createdelight:overworld_metal_ore_cluster"])
         .id("createdelight:crushing/crushed_raw_ore_from_overworld_metal_ore_cluster")
@@ -82,7 +85,9 @@ ServerEvents.recipes(e => {
         Item.of("create:raw_zinc").withChance(0.6),
         Item.of("minecraft:coal").withChance(0.5),
         Item.of("minecraft:raw_copper").withChance(0.25),
-        Item.of("createdelightcore:raw_tin").withChance(0.25)
+        Item.of("createdelightcore:raw_tin").withChance(0.25),
+        Item.of("mekanism:raw_osmium").withChance(0.4),
+        Item.of("mekanism:raw_lead").withChance(0.3)
     ],
         ["createdelight:overworld_metal_ore_cluster"])
         .id("createdelight:vibrating/raw_ore_from_overworld_metal_ore_cluster")
@@ -107,7 +112,8 @@ ServerEvents.recipes(e => {
         Item.of("create:crushed_raw_gold").withChance(0.5),
         Item.of("minecraft:lapis_lazuli", 4).withChance(0.4),
         Item.of("minecraft:emerald").withChance(0.2),
-        Item.of("minecraft:diamond").withChance(0.1)
+        Item.of("minecraft:diamond").withChance(0.1),
+        Item.of("mekanism:fluorite_gem", 2).withChance(0.4)
     ],
         ["createdelight:overworld_noble_metal_ore_cluster"])
         .id("createdelight:crushing/crushed_raw_ore_from_overworld_noble_metal_ore_cluster")
@@ -118,7 +124,8 @@ ServerEvents.recipes(e => {
         Item.of("createoreexcavation:raw_emerald").withChance(0.3),
         Item.of("minecraft:lapis_lazuli", 4).withChance(0.4),
         Item.of("iceandfire:raw_silver").withChance(0.25),
-        Item.of("minecraft:raw_gold").withChance(0.25)
+        Item.of("minecraft:raw_gold").withChance(0.25),
+        Item.of("mekanism:fluorite_gem").withChance(0.35)
     ],
         ["createdelight:overworld_noble_metal_ore_cluster"])
         .id("createdelight:vibrating/raw_ore_from_overworld_noble_metal_ore_cluster")

--- a/kubejs/server_scripts/Custom/metal/lead.js
+++ b/kubejs/server_scripts/Custom/metal/lead.js
@@ -1,0 +1,23 @@
+// 铅金属链：Mekanism 提供物品，Create 侧处理链 + 冶金热熔链
+// owner：mekanism（raw_lead / ingot_lead / dust_lead 等）
+
+ServerEvents.recipes(e => {
+    // 副产物：方铅矿伴生硫
+    byProductMap.set("mekanism:dust_lead", ["mekanism:dust_sulfur", 0.5])
+
+    // Create 湿法洗练链（粉碎矿用 Create 6 自带物品）
+    metal_production_line_5(e, [
+        "mekanism:dirty_dust_lead",
+        "mekanism:dust_lead",
+        "create:crushed_raw_lead",
+        "mekanism:raw_lead",
+        "mekanism:nugget_lead"
+    ])
+
+    // 冶金热熔链：铅块/锭 ↔ 熔融铅（解锁 createmetallurgy:molten_lead）
+    metal_production_line_7(e, [
+        "mekanism:block_lead",
+        "mekanism:ingot_lead",
+        "createmetallurgy:molten_lead"
+    ], "heated", 80)
+})

--- a/kubejs/server_scripts/Custom/metal/osmium.js
+++ b/kubejs/server_scripts/Custom/metal/osmium.js
@@ -1,0 +1,23 @@
+// 锇金属链：Mekanism 提供物品，Create 侧处理链 + 冶金热熔链
+// owner：mekanism（raw_osmium / ingot_osmium / dust_osmium 等）
+
+ServerEvents.recipes(e => {
+    // 副产物：锇矿石伴生青金石
+    byProductMap.set("mekanism:dust_osmium", ["minecraft:lapis_lazuli", 0.4])
+
+    // Create 湿法洗练链：脏粉→粉→粉碎矿→粗矿→粒（粉碎矿用 Create 6 自带物品）
+    metal_production_line_5(e, [
+        "mekanism:dirty_dust_osmium",
+        "mekanism:dust_osmium",
+        "create:crushed_raw_osmium",
+        "mekanism:raw_osmium",
+        "mekanism:nugget_osmium"
+    ])
+
+    // 冶金热熔链：锇块/锭 ↔ 熔融锇（解锁 createmetallurgy:molten_osmium）
+    metal_production_line_7(e, [
+        "mekanism:block_osmium",
+        "mekanism:ingot_osmium",
+        "createmetallurgy:molten_osmium"
+    ], "heated", 80)
+})

--- a/kubejs/server_scripts/Custom/unified_loot.js
+++ b/kubejs/server_scripts/Custom/unified_loot.js
@@ -715,12 +715,17 @@ function buildTechPools(tableId, tier) {
                 ["createaddition:electrum_ingot", 8, [1, 3]],
                 ["createaddition:capacitor", 7, [1, 2]],
                 ["createdieselgenerators:engine_piston", 6, [1, 2]],
-                ["create_new_age:overcharged_iron", 3, [1, 2]]
+                ["create_new_age:overcharged_iron", 3, [1, 2]],
+                ["mekanism:ingot_osmium", 10, [1, 3]],
+                ["mekanism:basic_control_circuit", 5]
             ],
         }
 
         if (tier === 2) {
             componentPool.entries.push(["create:precision_mechanism", 6])
+            componentPool.entries.push(["mekanism:advanced_control_circuit", 4])
+            componentPool.entries.push(["mekanism:fluorite_gem", 6, [1, 4]])
+            componentPool.entries.push(["alexscaves:uranium", 3])
         }
 
         techPools.push(componentPool)

--- a/kubejs/server_scripts/Mekanism Generators/generators.js
+++ b/kubejs/server_scripts/Mekanism Generators/generators.js
@@ -1,0 +1,139 @@
+// Mekanism Generators + 高价值设备门控
+// 原则：只门控"改变游戏节奏"的设备（燃气发电机/数字采矿机/QIO/核反应堆/SPS），常规发电机保持原版
+// 所有重建配方吃 Create 高级零件，与伟大工程师线的进度咬合
+
+ServerEvents.recipes(e => {
+    // === 燃气发电机：乙烯链的发电核心 ===
+    remove_recipes_id(e, ["mekanismgenerators:generator/gas_burning"])
+    e.recipes.kubejs.shaped("mekanismgenerators:gas_burning_generator", [
+        "SSS",
+        "PCP",
+        "IBI"
+    ], {
+        S: "createmetallurgy:steel_ingot",
+        P: "#forge:plates/copper",
+        C: "mekanism:advanced_control_circuit",
+        I: "createaddition:capacitor",
+        B: "create:brass_casing"
+    }).id("createdelight:crafting/mekanism/gas_burning_generator")
+
+    // === 数字采矿机：COE 提取器是它的原型机（叙事门控） ===
+    remove_recipes_id(e, ["mekanism:digital_miner"])
+    e.recipes.create.mechanical_crafting("mekanism:digital_miner", [
+        "CHHHC",
+        "HXXXH",
+        "HXEXH",
+        "HXXXH",
+        "CHHHC"
+    ], {
+        C: "mekanism:elite_control_circuit",
+        H: "mekanism:hdpe_sheet",
+        X: "mekanism:steel_casing",
+        E: "createoreexcavation:extractor"
+    }).id("createdelight:mechanical_crafting/mekanism/digital_miner")
+
+    // === QIO 数字存储：AE2 逻辑处理器跨体系绑定 ===
+    remove_recipes_id(e, [
+        "mekanism:qio_dashboard",
+        "mekanism:qio_drive_array",
+        "mekanism:qio_importer",
+        "mekanism:qio_exporter",
+        "mekanism:qio_redstone_adapter",
+        "mekanism:portable_qio_dashboard"
+    ])
+    e.recipes.kubejs.shaped("mekanism:qio_dashboard", [
+        "CHC",
+        "HPH",
+        "CHC"
+    ], {
+        C: "mekanism:basic_control_circuit",
+        H: "mekanism:hdpe_sheet",
+        P: "create:precision_mechanism"
+    }).id("createdelight:crafting/mekanism/qio_dashboard")
+
+    e.recipes.create.mechanical_crafting("mekanism:qio_drive_array", [
+        "CHC",
+        "LPL",
+        "CHC"
+    ], {
+        C: "mekanism:advanced_control_circuit",
+        H: "mekanism:hdpe_sheet",
+        L: "ae2:logic_processor",
+        P: "create:precision_mechanism"
+    }).id("createdelight:mechanical_crafting/mekanism/qio_drive_array")
+
+    // 【重建补全】以下 QIO 外围与核工业段原文件未留存，按上文模板模式补写，落地后按游戏内核对
+    e.recipes.kubejs.shaped("mekanism:qio_importer", [
+        "CHC",
+        "HPH",
+        "CHC"
+    ], {
+        C: "mekanism:basic_control_circuit",
+        H: "mekanism:hdpe_sheet",
+        P: "ae2:logic_processor"
+    }).id("createdelight:crafting/mekanism/qio_importer")
+
+    e.recipes.kubejs.shaped("mekanism:qio_exporter", [
+        "CHC",
+        "HPH",
+        "CHC"
+    ], {
+        C: "mekanism:basic_control_circuit",
+        H: "mekanism:hdpe_sheet",
+        P: "ae2:logic_processor"
+    }).id("createdelight:crafting/mekanism/qio_exporter")
+
+    e.recipes.kubejs.shaped("mekanism:qio_redstone_adapter", [
+        "CHC",
+        "HPH",
+        "CHC"
+    ], {
+        C: "mekanism:basic_control_circuit",
+        H: "mekanism:hdpe_sheet",
+        P: "minecraft:redstone"
+    }).id("createdelight:crafting/mekanism/qio_redstone_adapter")
+
+    // === 聚变反应堆：终局门槛（超导连接器 + 原子合金 + northstar 高级电路） ===
+    // 【重建补全】
+    remove_recipes_id(e, ["mekanismgenerators:fusion_reactor_controller"])
+    e.recipes.create.mechanical_crafting("mekanismgenerators:fusion_reactor_controller", [
+        "IAAAI",
+        "AUUUA",
+        "AUPUA",
+        "AUUUA",
+        "IAAAI"
+    ], {
+        I: "northstar:advanced_circuit",
+        A: "mekanism:alloy_atomic",
+        U: "createaddition:superconducting_connector",
+        P: "create:precision_mechanism"
+    }).id("createdelight:mechanical_crafting/mekanism/fusion_reactor_controller")
+
+    // === 裂变堆端口与 SPS 端口：核体系分阶段门槛 ===
+    // 【重建补全】
+    remove_recipes_id(e, ["mekanismgenerators:fission_reactor_port", "mekanism:sps_port"])
+    e.recipes.create.mechanical_crafting("mekanismgenerators:fission_reactor_port", [
+        "CRRRC",
+        "RSSSR",
+        "RSSSR",
+        "RSSSR",
+        "CRRRC"
+    ], {
+        C: "mekanism:elite_control_circuit",
+        R: "createmetallurgy:steel_ingot",
+        S: "mekanism:ingot_lead"
+    }).id("createdelight:mechanical_crafting/mekanism/fission_reactor_port")
+
+    e.recipes.create.mechanical_crafting("mekanism:sps_port", [
+        "CRRRC",
+        "ROOOR",
+        "ROUOR",
+        "ROOOR",
+        "CRRRC"
+    ], {
+        C: "mekanism:ultimate_control_circuit",
+        R: "createmetallurgy:steel_ingot",
+        O: "mekanism:ingot_refined_obsidian",
+        U: "createaddition:superconducting_connector"
+    }).id("createdelight:mechanical_crafting/mekanism/sps_port")
+})

--- a/kubejs/server_scripts/Mekanism/chemical_chain.js
+++ b/kubejs/server_scripts/Mekanism/chemical_chain.js
@@ -1,0 +1,19 @@
+// Mekanism 化学/农业绑定
+// Mek 原生已有 100+ 原版物品 -> 生物燃料的粉碎配方（crushing/biofuel/*）
+// 这里补充包内自创作物与 Farmer's Delight 食材，让美食包的农业盈余直通乙烯->塑料链
+
+ServerEvents.recipes(e => {
+    const CROPS = [
+        "createdelight:adzuki_beans_seed",
+        "createdelight:artemisia_argyi_seed",
+        "farmersdelight:rice",
+        "farmersdelight:tomato"
+    ]
+    CROPS.forEach(crop => {
+        e.custom({
+            type: "mekanism:crushing",
+            input: { ingredient: { item: crop } },
+            output: { item: "mekanism:bio_fuel", count: 2 }
+        }).id(`createdelight:crushing/bio_fuel_from_${crop.split(":")[1]}`)
+    })
+})

--- a/kubejs/server_scripts/Mekanism/control_circuits.js
+++ b/kubejs/server_scripts/Mekanism/control_circuits.js
@@ -1,0 +1,61 @@
+// Mekanism 四级控制电路重建：全部绑定 Create 产线
+// 基础=黄铜+电子管 / 进阶=精密机构+注入合金+电容 / 精英=4x4机械合成 / 终极=5x5机械合成
+// 电路是全部 Mek 机器/工厂/QIO 的核心耗材，等级梯度即进度门控
+
+ServerEvents.recipes(e => {
+    remove_recipes_id(e, [
+        "mekanism:control_circuit/basic",
+        "mekanism:control_circuit/advanced",
+        "mekanism:control_circuit/elite",
+        "mekanism:control_circuit/ultimate"
+    ])
+
+    // 基础控制电路：黄铜 + 电子管 + 红石
+    e.recipes.kubejs.shaped("2x mekanism:basic_control_circuit", [
+        "RBR",
+        "BAB",
+        "RBR"
+    ], {
+        R: "minecraft:redstone",
+        B: "create:brass_ingot",
+        A: "create:electron_tube"
+    }).id("createdelight:crafting/mekanism/basic_control_circuit")
+
+    // 进阶控制电路：精密机构 + 注入合金 + CCA 电容
+    e.recipes.kubejs.shaped("2x mekanism:advanced_control_circuit", [
+        "IPI",
+        "PAP",
+        "IPI"
+    ], {
+        I: "mekanism:alloy_infused",
+        P: "create:precision_mechanism",
+        A: "createaddition:capacitor"
+    }).id("createdelight:crafting/mekanism/advanced_control_circuit")
+
+    // 精英控制电路：4x4 机械合成（强化合金 + northstar 电路 + 电子管）
+    e.recipes.create.mechanical_crafting("2x mekanism:elite_control_circuit", [
+        "IRRI",
+        "REER",
+        "REER",
+        "IRRI"
+    ], {
+        I: "northstar:circuit",
+        R: "mekanism:alloy_reinforced",
+        E: "create:electron_tube"
+    }).id("createdelight:mechanical_crafting/mekanism/elite_control_circuit")
+
+    // 终极控制电路：5x5 机械合成（原子合金 + northstar 高级电路 + 钨锭 + 精密机构）
+    e.recipes.create.mechanical_crafting("2x mekanism:ultimate_control_circuit", [
+        "IAAAI",
+        "ATPTA",
+        "APCPA",
+        "ATPTA",
+        "IAAAI"
+    ], {
+        I: "northstar:advanced_circuit",
+        A: "mekanism:alloy_atomic",
+        T: "createmetallurgy:tungsten_ingot",
+        P: "create:precision_mechanism",
+        C: "createaddition:capacitor"
+    }).id("createdelight:mechanical_crafting/mekanism/ultimate_control_circuit")
+})

--- a/kubejs/server_scripts/Mekanism/factories.js
+++ b/kubejs/server_scripts/Mekanism/factories.js
@@ -1,0 +1,82 @@
+// Mekanism 工厂方块重建：全部走 Create 序列装配（机械手流水线）
+// 叙事：单机上装配线，机械手逐步加装机器/机构/塑料，最终组装成工厂
+// 9 种工厂类型 x 4 等级，低阶工厂是高阶的装配基底
+
+ServerEvents.recipes(e => {
+    // 工厂类型 -> 对应单机
+    const FACTORY_MACHINES = {
+        smelting: "mekanism:energized_smelter",
+        enriching: "mekanism:enrichment_chamber",
+        crushing: "mekanism:crusher",
+        sawing: "mekanism:precision_sawmill",
+        compressing: "mekanism:osmium_compressor",
+        combining: "mekanism:combiner",
+        infusing: "mekanism:metallurgic_infuser",
+        purifying: "mekanism:purification_chamber",
+        injecting: "mekanism:chemical_injection_chamber"
+    }
+    const TIERS = ["basic", "advanced", "elite", "ultimate"]
+
+    // 移除全部原版工厂配方（mek_data 类型按精确 id 删除；Rhino 无 flatMap，用双循环）
+    let factoryIds = []
+    TIERS.forEach(t => Object.keys(FACTORY_MACHINES).forEach(type =>
+        factoryIds.push(`mekanism:factory/${t}/${type}`)))
+    remove_recipes_id(e, factoryIds)
+
+    let iner = "createdelight:incomplete_factory"
+
+    Object.keys(FACTORY_MACHINES).forEach(type => {
+        let machine = FACTORY_MACHINES[type]
+
+        // 基础工厂：单机为基底，加装 2 单机 + 2 精密机构 + 2 HDPE 板
+        e.recipes.create.sequenced_assembly(`mekanism:basic_${type}_factory`, machine, [
+            e.recipes.create.deploying(iner, [iner, machine]),
+            e.recipes.create.deploying(iner, [iner, machine]),
+            e.recipes.create.deploying(iner, [iner, "create:precision_mechanism"]),
+            e.recipes.create.deploying(iner, [iner, "create:precision_mechanism"]),
+            e.recipes.create.deploying(iner, [iner, "mekanism:hdpe_sheet"]),
+            e.recipes.create.deploying(iner, [iner, "mekanism:hdpe_sheet"])
+        ])
+            .transitionalItem(iner)
+            .loops(1)
+            .id(`createdelight:sequenced_assembly/basic_${type}_factory`)
+
+        // 进阶工厂：基础工厂为基底，加装 2 进阶电路 + 黄铜机壳 + HDPE 板
+        e.recipes.create.sequenced_assembly(`mekanism:advanced_${type}_factory`, `mekanism:basic_${type}_factory`, [
+            e.recipes.create.deploying(iner, [iner, "mekanism:advanced_control_circuit"]),
+            e.recipes.create.deploying(iner, [iner, "mekanism:advanced_control_circuit"]),
+            e.recipes.create.deploying(iner, [iner, "create:brass_casing"]),
+            e.recipes.create.deploying(iner, [iner, "mekanism:hdpe_sheet"])
+        ])
+            .transitionalItem(iner)
+            .loops(1)
+            .id(`createdelight:sequenced_assembly/advanced_${type}_factory`)
+
+        // 精英工厂：进阶工厂为基底，加装 2 精英电路 + 2 冶金钢 + HDPE 板
+        // 【重建补全】原文件此段未留存，按基础/进阶模板模式补写
+        e.recipes.create.sequenced_assembly(`mekanism:elite_${type}_factory`, `mekanism:advanced_${type}_factory`, [
+            e.recipes.create.deploying(iner, [iner, "mekanism:elite_control_circuit"]),
+            e.recipes.create.deploying(iner, [iner, "mekanism:elite_control_circuit"]),
+            e.recipes.create.deploying(iner, [iner, "createmetallurgy:steel_ingot"]),
+            e.recipes.create.deploying(iner, [iner, "createmetallurgy:steel_ingot"]),
+            e.recipes.create.deploying(iner, [iner, "mekanism:hdpe_sheet"])
+        ])
+            .transitionalItem(iner)
+            .loops(1)
+            .id(`createdelight:sequenced_assembly/elite_${type}_factory`)
+
+        // 终极工厂：精英工厂为基底，加装 2 终极电路 + 2 钨锭 + 2 HDPE 板
+        // 【重建补全】同上
+        e.recipes.create.sequenced_assembly(`mekanism:ultimate_${type}_factory`, `mekanism:elite_${type}_factory`, [
+            e.recipes.create.deploying(iner, [iner, "mekanism:ultimate_control_circuit"]),
+            e.recipes.create.deploying(iner, [iner, "mekanism:ultimate_control_circuit"]),
+            e.recipes.create.deploying(iner, [iner, "createmetallurgy:tungsten_ingot"]),
+            e.recipes.create.deploying(iner, [iner, "createmetallurgy:tungsten_ingot"]),
+            e.recipes.create.deploying(iner, [iner, "mekanism:hdpe_sheet"]),
+            e.recipes.create.deploying(iner, [iner, "mekanism:hdpe_sheet"])
+        ])
+            .transitionalItem(iner)
+            .loops(1)
+            .id(`createdelight:sequenced_assembly/ultimate_${type}_factory`)
+    })
+})

--- a/kubejs/server_scripts/Mekanism/gear_gating.js
+++ b/kubejs/server_scripts/Mekanism/gear_gating.js
@@ -1,0 +1,41 @@
+// Mekanism 装备门槛：MekaSuit/MekaTool 纳入包内终局门槛 + Mekanism Tools 装备断获取
+// 原则：不重排配方结构，用范围化 replaceInput 注入包内同语义材料
+// 数值平衡（OED 审查）另行处理
+
+ServerEvents.recipes(e => {
+    // === MekaSuit 模块门槛：原版特殊件 → 包内同语义材料 ===
+    const module_gates = [
+        // 飞行 = 星际科技特权
+        ["mekanism:module_jetpack_unit", "mekanism:jetpack", "northstar:lunar_sapphire_shard"],
+        // 制氧 = 北极星线终点
+        ["mekanism:module_electrolytic_breathing_unit", "mekanism:electrolytic_core", "createdelight:sturdy_oxygen_tank"],
+        // 反重力 = 深渊战利品
+        ["mekanism:module_gravitational_modulating_unit", "#forge:nether_stars", "alexscaves:occult_gem"],
+        // 速度 = 星际科技
+        ["mekanism:module_locomotive_boosting_unit", "minecraft:diamond_leggings", "northstar:advanced_circuit"],
+        // 跳跃 = Create 高阶弹簧
+        ["mekanism:module_hydraulic_propulsion_unit", "mekanism:free_runners", "#forge:spring/between_500_2_1000"],
+        // 夜视 = 望远镜
+        ["mekanism:module_vision_enhancement_unit", "minecraft:emerald", "minecraft:spyglass"],
+        // 磁吸 = 磁洞纪念品
+        ["mekanism:module_magnetic_attraction_unit", "minecraft:iron_bars", "alexscaves:magnetron"],
+        // 伤害增幅 = 屠龙
+        ["mekanism:module_attack_amplification_unit", "minecraft:iron_sword", "iceandfire:dragonbone"]
+        // 辐射防护模块：原版即铅块门槛（铅的刚需出口），不改
+    ]
+    module_gates.forEach(([id, from, to]) => e.replaceInput({ output: id }, from, to))
+
+    // === MekaTool：与「命定之门」入场券同源（over_core），外壳换冶金钢 ===
+    e.replaceInput({ output: "mekanism:meka_tool" }, "mekanism:atomic_disassembler", "#more_mod_tetra:over_core")
+    e.replaceInput({ output: "mekanism:meka_tool" }, "mekanism:hdpe_sheet", "createmetallurgy:steel_ingot")
+
+    // === MekaSuit 本体四件：外壳冶金钢、精炼萤石换深渊宝珠 ===
+    const suits = ["meka_suit_helmet", "meka_suit_bodyarmor", "meka_suit_pants", "meka_suit_boots"]
+    suits.forEach(piece => {
+        e.replaceInput({ output: "mekanism:" + piece }, "mekanism:hdpe_sheet", "createmetallurgy:steel_ingot")
+        e.replaceInput({ output: "mekanism:" + piece }, "mekanism:ingot_refined_glowstone", "alexscaves:occult_gem")
+    })
+
+    // === Mekanism Tools 装备：断获取（客户端已 JEI 隐藏，此处断全部配方） ===
+    remove_recipes_mod(e, ["mekanismtools"])
+})

--- a/kubejs/server_scripts/Mekanism/machine_tiers.js
+++ b/kubejs/server_scripts/Mekanism/machine_tiers.js
@@ -1,0 +1,140 @@
+// Mekanism 基础机器 + 等级安装器重建
+// 注意：Mek 机器的等级存在方块 NBT 中，高阶机器不是独立物品——升级唯一途径是等级安装器
+// 因此安装器配方是整个阶梯的核心，做成 Create 序列装配（精密机构同款产线）
+
+ServerEvents.recipes(e => {
+    // 9 台基础机器：安山合金 + 铜板 + 基础电路 + 安山机壳
+    // 机器配方是 mekanism:mek_data 类型，必须按精确 id 删除
+    remove_recipes_id(e, [
+        "mekanism:enrichment_chamber",
+        "mekanism:crusher",
+        "mekanism:energized_smelter",
+        "mekanism:precision_sawmill",
+        "mekanism:osmium_compressor",
+        "mekanism:combiner",
+        "mekanism:metallurgic_infuser",
+        "mekanism:purification_chamber",
+        "mekanism:chemical_injection_chamber"
+    ])
+
+    /**
+     * 基础机器统一模板
+     * @param {string} machine 机器物品 id
+     * @param {string} core 该机器的风味核心材料
+     */
+    function basic_machine(machine, core) {
+        e.recipes.kubejs.shaped(machine, [
+            "AUA",
+            "PCP",
+            "AKA"
+        ], {
+            A: "create:andesite_alloy",
+            U: core,
+            P: "#forge:plates/copper",
+            C: "mekanism:basic_control_circuit",
+            K: "create:andesite_casing"
+        }).id(`createdelight:crafting/mekanism/${machine.split(":")[1]}`)
+    }
+    basic_machine("mekanism:enrichment_chamber", "minecraft:iron_ingot")
+    basic_machine("mekanism:crusher", "minecraft:copper_ingot")
+    basic_machine("mekanism:energized_smelter", "minecraft:iron_ingot")
+    basic_machine("mekanism:precision_sawmill", "#minecraft:planks")
+    basic_machine("mekanism:osmium_compressor", "mekanism:ingot_osmium")
+    basic_machine("mekanism:combiner", "minecraft:cobblestone")
+    basic_machine("mekanism:metallurgic_infuser", "minecraft:redstone")
+    basic_machine("mekanism:purification_chamber", "mekanism:ingot_lead")
+    basic_machine("mekanism:chemical_injection_chamber", "mekanism:ingot_osmium")
+
+    // 等级安装器：序列装配（部署电路 -> 压制铁板 -> 部署阶位材料），loops(1)
+    remove_recipes_id(e, [
+        "mekanism:tier_installer/basic",
+        "mekanism:tier_installer/advanced",
+        "mekanism:tier_installer/elite",
+        "mekanism:tier_installer/ultimate"
+    ])
+
+    /**
+     * 等级安装器统一模板
+     * @param {string} installer 安装器物品 id
+     * @param {string} circuit 对应等级控制电路
+     * @param {string} bond 阶位绑定材料
+     */
+    function tier_installer(installer, circuit, bond) {
+        let iner = "createdelight:incomplete_tier_installer"
+        e.recipes.create.sequenced_assembly(installer, "create:iron_sheet", [
+            e.recipes.create.deploying(iner, [iner, circuit]),
+            e.recipes.create.pressing(iner, iner),
+            e.recipes.create.deploying(iner, [iner, bond])
+        ])
+            .transitionalItem(iner)
+            .loops(1)
+            .id(`createdelight:sequenced_assembly/${installer.split(":")[1]}`)
+    }
+    tier_installer("mekanism:basic_tier_installer", "mekanism:basic_control_circuit", "create:andesite_alloy")
+    tier_installer("mekanism:advanced_tier_installer", "mekanism:advanced_control_circuit", "create:brass_ingot")
+    tier_installer("mekanism:elite_tier_installer", "mekanism:elite_control_circuit", "createmetallurgy:steel_ingot")
+    tier_installer("mekanism:ultimate_tier_installer", "mekanism:ultimate_control_circuit", "createmetallurgy:tungsten_ingot")
+
+    // === 化学线中阶机器（湿法冶金五倍链 + 气体工业）：进阶电路 + 黄铜机壳 ===
+    remove_recipes_id(e, [
+        "mekanism:electrolytic_separator",
+        "mekanism:chemical_infuser",
+        "mekanism:chemical_oxidizer",
+        "mekanism:chemical_dissolution_chamber",
+        "mekanism:chemical_washer",
+        "mekanism:chemical_crystallizer",
+        "mekanism:rotary_condensentrator",
+        "mekanism:pressurized_reaction_chamber"
+    ])
+
+    /**
+     * 化学机器统一模板
+     * @param {string} machine 机器物品 id
+     * @param {string} core 风味核心材料 x2
+     */
+    function chemical_machine(machine, core) {
+        e.recipes.kubejs.shaped(machine, [
+            "PUP",
+            "BCB",
+            "PUP"
+        ], {
+            P: "create:brass_ingot",
+            U: core,
+            B: "create:brass_casing",
+            C: "mekanism:advanced_control_circuit"
+        }).id(`createdelight:crafting/mekanism/${machine.split(":")[1]}`)
+    }
+    chemical_machine("mekanism:electrolytic_separator", "createaddition:copper_spool")
+    chemical_machine("mekanism:chemical_infuser", "mekanism:basic_pressurized_tube")
+    chemical_machine("mekanism:chemical_oxidizer", "mekanism:dust_sulfur")
+    chemical_machine("mekanism:chemical_dissolution_chamber", "minecraft:glass")
+    chemical_machine("mekanism:chemical_washer", "create:fluid_tank")
+    chemical_machine("mekanism:chemical_crystallizer", "create:polished_rose_quartz")
+    chemical_machine("mekanism:rotary_condensentrator", "create:mechanical_pump")
+    chemical_machine("mekanism:pressurized_reaction_chamber", "create:propeller")
+
+    // === 后阶核工业机器：精英电路 + 冶金钢 ===
+    remove_recipes_id(e, [
+        "mekanism:isotopic_centrifuge",
+        "mekanism:solar_neutron_activator"
+    ])
+
+    /**
+     * 后阶机器统一模板
+     * @param {string} machine 机器物品 id
+     * @param {string} core 风味核心材料 x2
+     */
+    function late_machine(machine, core) {
+        e.recipes.kubejs.shaped(machine, [
+            "SXS",
+            "XCX",
+            "SXS"
+        ], {
+            S: "createmetallurgy:steel_ingot",
+            X: core,
+            C: "mekanism:elite_control_circuit"
+        }).id(`createdelight:crafting/mekanism/${machine.split(":")[1]}`)
+    }
+    late_machine("mekanism:isotopic_centrifuge", "mekanism:alloy_reinforced")
+    late_machine("mekanism:solar_neutron_activator", "createaddition:capacitor")
+})

--- a/kubejs/server_scripts/Mekanism/ore_processing.js
+++ b/kubejs/server_scripts/Mekanism/ore_processing.js
@@ -1,0 +1,8 @@
+// Mekanism 矿石处理：氟石 Create 链
+// 锇/铅/铀/氟石并入数字矿机矿簇产物的部分已直接写入 Create Ore/recipes.js（保留原配方 id，避免重复注册）
+// 锇/铅的完整湿法洗练链见 Custom/metal/osmium.js、lead.js
+
+ServerEvents.recipes(e => {
+    // 氟石：Create 破碎链（Mek 富集仓原生 5-6 宝石，Create 侧 5 + 概率副产）
+    crushing_ore(e, "mekanism:fluorite_ore", "mekanism:fluorite_gem", 5, "minecraft:cobblestone")
+})

--- a/kubejs/server_scripts/Mekanism/steel_retire.js
+++ b/kubejs/server_scripts/Mekanism/steel_retire.js
@@ -1,0 +1,16 @@
+// Mekanism 钢退役：钢锭唯一 owner 为 createmetallurgy
+// 冶金钢已挂 forge:ingots/steel 标签，Mek 的钢机壳等消费方直接吃冶金钢
+// 这里掐断 Mek 钢的全部生产配方（灌注链：铁+碳->富集铁->钢粉->钢锭）
+
+ServerEvents.recipes(e => {
+    remove_recipes_id(e, [
+        // 富集铁 -> 钢粉（钢的诞生点）
+        "mekanism:processing/steel/enriched_iron_to_dust",
+        // 钢锭 <-> 粉/粒/块互转
+        "mekanism:processing/steel/ingot/from_block",
+        "mekanism:processing/steel/ingot/from_dust_blasting",
+        "mekanism:processing/steel/ingot/from_dust_smelting",
+        "mekanism:processing/steel/ingot/from_nuggets",
+        "mekanism:processing/steel/ingot_to_dust"
+    ])
+})

--- a/kubejs/server_scripts/Mekanism/tags.js
+++ b/kubejs/server_scripts/Mekanism/tags.js
@@ -1,0 +1,23 @@
+// Mekanism 接入：标签统一
+// 原则：包内已有的金属保持 owner 地位，通过 forge 标签喂给 Mekanism 配方
+
+ServerEvents.tags("minecraft:item", e => {
+    // 锡：包内 createdelightcore 锡是唯一来源，挂入常规标签驱动 Mek 青铜等配方
+    e.add("forge:ingots/tin", ["createdelightcore:tin_ingot"])
+    e.add("forge:nuggets/tin", ["createdelightcore:tin_nugget"])
+    e.add("forge:storage_blocks/tin", ["createdelightcore:tin_block"])
+    e.add("forge:raw_materials/tin", ["createdelightcore:raw_tin"])
+    e.add("forge:raw_material_blocks/tin", ["createdelightcore:raw_tin_block"])
+    e.add("forge:ores/tin", [
+        "createdelightcore:tin_ore",
+        "createdelightcore:deepslate_tin_ore"
+    ])
+
+    // 青铜：Mek 与包内青铜互通（owner 仍为 createdelightcore）
+    e.add("forge:ingots/bronze", ["createdelightcore:bronze_ingot"])
+
+    // 钢：Mek 钢与冶金钢互通（owner 仍为 createmetallurgy）
+    e.add("forge:ingots/steel", ["createmetallurgy:steel_ingot"])
+
+    // 铀：alexscaves 已挂 forge:ingots/uranium，Mek 铀锭由模组自挂，形成三向互通
+})

--- a/kubejs/server_scripts/Mekanism/unification.js
+++ b/kubejs/server_scripts/Mekanism/unification.js
@@ -1,0 +1,23 @@
+// Mekanism 接入：跨模组材料统一（1:1 互转）
+// 原则：标签保证配方互通，互转配方保证玩家存量物品不废
+
+ServerEvents.recipes(e => {
+    // 青铜：Mek 青铜锭 ↔ 包内青铜锭（owner: createdelightcore）
+    e.recipes.kubejs.shapeless("createdelightcore:bronze_ingot", "mekanism:ingot_bronze")
+        .id("createdelight:crafting/mekanism/mek_bronze_2_bronze")
+    e.recipes.kubejs.shapeless("mekanism:ingot_bronze", "createdelightcore:bronze_ingot")
+        .id("createdelight:crafting/mekanism/bronze_2_mek_bronze")
+
+    // 钢：不设互转——Mek 钢已退役（steel_retire.js），钢锭唯一 owner 为 createmetallurgy
+    // Mek 侧钢机壳等消费方走 forge:ingots/steel 标签直接吃冶金钢
+
+    // 锡：Mek 锡锭 ↔ 包内锡（owner: createdelightcore）
+    // Mek 锡无生成来源，仅作为其机器加工包内锡矿时的产物形态回收
+    // 注：本版未注册 createdelight:tin_dust，锡粉互转暂缺
+    e.recipes.kubejs.shapeless("createdelightcore:tin_ingot", "mekanism:ingot_tin")
+        .id("createdelight:crafting/mekanism/mek_tin_2_tin")
+
+    // 铀：alexscaves 铀 → Mek 铀（owner: alexscaves，Mek 侧供裂变燃料链取料）
+    e.recipes.kubejs.shapeless("mekanism:ingot_uranium", "alexscaves:uranium")
+        .id("createdelight:crafting/mekanism/uranium_2_mek_uranium")
+})

--- a/kubejs/server_scripts/Mekanism/upgrades.js
+++ b/kubejs/server_scripts/Mekanism/upgrades.js
@@ -1,0 +1,57 @@
+// Mekanism 机器升级组件重建：超频件全部 Create 化
+// 速度=齿轮驱动 / 能量=CCA 电路 / 气体=铅制储气 / 过滤=造纸链
+// 消音/锚定/造石升级保持原版（纯 QoL，无平衡影响）
+// 注意：物品 id 是 upgrade_ 前缀（mekanism:upgrade_speed 等）
+
+ServerEvents.recipes(e => {
+    remove_recipes_id(e, [
+        "mekanism:upgrade/speed",
+        "mekanism:upgrade/energy",
+        "mekanism:upgrade/gas",
+        "mekanism:upgrade/filter"
+    ])
+
+    // 速度升级：锇锭 + Create 齿轮 + 红石（动力学超频）
+    e.recipes.kubejs.shaped("mekanism:upgrade_speed", [
+        " R ",
+        "OCO",
+        " R "
+    ], {
+        R: "minecraft:redstone",
+        O: "mekanism:ingot_osmium",
+        C: "create:cogwheel"
+    }).id("createdelight:crafting/mekanism/upgrade_speed")
+
+    // 能量升级：CCA 电容 + 电子管 + 铜线卷（与包内 FE 体系同源）
+    e.recipes.kubejs.shaped("mekanism:upgrade_energy", [
+        " E ",
+        "ACA",
+        " E "
+    ], {
+        E: "create:electron_tube",
+        A: "createaddition:capacitor",
+        C: "createaddition:copper_spool"
+    }).id("createdelight:crafting/mekanism/upgrade_energy")
+
+    // 气体升级：铅锭 + 加压管道 + HDPE 板
+    e.recipes.kubejs.shaped("mekanism:upgrade_gas", [
+        " T ",
+        "LPL",
+        " T "
+    ], {
+        T: "mekanism:basic_pressurized_tube",
+        L: "mekanism:ingot_lead",
+        P: "mekanism:hdpe_sheet"
+    }).id("createdelight:crafting/mekanism/upgrade_gas")
+
+    // 过滤升级：纸 + 筛网 + 锇锭（接包内 Custom/paper.js 造纸链）
+    e.recipes.kubejs.shaped("mekanism:upgrade_filter", [
+        "PPP",
+        "PIQ",
+        "PPP"
+    ], {
+        P: "minecraft:paper",
+        I: "create:filter",
+        Q: "mekanism:ingot_osmium"
+    }).id("createdelight:crafting/mekanism/upgrade_filter")
+})

--- a/kubejs/startup_scripts/custom/value_data.js
+++ b/kubejs/startup_scripts/custom/value_data.js
@@ -306,6 +306,10 @@ let MaterialWhitelistValueDict = {
     "collectorsreap:lime_popsicle": 6,
     "collectorsreap:urchin": 4,
     "brewinandchewin:unripe_scarlet_cheese_wheel": 32,
+    // Mekanism 采矿价值源（价值经配方链自动传导至粉/锭/电路/塑料）
+    "mekanism:raw_osmium": 3,
+    "mekanism:raw_lead": 3,
+    "mekanism:fluorite_gem": 2,
 }
 
 let FoodIngredientValueDict = {

--- a/kubejs/startup_scripts/registry_item_mekanism.js
+++ b/kubejs/startup_scripts/registry_item_mekanism.js
@@ -1,0 +1,10 @@
+// Mekanism 融合注册物：序列组装过渡物（create:sequenced_assembly 类型，JEI 不显示）
+// incomplete_tier_installer 供 machine_tiers.js 的四级安装器链使用
+// incomplete_factory 供 factories.js 的 36 条工厂链使用
+
+StartupEvents.registry("item", e => {
+    e.create("createdelight:incomplete_tier_installer", "create:sequenced_assembly")
+        .translationKey("item.createdelight.incomplete_tier_installer")
+    e.create("createdelight:incomplete_factory", "create:sequenced_assembly")
+        .translationKey("item.createdelight.incomplete_factory")
+})

--- a/mods/applied-mekanistics.pw.toml
+++ b/mods/applied-mekanistics.pw.toml
@@ -1,0 +1,13 @@
+name = "Applied Mekanistics"
+filename = "Applied-Mekanistics-1.4.3.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "8b37889d94b6c1ae5cd31ddde379a1c323c3c501"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 7244744
+project-id = 574300

--- a/mods/just-enough-mekanism-multiblocks.pw.toml
+++ b/mods/just-enough-mekanism-multiblocks.pw.toml
@@ -1,0 +1,13 @@
+name = "Just Enough Mekanism Multiblocks"
+filename = "JustEnoughMekanismMultiblocks-1.20.1-4.10.jar"
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "58d6a6c0e0028d286910331b2765a49da5f694cd"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6170219
+project-id = 898746

--- a/mods/mekanism-additions.pw.toml
+++ b/mods/mekanism-additions.pw.toml
@@ -1,0 +1,13 @@
+name = "Mekanism Additions"
+filename = "MekanismAdditions-1.20.1-10.4.16.80.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "64e930adf31b23db53412a62b0e8f950e64f7f2d"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6552913
+project-id = 345425

--- a/mods/mekanism-curios.pw.toml
+++ b/mods/mekanism-curios.pw.toml
@@ -1,0 +1,13 @@
+name = "Mekanism Curios"
+filename = "mekanismcurios-1.20.1-1.2.1.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "0f14928d846a862361ea85d8656f5aa0bfc61504"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6602972
+project-id = 1251061

--- a/mods/mekanism-generators.pw.toml
+++ b/mods/mekanism-generators.pw.toml
@@ -1,0 +1,13 @@
+name = "Mekanism Generators"
+filename = "MekanismGenerators-1.20.1-10.4.16.80.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "53fa707fd204ca1dd099a08995c2197145ff9a36"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6552914
+project-id = 268566

--- a/mods/mekanism-tools.pw.toml
+++ b/mods/mekanism-tools.pw.toml
@@ -1,0 +1,13 @@
+name = "Mekanism Tools"
+filename = "MekanismTools-1.20.1-10.4.16.80.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "0d22b1cc01a33702f1b9e17b26cc55e233a4e7ff"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6552915
+project-id = 268567

--- a/mods/mekanism.pw.toml
+++ b/mods/mekanism.pw.toml
@@ -1,0 +1,13 @@
+name = "Mekanism"
+filename = "Mekanism-1.20.1-10.4.16.80.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "b7f12ae710888b01746507a0aa8cb375f5897158"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6552911
+project-id = 268560


### PR DESCRIPTION
## 变更内容
- 新增 Mekanism 四件套（10.4.16.80）与 Applied-Mekanistics/JEMM/mekanismcurios 三个附属的 packwiz 元数据（JEMM side=client）
- 新增 defaultconfigs/Mekanism/world.toml：锡/铀/盐关闭生成，锇/铅/萤石默认密度
- 新增 server_scripts/Mekanism/ 十件套：unification（owner 制 1:1 互转）、tags、steel_retire（Mek 钢全链退役，owner=冶金钢）、control_circuits（四级电路绑定 Create/Northstar，精英/终极走机械合成）、machine_tiers（9+8+2 台机器三档模板 + 四级安装器序列装配）、factories（9 类型×4 等级渐进装配链）、upgrades（速度/能量/气体/过滤 Create 化）、ore_processing（氟石破碎链）、chemical_chain（作物→生物燃料）、gear_gating（MekaSuit 模块/MekaTool/本体终局门槛 + Mekanism Tools 断获取）
- 新增 Mekanism Generators/generators.js（燃气发电机/数字矿机=COE 提取器 5×5/QIO←AE2/聚变终局/裂变+SPS 分阶段）
- 新增 Applied Mekanistics/recipes.js（化学品外壳走 VI 压弯复用 AE2 压头，五级元件按 Mek 电路分档）
- 新增 Custom/metal/{osmium,lead}.js（湿法洗练 + 冶金热熔双链 + 副产物表）
- 新增 registry_item_mekanism.js（等级安装器/工厂过渡物）与 client 端 JEI 信息页 + Mek 工具隐藏
- 扩展 Create Ore 矿簇产物（锇/铅/铀/氟石并入数字矿机产物）、value_data 采矿价值源、unified_loot 科技池
- 新增 .agents/skills/mekanism-integration/SKILL.md：重建手册 + 六条实战铁律（级联中断/整树同步/latest.log 取证/探针创建序/Schema 版本耦合/健康基线）

## 影响范围
- Mekanism 全机器/工厂/升级/装备获取路径重构；主世界金属与贵金属矿簇产物扩展
- 已在 v0.5.0.7-test 实例全链路验证（配方事件 0 Mek 报错，终局探针：原版电路/速度升级/Mek 钢配方均确认移除）

## 验证说明
- 全部脚本 node --check 通过；配方 ID 均对照 Mekanism 10.4.16.80 JAR 实测
- factories 精英/终极与 generators QIO 外围/核工业段为按模板重建（文件内标注），数值待游戏内复核

