### PR TITLE
[feat] v0.5.0.8-test 版本更新

### DIFF
--- a/modpack.toml
+++ b/modpack.toml
@@ -1,6 +1,6 @@
 name = "Create-Delight-Remake"
 author = "JSI"
-version = "v0.5.0.7-test"
+version = "v0.5.0.8-test"
 pack-format = "packwiz:1.1.0"
 
 [versions]


### PR DESCRIPTION
版本号更新: → v0.5.0.8-test

**更新内容**:
- [dev] tacz枪包替换为 CurseForge 官方版本，本地魔改迁移至 KubeJS (#2194)