### PR TITLE
[feat] 活塞激发器统一为撞针激发器并改工作台合成

### DIFF
--- a/kubejs/data/oei/replacements/exciter.json
+++ b/kubejs/data/oei/replacements/exciter.json
@@ -1,0 +1,8 @@
+[
+    {
+        "matchItems": [
+            "kinetic_pixel:pistonexciter"
+        ],
+        "resultItems": "kinetic_pixel:strikerexciter"
+    }
+]

--- a/kubejs/server_scripts/Kinetic Pixel/recipes.js
+++ b/kubejs/server_scripts/Kinetic Pixel/recipes.js
@@ -4,6 +4,8 @@ ServerEvents.recipes(e => {
         "kinetic_pixel:endercsloot",
         "kinetic_pixel:tableloot",
         "kinetic_pixel:shellloot",
+        "kinetic_pixel:pistonloot",
+        "kinetic_pixel:strikerloot",
         "kinetic_pixel:barrelreuse"
     ])
     remove_recipes_output(e,
@@ -408,6 +410,20 @@ ServerEvents.recipes(e => {
         B: "#forge:nuggets/iron"
     })
     .id("createdelight:muzzle_refit_iron_spike")
+    kubejs.shaped(
+        "kinetic_pixel:strikerexciter",
+        [
+            "AAF",
+            "BSB",
+            " S "
+        ],
+        {
+            A: "#forge:spring/between_500_2_1000",
+            F: "createaddition:iron_rod",
+            B: "create:iron_sheet",
+            S: "create:shaft"
+        }
+    ).id("createdelight:strikerexciter")
     threshing(e,  'kinetic_pixel:graycotton', [
         '2x minecraft:string',
         Item.of('2x minecraft:string').withChance(0.5),


### PR DESCRIPTION
## 改动内容

- **OEI 统一**：新增 `kubejs/data/oei/replacements/exciter.json`，将 `kinetic_pixel:pistonexciter`（活塞激发器）统一到 `kinetic_pixel:strikerexciter`（撞针激发器）。
- **删除动力合成**：移除两个激发器的动力合成配方 `kinetic_pixel:pistonloot` 与 `kinetic_pixel:strikerloot`（已解包 mod jar 核实两者均为 `create:mechanical_crafting` 且分别输出对应激发器）。
- **新增工作台合成**：为撞针激发器添加配方 `createdelight:strikerexciter`：

  | | | |
  |---|---|---|
  | 任意高强度弹簧 | 任意高强度弹簧 | 铁棒 |
  | 铁板 | 传动杆 | 铁板 |
  | （空） | 传动杆 | （空） |

  - 高强度弹簧使用 tag `forge:spring/between_500_2_1000`（铁弹簧 / 钢弹簧 / 烈焰弹簧），与任务书"高强度弹簧"节点口径一致
  - 铁棒 `createaddition:iron_rod`、铁板 `create:iron_sheet`、传动杆 `create:shaft`

## 影响范围

- Kinetic Pixel 枪械配件的激发器获取途径；枪械机械合成中原引用 `pistonexciter` 的两处输入由 OEI 运行时等价替换，无需改动。
- 任务书（Masterful_Machinery）与 bounty 奖励池中对两个激发器的引用在 OEI 等价下均可正常完成。

## 验证

- 解包 `kinetic_pixel-1.0.3-forge-1.20.1.jar` 核对被删配方 ID 与类型无误。
- 材料物品中文名逐一与运行时物品表（`.vscode/item-attributes.json`）比对确认。
- 待游戏内 `/reload` 后验证：动力合成中两配方消失、活塞激发器显示为撞针激发器、工作台可按新配方合成。
