### PR TITLE
[dev] 仓库不再跟踪py cache文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@
 # Agent knowledge base (compatible with OpenCode + Codex)
 !/AGENTS.md
 !/lessons-learned.md
+
+# Python runtime artifacts (e.g. scripts/__pycache__/)
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## 改动内容

- `.gitignore` 新增 `__pycache__/` 与 `*.py[cod]` 忽略规则
- 修复 `scripts/__pycache__/` 等 Python 编译产物在 `git status` 中显示为未跟踪的问题

## 验证

- 改动后 `git status` 不再列出 `scripts/__pycache__/`
- 其余未跟踪/修改文件列表不受影响
