### PR TITLE
[feat] 增加 ServerWarashi 用于服务器区块消耗诊断

### DIFF
--- a/config/modpack_defaults/config/crash_assistant/modlist.json
+++ b/config/modpack_defaults/config/crash_assistant/modlist.json
@@ -1584,6 +1584,11 @@
     "name": "ServerCore",
     "version": "1.5.2+1.20.1"
   },
+  "serverwarashi-1.20.1-2.0.4.1-all.jar": {
+    "modId": "serverwarashi",
+    "name": "ServerWarashi",
+    "version": "1.20.1-2.0.4.1-all"
+  },
   "shadowizardlib-1.20.1-1.3.1.jar": {
     "modId": "shadowizardlib",
     "name": "ShadowizardLib",

--- a/mods/serverwarashi.pw.toml
+++ b/mods/serverwarashi.pw.toml
@@ -1,0 +1,13 @@
+name = "ServerWarashi"
+filename = "serverwarashi-1.20.1-2.0.4.1-all.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "a846e922dc6e0298ad6c51e623ecff63cb00b624"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8721142
+project-id = 1359418


### PR DESCRIPTION
Closes #2039

## 变更内容

- 通过 `scripts/add-packwiz-target.ps1` 添加 [ServerWarashi](https://www.curseforge.com/minecraft/mc-mods/serverwarashi/files/8721142)（`serverwarashi-1.20.1-2.0.4.1-all.jar`），用于服务器区块消耗诊断
- 元数据 `mods/serverwarashi.pw.toml`，`side = "both"`：服务端统计区块加载消耗，客户端在地图上渲染区块热力图 overlay
- pre-commit hook 已自动重建 Crash Assistant modlist 基线（`config/modpack_defaults/config/crash_assistant/modlist.json`）

## 验证

- `add-packwiz-target.ps1` 已完成本地运行时同步，JAR 下载并校验 sha1 一致
- JAR 内含客户端 shader / 地图 overlay API 资源，确认需要双端安装
