### PR TITLE
[dev] 新增 ZCode MCP 服务器配置并迁移 Codex Stop hooks

### DIFF
--- a/.agents/skills/knowledge-check/SKILL.md
+++ b/.agents/skills/knowledge-check/SKILL.md
@@ -30,7 +30,7 @@ description: 实现后知识检查、知识库维护、项目经验沉淀。用�
 
 如果存在 `tmp-opencode/knowledge-candidate-report.md`，先读取它再决定；除非当前任务明确要求维护知识库，否则 process note 候选需要用户接受后再落库。
 
-Codex Stop hook 会运行 `scripts/validate-knowledge-base.ps1`，并写入 `tmp-opencode/knowledge-candidate-report.md`；该报告只提供建议，不会自动修改知识文件。
+Codex（`.codex/hooks.json`）和 ZCode（`.zcode/config.json` 的 Stop hooks）都会运行 `scripts/validate-knowledge-base.ps1`，并写入 `tmp-opencode/knowledge-candidate-report.md`；该报告只提供建议，不会自动修改知识文件。
 
 如果任务中途遇到非显而易见的失败或绕路做法，但最终还没决定是否落库，可用 `scripts/add-knowledge-note.ps1` 追加临时 note，让候选报告把它路由到这里。
 

--- a/.agents/skills/minecraft-mcp/SKILL.md
+++ b/.agents/skills/minecraft-mcp/SKILL.md
@@ -1,41 +1,43 @@
 ---
 name: minecraft-mcp
-description: 连接、诊断、测试、操作、修复、构建和部署 minecraft-mod-mcp（mcpmod）及其 Forge 1.20.1 模组，并通过运行时帮助探索 FTB Library、KubeJS 等模组指令。用于 CDRdev 中的 MCP 端口冲突、Mod not connected、截图/键鼠/命令调用、玩家或世界数据异常、生产环境反射映射失效、测试 JAR 替换与真实游戏回归。
+description: 连接、诊断、测试、操作、修复、构建和部署 minecraft-mod-mcp（mcpmod）及其 Forge 1.20.1 模组，并通过运行时帮助探索 FTB Library、KubeJS 等模组指令。用于整合包开发环境中的 MCP 端口冲突、Mod not connected、截图/键鼠/命令调用、玩家或世界数据异常、生产环境反射映射失效、测试 JAR 替换与真实游戏回归。
 ---
 
 # Minecraft MCP
 
-使用 Minecraft MCP 观察和控制 CDRdev 客户端，并在外部 fork 中维护模组源码。
+使用 Minecraft MCP 观察和控制整合包客户端，并在各自的 fork 中维护模组源码。
 
 ## 边界
 
-- 把 `D:\game\.minecraft\versions\CDRdev` 仅用于运行验证和 Packwiz 资产管理。
-- 把干净源码放在 `D:\learnmod\minecraft-mod-mcp-SSWTLZZ69`；保留已有脏目录 `D:\learnmod\minecraft-mod-mcp`，不要覆盖或清理其中改动。
-- 使用上游 `langyo/minecraft-mod-mcp`，fork 为 `SSWTLZZ69/minecraft-mod-mcp`。
-- 未经用户明确要求，不创建 PR；可以在用户要求 fork/修复时提交并推送 fork 分支。
+- 运行验证和 Packwiz 资产管理统一在本整合包仓库的本地检出目录（即本 skill 所在仓库）进行；不同开发者的检出路径不同，命令一律以仓库根目录为工作目录，不要硬编码绝对路径。
+- minecraft-mod-mcp 源码克隆放在每个开发者自己的本地工作目录，下文用 `<mcp-src>` 指代该路径；从上游 `langyo/minecraft-mod-mcp` 克隆，如需修复可 fork 到自己的 GitHub 账号。不要覆盖或清理本地的脏改动目录。
+- 未经用户明确要求，不创建 PR；可以在用户要求 fork/修复时提交并推送自己的 fork 分支。
 - 修改 `mods/`、`packwiz-files/` 或 Packwiz 元数据前，先使用 `/packwiz-assets`。
 - 把 `mods/*.jar` 视为本机运行文件；测试替换不能成为 Git 跟踪内容。
