### PR TITLE
[dev] 更新每次启动都会改动的JEI配置文件

### DIFF
--- a/config/jei/recipe-category-sort-order.ini
+++ b/config/jei/recipe-category-sort-order.ini
@@ -221,3 +221,4 @@ create_dragons_plus:grinding
 create_dragons_plus:printing
 create_dragons_plus:sanding
 just_enough_lightmans_trades:lightman_trades
+jei_plus_plus:ingredient_directory


### PR DESCRIPTION
## 改动内容

`config/jei/recipe-category-sort-order.ini` 末尾追加一行 `jei_plus_plus:ingredient_directory`。

游戏运行时 JEI Plus Plus 注册该配方类别，JEI 将其追加到排序文件末尾（排在 `just_enough_lightmans_trades:lightman_trades` 之后）。该改动在每次游戏会话后稳定重现，入库以免工作区反复出现本地改动。

## 影响范围

- 仅 JEI 客户端配方类别排序，无功能变化。

## 验证

- 与上次游戏会话产生的改动逐行一致；文件整体被游戏以 CRLF 重写，经 `.gitattributes` 归一化后入库为 LF，diff 仅 1 行新增。
