### PR TITLE
[fix] 修复野生曼德拉世界生成

### DIFF
--- a/kubejs/data/youkaishomecoming/worldgen/configured_feature/mandrake.json
+++ b/kubejs/data/youkaishomecoming/worldgen/configured_feature/mandrake.json
@@ -1,0 +1,44 @@
+{
+  "type": "minecraft:random_patch",
+  "config": {
+    "feature": {
+      "feature": {
+        "type": "minecraft:simple_block",
+        "config": {
+          "to_place": {
+            "type": "minecraft:simple_state_provider",
+            "state": {
+              "Name": "youkaishomecoming:wild_mandrake"
+            }
+          }
+        }
+      },
+      "placement": [
+        {
+          "type": "minecraft:block_predicate_filter",
+          "predicate": {
+            "type": "minecraft:all_of",
+            "predicates": [
+              {
+                "type": "minecraft:replaceable"
+              },
+              {
+                "type": "minecraft:matching_fluids",
+                "fluids": "minecraft:empty"
+              },
+              {
+                "type": "minecraft:would_survive",
+                "state": {
+                  "Name": "youkaishomecoming:wild_mandrake"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "tries": 12,
+    "xz_spread": 5,
+    "y_spread": 3
+  }
+}

--- a/kubejs/data/youkaishomecoming/worldgen/placed_feature/mandrake.json
+++ b/kubejs/data/youkaishomecoming/worldgen/placed_feature/mandrake.json
@@ -1,0 +1,19 @@
+{
+  "feature": "youkaishomecoming:mandrake",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 6
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "MOTION_BLOCKING_NO_LEAVES"
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}


### PR DESCRIPTION
## 变更内容

- 保留 Youkai's Homecoming 2.7.0 原模组默认的 chance=6、tries=12。
- 将曼德拉 placed feature 的高度图改为 MOTION_BLOCKING_NO_LEAVES，避免树叶树冠抬高采样位置。
- 使用 minecraft:would_survive，按 wild_mandrake 的 BushBlock 生存规则判断可放置位置。

## 验证

- 已从原模组 JAR 核对默认 chance=6、tries=12。
- JSON 解析、字段断言、空白检查和 git diff --check 通过。
- 尚未进行游戏内新世界生成回归。