+- MCP 连接配置不入仓库：各开发者在用户级 `~/.zcode/cli/config.json` 的 `mcp.servers` 自行添加 `minecraft_mcp`（Windows 用 `"command": "cmd", "args": ["/c", "npx", "-y", "minecraft-mod-mcp"]`；macOS/Linux 直接用 `"command": "npx"`）。`.zcode/config.json` 只随仓库共享 Stop hooks。
 
 ## 连接诊断
 
-1. 从可用工具中查找 `mcp__minecraft_mcp__*`。
+1. 从可用工具中查找 `mcp__minecraft_mcp__*`；若不存在，确认用户级 `~/.zcode/cli/config.json` 已按"边界"一节添加 `minecraft_mcp` 并重启会话。
 2. 调用 `get_minecraft_status` 和 `ping`；以 `connected: true` 与 `pong` 判断连接，不要只看 `processAlive`。
-3. HMCL 外部启动的 CDRdev 可能显示 `processAlive: false`，这不代表模组断连。
-4. 检查模组和日志：
+3. HMCL 外部启动的客户端可能显示 `processAlive: false`，这不代表模组断连。
+4. 架构与发现机制：游戏内模组只提供 `/api/*` REST 端点（不做 MCP 握手）；ZCode 通过 stdio 桥接 `minecraft-mod-mcp` 连接，桥接从 `9876` 向下扫描到 `9000`，用 `GET /api/status` 自动发现游戏。
+5. 若游戏运行中桥接仍报 `No Minecraft mod detected`，先 `curl http://127.0.0.1:9876/api/status` 验证；返回 502/非 200 时检查系统代理（`HTTP_PROXY`/`HTTPS_PROXY`）是否劫持了 localhost，必要时设置 `NO_PROXY=127.0.0.1,localhost` 后重启会话。
+6. 检查模组和日志：
 
 ```powershell
 Get-ChildItem -LiteralPath mods -Force | Where-Object Name -Match 'minecraft.*mcp|mcp.*minecraft'
 rg -n -i 'mcpmod|MCP-MOD|Address already in use' logs\latest.log
 ```
 
-5. 检查默认端口及占用者：
+7. 检查默认端口及占用者：
 
 ```powershell
 Get-NetTCPConnection -LocalPort 9876 -ErrorAction SilentlyContinue |
   Select-Object State, LocalAddress, LocalPort, OwningProcess
 ```
 
-6. 不要因为端口冲突直接结束 Blender 或 Minecraft；先确认 PID、进程名和用户当前状态。
+8. 不要因为端口冲突直接结束 Blender 或 Minecraft；先确认 PID、进程名和用户当前状态。
 
 ## 安全调用
 
@@ -134,7 +136,7 @@ packages/mods/1.20.1/forge/src/main/java/xyz/langyo/minecraft/mcp/mod/
 在目标模块构建：
 
 ```powershell
-Set-Location D:\learnmod\minecraft-mod-mcp-SSWTLZZ69\packages\mods\1.20.1\forge
+Set-Location <mcp-src>\packages\mods\1.20.1\forge
 .\gradlew.bat clean build --no-daemon --console=plain
 ```
 
@@ -143,7 +145,7 @@ Set-Location D:\learnmod\minecraft-mod-mcp-SSWTLZZ69\packages\mods\1.20.1\forge
 - 构建后检查 `build/libs/`、SHA-256、JAR 内适配器类以及 `git diff --check`。
 - 部署前确认 Minecraft 已正常退出。
 - 备份旧运行 JAR，再以相同运行文件名复制修复版；复制后核对 SHA-256。
-- 检查 CDRdev `git status --short`，不要把已有用户改动归因于本次测试。
+- 检查整合包仓库 `git status --short`，不要把已有用户改动归因于本次测试。
 - 若要正式纳入整合包，转入 `/packwiz-assets` 的 `packwiz-files` 与元数据流程；不要提交 `mods/*.jar`。
 
 ## 回归与交付

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 
 # Root directories that manage their own allowlists.
 !/.agents/
