### PR TITLE
[fix] 任务书与 KubeJS 残留的活塞激发器统一为撞针激发器

### DIFF
--- a/config/ftbquests/quests/chapters/Masterful_Machinery.snbt
+++ b/config/ftbquests/quests/chapters/Masterful_Machinery.snbt
@@ -575,7 +575,7 @@
 			size: 1.5d
 			tasks: [{
 				id: "4078E5D27B70DEFB"
-				item: "kinetic_pixel:pistonexciter"
+				item: "kinetic_pixel:strikerexciter"
 				type: "item"
 			}]
 			x: 2.25d

--- a/kubejs/assets/createdelight/lang/zh_cn.json
+++ b/kubejs/assets/createdelight/lang/zh_cn.json
@@ -925,7 +925,7 @@
     "tetra/schematic/sword/katana/hone_demon_eye.slot1": "暗染苹果",
     "tetra/schematic/sword/katana/hone_preemptive_strike.description": "在刀鞘部位装上激发器,可将刀刃快速弹出刀鞘,加强冲击力,对满血敌人造成的首次伤害将额外提升100%%。",
     "tetra/schematic/sword/katana/hone_preemptive_strike.name": "先发制人",
-    "tetra/schematic/sword/katana/hone_preemptive_strike.slot1": "活塞激发器",
+    "tetra/schematic/sword/katana/hone_preemptive_strike.slot1": "撞针激发器",
     "tetra/schematic/sword/katana/hone_puncture_1.description": "使用赛特斯石英水晶加强剑刃的能量密度,右键充能后命中敌人后将造成伤害并降低其40%%护甲,持续4秒。",
     "tetra/schematic/sword/katana/hone_puncture_1.name": "充能打击I",
     "tetra/schematic/sword/katana/hone_puncture_1.slot1": "充能赛特斯石英水晶",

--- a/kubejs/server_scripts/Kinetic Pixel/recipes.js
+++ b/kubejs/server_scripts/Kinetic Pixel/recipes.js
@@ -76,7 +76,7 @@ ServerEvents.recipes(e => {
             C: "create_sa:steam_engine",
             D: "#minecraft:logs",
             E: "kinetic_pixel:ammunitionbox",
-            F: "kinetic_pixel:pistonexciter"
+            F: "kinetic_pixel:strikerexciter"
         })
         .id("createdelight:pistol_revolver_torque")
     create.mechanical_crafting(
@@ -94,7 +94,7 @@ ServerEvents.recipes(e => {
             D: "#minecraft:logs",
             E: "vintageimprovements:andesite_sheet",
             F: "kinetic_pixel:ammunitionbox",
-            G: "kinetic_pixel:pistonexciter"
+            G: "kinetic_pixel:strikerexciter"
         })
         .id("createdelight:pistol_auto_stress")
     create.mechanical_crafting(


### PR DESCRIPTION
## 改动内容

补齐 #2207 漏掉的活塞激发器（`kinetic_pixel:pistonexciter`）直接引用点，统一为撞针激发器（`kinetic_pixel:strikerexciter`）：

- `Masterful_Machinery` 任务书中"任务物品"任务节点仍指向 `kinetic_pixel:pistonexciter`，改为 `kinetic_pixel:strikerexciter`
- `kubejs/server_scripts/Kinetic Pixel/recipes.js` 中 torque 左轮手炮（`pistol_revolver_torque`）与应力自动手炮（`pistol_auto_stress`）两把枪械机械合成的激发器输入改为 `kinetic_pixel:strikerexciter`
- `kubejs/assets/createdelight/lang/zh_cn.json` 中 tetra"先发制人"磨刀的材料文案由"活塞激发器"改为"撞针激发器"（底层数据在 mod jar 内，由 OEI 等价规则兼容）

## 影响范围

- 仅引用与文案层面，配方逻辑与 OEI 等价规则不变。
- bountiful 奖励池中的 `scientist_pistonexciter` 条目保持原样（OEI 等价下可正常完成）。

## 验证

- 全库检索 `pistonexciter` 与"活塞激发器"，kubejs 范围内仅剩 probejs 自动生成文件与 OED 缓存，无需人工修改。
