### PR TITLE
[fix] 放宽发布脚本 PreviousVersion 格式校验以支持 -test tag

### DIFF
--- a/.agents/skills/release/release-publish.ps1
+++ b/.agents/skills/release/release-publish.ps1
@@ -199,8 +199,9 @@ if (-not $PreviousVersion) {
 }
 
 # Validate PreviousVersion format (now that it may be auto-detected)
-if ($PreviousVersion -notmatch '^v\d+\.\d+\.\d+\.\d+$') {
-    Fail "PreviousVersion format invalid: '$PreviousVersion'. Expected format: v0.4.7.15"
+# Allow "-test" suffix so a test release can diff against the previous test tag (used for notes/compare link only; patches are stable-only)
+if ($PreviousVersion -notmatch '^v\d+\.\d+\.\d+\.\d+(-test)?$') {
+    Fail "PreviousVersion format invalid: '$PreviousVersion'. Expected format: v0.4.7.15 or v0.4.7.15-test"
 }
 
 # Verify PreviousVersion tag exists


### PR DESCRIPTION
## 背景

v0.5.0.8-test 发布时发现测试版的 PreviousVersion 被推导为上一个稳定版 v0.5.0.4 而非上一个测试版 v0.5.0.7-test。两个原因叠加：

1. dry run 阶段版本 tag 尚未创建，`git describe` 主路径推导失败，兜底逻辑的正则只匹配稳定版 tag，显式跳过 `-test` 后缀。
2. 主路径即使正确推导出 `v0.5.0.7-test`，格式校验 `^v\d+\.\d+\.\d+\.\d+$` 也会拒绝带 `-test` 后缀的值直接 Fail。历史测试版发布说明一直从上一个稳定版写起、包含大量已发布过的重复内容，正是这个校验造成的。

## 修复

- 校验正则放宽为 `^v\d+\.\d+\.\d+\.\d+(-test)?$`，允许 `-test` 后缀。

## 影响范围

- 测试版不提供 Patch 文件（发布说明明确提示下载完整包），PreviousVersion 仅用于发布说明的 commit 范围和 compare 链接，改用上一个测试版 tag 是安全的。
- 正式版行为不变，Patch 命名和下载仍基于稳定版基线。

## 验证

- v0.5.0.8-test 发布流程实测通过：auto-detect 返回 `v0.5.0.7-test`，发布说明范围 `v0.5.0.7-test..v0.5.0.8-test`，2 个产物上传校验成功。