+!/.zcode/
 !/.codex/
 !/.github/
 !/PCL/

--- a/.zcode/config.json
+++ b/.zcode/config.json
@@ -1,0 +1,39 @@
+{
+  "hooks": {
+    "enabled": true,
+    "events": {
+      "Stop": [
+        {
+          "hooks": [
+            {
+              "type": "process",
+              "command": "pwsh",
+              "args": [
+                "-NoLogo",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "${CLAUDE_PROJECT_DIR}/scripts/validate-knowledge-base.ps1"
+              ],
+              "timeoutMs": 30000
+            },
+            {
+              "type": "process",
+              "command": "pwsh",
+              "args": [
+                "-NoLogo",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "${CLAUDE_PROJECT_DIR}/scripts/write-knowledge-candidate-report.ps1"
+              ],
+              "timeoutMs": 30000
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## 变更内容

为 ZCode 客户端补齐本仓库此前仅覆盖 Codex 的 Stop hooks，并去除开发知识中的机器专属路径。

### 1. ZCode Stop hooks（新增 `.zcode/config.json`，仅 hooks）

- 将 `.codex/hooks.json` 的两个 Stop hook（`scripts/validate-knowledge-base.ps1`、`scripts/write-knowledge-candidate-report.ps1`）迁移为 ZCode 配置格式；原 Codex 配置保留不动，双启动器并存
- 按差异点调整：显式 `"enabled": true`（ZCode 配置文件 hook 默认禁用）；`command` 类型改为 `process` 类型（参数向量不经 shell，规避 Windows 跨平台问题）；超时字段 `timeout`(秒) → `timeoutMs`(毫秒)；脚本路径改用 `${CLAUDE_PROJECT_DIR}` 模板变量

### 2. MCP 服务器配置不入仓库

`minecraft_mcp`（stdio 桥接 `npx -y minecraft-mod-mcp`，扫描 9876→9000 自动发现游戏内 mcpmod）**不随仓库分发**，由各开发者在用户级 `~/.zcode/cli/config.json` 自行添加：

- Windows：`"command": "cmd", "args": ["/c", "npx", "-y", "minecraft-mod-mcp"]`（无 shell 直接 spawn `npx` 会 ENOENT，已实测）
- macOS/Linux：`"command": "npx"`

理由：workspace 级 MCP 对所有 ZCode 用户自动连接，会导致①Windows 专属命令在其他平台连接失败；②会话启动时自动执行未锁版本的第三方 npm 包（供应链面）；③连游戏测试属个人工具选择。详见 `.agents/skills/minecraft-mcp/SKILL.md` 的"边界"一节。

### 3. 文档泛化（`.agents/skills/minecraft-mcp/SKILL.md`）

- 去除机器专属路径：`D:\game\...` 实例目录 → 仓库相对路径；`D:\learnmod\minecraft-mod-mcp-SSWTLZZ69` → `<mcp-src>` 占位符；三处旧实例名 `CDRdev` → 通用表述
- 补充连接诊断：stdio 桥接架构说明、系统代理劫持 localhost 导致桥接发现失败的排查项（`NO_PROXY=127.0.0.1,localhost`）、用户级 MCP 配置说明

### 4. 其他

- `.gitignore` 放行 `/.zcode/`（白名单模式）
- `.agents/skills/knowledge-check/SKILL.md` 同步说明双启动器覆盖

## 验证

- 配置 JSON 解析通过
- 两个 hook 脚本以 ZCode 实际调用方式（`process` 参数向量、无 shell、仓库外工作目录）实测 exit 0，报告脚本正确写入 `tmp-opencode/knowledge-candidate-report.md`
- `npx -y minecraft-mod-mcp status` 可运行（桥接包本身正常）
- hook 实际触发需会话重启后观察，触发记录可在 ZCode 日志查看

## 审阅提示

- `.gitignore` 的 `!/.zcode/` 与本次新增 `.zcode/config.json` 需一起审阅
- 非 Windows 开发者如需游戏 MCP，按 SKILL.md"边界"一节在用户级配置中添加
