### PR TITLE
[dev] 开发知识库记录机制优化

### DIFF
--- a/.agents/skills/dev-knowledge/SKILL.md
+++ b/.agents/skills/dev-knowledge/SKILL.md
@@ -9,6 +9,10 @@ description: 开发知识路由、知识库整理、实现记录、代码位置�
 
 本 skill 是知识存放路由的唯一来源；`knowledge-check` 应引用这里的存放表，而不是重复维护一份规则。
 
+## 任务中随手记录
+
+任务进行中遇到非显而易见的失败、绕路、根因或约束时，不要等任务结束再回忆：立即用 `scripts/add-knowledge-note.ps1` 追加临时 note（写入 `tmp-opencode/knowledge-notes.md`）。Stop hook 的候选报告只扫描 diff，看不到这类过程信息；note 会被报告读入 Process Notes 并路由到 knowledge-check。任务结束落库或否决后，运行 `scripts/resolve-knowledge-candidate.ps1` 清掉临时 note，避免重复出现。
+
 ## 存放表
 
 | 知识类型 | 目标位置 | 使用场景 |

--- a/.agents/skills/knowledge-check/SKILL.md
+++ b/.agents/skills/knowledge-check/SKILL.md
@@ -30,7 +30,7 @@ description: 实现后知识检查、知识库维护、项目经验沉淀。用�
 
 如果存在 `tmp-opencode/knowledge-candidate-report.md`，先读取它再决定；除非当前任务明确要求维护知识库，否则 process note 候选需要用户接受后再落库。
 
-Codex（`.codex/hooks.json`）和 ZCode（`.zcode/config.json` 的 Stop hooks）都会运行 `scripts/validate-knowledge-base.ps1`，并写入 `tmp-opencode/knowledge-candidate-report.md`；该报告只提供建议，不会自动修改知识文件。
+Codex（`.codex/hooks.json`）和 ZCode（`.zcode/config.json` 的 Stop hooks）都会运行 `scripts/validate-knowledge-base.ps1`，并写入 `tmp-opencode/knowledge-candidate-report.md`；该报告只提供建议，不会自动修改知识文件。报告覆盖范围为工作区改动加上自上次报告以来未报告的最近提交（`-RecentCommits`，默认 1），并按时间戳归档到 `tmp-opencode/knowledge-candidate-history/`（保留最近 50 份）；漏记的知识候选可从归档或 git 提交历史回溯补记。
 
 如果任务中途遇到非显而易见的失败或绕路做法，但最终还没决定是否落库，可用 `scripts/add-knowledge-note.ps1` 追加临时 note，让候选报告把它路由到这里。
 

--- a/.agents/skills/knowledge-check/SKILL.md
+++ b/.agents/skills/knowledge-check/SKILL.md
@@ -30,9 +30,9 @@ description: 实现后知识检查、知识库维护、项目经验沉淀。用�
 
 如果存在 `tmp-opencode/knowledge-candidate-report.md`，先读取它再决定；除非当前任务明确要求维护知识库，否则 process note 候选需要用户接受后再落库。
 
-Codex（`.codex/hooks.json`）和 ZCode（`.zcode/config.json` 的 Stop hooks）都会运行 `scripts/validate-knowledge-base.ps1`，并写入 `tmp-opencode/knowledge-candidate-report.md`；该报告只提供建议，不会自动修改知识文件。报告覆盖范围为工作区改动加上自上次报告以来未报告的最近提交（`-RecentCommits`，默认 1），并按时间戳归档到 `tmp-opencode/knowledge-candidate-history/`（保留最近 50 份）；漏记的知识候选可从归档或 git 提交历史回溯补记。
+Codex（`.codex/hooks.json`）和 ZCode（`.zcode/config.json` 的 Stop hooks）都会运行 `scripts/validate-knowledge-base.ps1`，并写入 `tmp-opencode/knowledge-candidate-report.md`；该报告只提供建议，不会自动修改知识文件。报告覆盖范围为工作区改动加上自上次报告以来的全部未报告提交；仅当上次报告基线缺失或不再是 HEAD 祖先（如 rebase）时，才回看最近 `-RecentCommits` 个提交（默认 1）。有候选的报告会按时间戳归档到 `tmp-opencode/knowledge-candidate-history/`（保留最近 50 份，空报告不归档）；漏记的知识候选可从归档或 git 提交历史回溯补记。
 
-如果任务中途遇到非显而易见的失败或绕路做法，但最终还没决定是否落库，可用 `scripts/add-knowledge-note.ps1` 追加临时 note，让候选报告把它路由到这里。
+diff 扫描只覆盖代码改动，看不到任务过程中发现的信息。因此任务进行中遇到非显而易见的失败、绕路、根因或约束时，立即用 `scripts/add-knowledge-note.ps1` 追加临时 note，不要等任务结束再回忆；候选报告会读取这些 note 并把它路由到这里。
 
 通常值得记录的知识分为：
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,3 +117,4 @@ CD-master-dev/
 - Client-only mods → set `side = "client"` in the corresponding `mods/*.pw.toml`
 - Server-only mods → set `side = "server"` in the corresponding `mods/*.pw.toml`
 - Language files validated by `.vscode/probe.lang-schema.json`
+- **任务中发现非显而易见的失败、绕路、根因或约束时，立即用 `scripts/add-knowledge-note.ps1` 记临时 note**；Stop hook 的候选报告只扫描 diff，看不到这些过程信息（细节见 knowledge-check skill）。

--- a/scripts/write-knowledge-candidate-report.ps1
+++ b/scripts/write-knowledge-candidate-report.ps1
@@ -141,9 +141,23 @@ if (Test-Path -LiteralPath $StatePath) {
 }
 
 $hasCurrentChanges = (@($dirtyFiles + $stagedFiles + $untrackedFiles).Count -gt 0)
+# 检查自上次报告以来未报告过的最近提交；lastReportedHead 缺失或不再是 HEAD 祖先（如 rebase）时只看 HEAD，
+# 避免一次性扫入大量历史提交。没有这个回溯窗口，漏记的知识候选会在下一个提交后永久不可见。
 $recentFiles = @()
-if (-not $hasCurrentChanges -and $head -and $head -ne $lastReportedHead) {
-    $recentFiles = Invoke-Git -GitArgs @("diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD")
+$scannedCommits = @()
+if ($head -and $RecentCommits -gt 0) {
+    $lastReportedHeadIsAncestor = $false
+    if (-not [string]::IsNullOrWhiteSpace($lastReportedHead)) {
+        & git -C $Root merge-base --is-ancestor $lastReportedHead $head 2>$null
+        $lastReportedHeadIsAncestor = ($LASTEXITCODE -eq 0)
+    }
+    $commitShas = @(Invoke-Git -GitArgs @("rev-list", "--max-count=$RecentCommits", $head))
+    foreach ($commit in $commitShas) {
+        if ($lastReportedHeadIsAncestor -and $commit -eq $lastReportedHead) { break }
+        if (-not $lastReportedHeadIsAncestor -and $scannedCommits.Count -gt 0) { break }
+        $scannedCommits += $commit
+        $recentFiles += @(Invoke-Git -GitArgs @("diff-tree", "--no-commit-id", "--name-only", "-r", $commit))
+    }
 }
 
 $allFiles = New-Object System.Collections.Generic.List[string]
@@ -245,7 +259,13 @@ $lines = New-Object System.Collections.Generic.List[string]
 $lines.Add("# Knowledge Candidate Report") | Out-Null
 $lines.Add("") | Out-Null
 $lines.Add("- Generated: $timestamp") | Out-Null
-$lines.Add("- Scope: working tree, index, and HEAD commit") | Out-Null
+$lines.Add("- Scope: working tree, index, and unreported recent commits") | Out-Null
+if ($scannedCommits.Count -gt 0) {
+    foreach ($commit in $scannedCommits) {
+        $subject = (Invoke-Git -GitArgs @("show", "-s", "--format=%h %s", $commit) | Select-Object -First 1)
+        $lines.Add("- Scanned commit: $subject") | Out-Null
+    }
+}
 $lines.Add("- Mode: report only; no knowledge files were edited") | Out-Null
 $lines.Add("- Decision: $decisionStatus") | Out-Null
 $lines.Add("") | Out-Null
@@ -297,6 +317,18 @@ $lines.Add('If the recommendation is actionable, ask the user to accept it unles
 $lines.Add('After applying or rejecting it, run `scripts/resolve-knowledge-candidate.ps1 -Status applied|rejected` to clear temporary notes.') | Out-Null
 
 Set-Content -LiteralPath $OutputPath -Value $lines -Encoding UTF8
+
+# 报告同时按时间戳归档，避免下一轮报告覆盖后候选历史丢失；只保留最新 50 份。
+$archiveDir = Join-Path (Split-Path -Parent $OutputPath) "knowledge-candidate-history"
+if (-not (Test-Path -LiteralPath $archiveDir)) {
+    New-Item -ItemType Directory -Path $archiveDir -Force | Out-Null
+}
+$archiveName = "knowledge-candidate-" + (Get-Date -Format "yyyyMMdd-HHmmss") + ".md"
+Set-Content -LiteralPath (Join-Path $archiveDir $archiveName) -Value $lines -Encoding UTF8
+$existingArchives = @(Get-ChildItem -LiteralPath $archiveDir -Filter "knowledge-candidate-*.md" | Sort-Object Name -Descending)
+if ($existingArchives.Count -gt 50) {
+    $existingArchives | Select-Object -Skip 50 | Remove-Item -Force
+}
 
 if ($head) {
     $stateObject = [ordered]@{

--- a/scripts/write-knowledge-candidate-report.ps1
+++ b/scripts/write-knowledge-candidate-report.ps1
@@ -140,21 +140,25 @@ if (Test-Path -LiteralPath $StatePath) {
     }
 }
 
-$hasCurrentChanges = (@($dirtyFiles + $stagedFiles + $untrackedFiles).Count -gt 0)
-# 检查自上次报告以来未报告过的最近提交；lastReportedHead 缺失或不再是 HEAD 祖先（如 rebase）时只看 HEAD，
-# 避免一次性扫入大量历史提交。没有这个回溯窗口，漏记的知识候选会在下一个提交后永久不可见。
+# 检查自上次报告以来未报告过的提交。已知基线（lastReportedHead 是 HEAD 祖先）时全量回溯
+# lastReportedHead..HEAD，避免窗口截断导致中间提交漏记；基线缺失或不再是祖先（如 rebase）时
+# 只回看最近 -RecentCommits 个提交，避免一次性扫入大量历史。
 $recentFiles = @()
 $scannedCommits = @()
-if ($head -and $RecentCommits -gt 0) {
+if ($head) {
     $lastReportedHeadIsAncestor = $false
     if (-not [string]::IsNullOrWhiteSpace($lastReportedHead)) {
         & git -C $Root merge-base --is-ancestor $lastReportedHead $head 2>$null
         $lastReportedHeadIsAncestor = ($LASTEXITCODE -eq 0)
     }
-    $commitShas = @(Invoke-Git -GitArgs @("rev-list", "--max-count=$RecentCommits", $head))
+    if ($lastReportedHeadIsAncestor) {
+        $commitShas = @(Invoke-Git -GitArgs @("rev-list", "$lastReportedHead..$head"))
+    } elseif ($RecentCommits -gt 0) {
+        $commitShas = @(Invoke-Git -GitArgs @("rev-list", "--max-count=$RecentCommits", $head))
+    } else {
+        $commitShas = @()
+    }
     foreach ($commit in $commitShas) {
-        if ($lastReportedHeadIsAncestor -and $commit -eq $lastReportedHead) { break }
-        if (-not $lastReportedHeadIsAncestor -and $scannedCommits.Count -gt 0) { break }
         $scannedCommits += $commit
         $recentFiles += @(Invoke-Git -GitArgs @("diff-tree", "--no-commit-id", "--name-only", "-r", $commit))
     }
@@ -319,15 +323,18 @@ $lines.Add('After applying or rejecting it, run `scripts/resolve-knowledge-candi
 Set-Content -LiteralPath $OutputPath -Value $lines -Encoding UTF8
 
 # 报告同时按时间戳归档，避免下一轮报告覆盖后候选历史丢失；只保留最新 50 份。
-$archiveDir = Join-Path (Split-Path -Parent $OutputPath) "knowledge-candidate-history"
-if (-not (Test-Path -LiteralPath $archiveDir)) {
-    New-Item -ItemType Directory -Path $archiveDir -Force | Out-Null
-}
-$archiveName = "knowledge-candidate-" + (Get-Date -Format "yyyyMMdd-HHmmss") + ".md"
-Set-Content -LiteralPath (Join-Path $archiveDir $archiveName) -Value $lines -Encoding UTF8
-$existingArchives = @(Get-ChildItem -LiteralPath $archiveDir -Filter "knowledge-candidate-*.md" | Sort-Object Name -Descending)
-if ($existingArchives.Count -gt 50) {
-    $existingArchives | Select-Object -Skip 50 | Remove-Item -Force
+# 没有 signals 也没有 process notes 的空报告不归档，避免逐渐填满历史配额。
+if ($signals.Count -gt 0 -or -not [string]::IsNullOrWhiteSpace($processNotes)) {
+    $archiveDir = Join-Path (Split-Path -Parent $OutputPath) "knowledge-candidate-history"
+    if (-not (Test-Path -LiteralPath $archiveDir)) {
+        New-Item -ItemType Directory -Path $archiveDir -Force | Out-Null
+    }
+    $archiveName = "knowledge-candidate-" + (Get-Date -Format "yyyyMMdd-HHmmss") + ".md"
+    Set-Content -LiteralPath (Join-Path $archiveDir $archiveName) -Value $lines -Encoding UTF8
+    $existingArchives = @(Get-ChildItem -LiteralPath $archiveDir -Filter "knowledge-candidate-*.md" | Sort-Object Name -Descending)
+    if ($existingArchives.Count -gt 50) {
+        $existingArchives | Select-Object -Skip 50 | Remove-Item -Force
+    }
 }
 
 if ($head) {
@@ -339,3 +346,6 @@ if ($head) {
 }
 
 Write-Host "Knowledge candidate report written to $(Resolve-Path -LiteralPath $OutputPath)"
+if ([string]::IsNullOrWhiteSpace($processNotes)) {
+    Write-Host "Reminder: if this task discovered non-obvious knowledge that is not visible in the diff (dead ends, root causes, constraints), append it with scripts/add-knowledge-note.ps1 and re-run this report so it lands in Process Notes."
+}


### PR DESCRIPTION
## 改动

### 知识候选报告机制修复

- 修复 RecentCommits 参数声明了但未实现的 bug：报告现在检查自上次报告以来全部未报告提交，lastReportedHead 缺失或不再是 HEAD 祖先（如 rebase）时只回看 `-RecentCommits`（默认 1）个提交
- **基线全量回溯**：已知基线（lastReportedHead 是 HEAD 祖先）时改用 `git rev-list lastReportedHead..HEAD`，关闭默认窗口导致的丢失窗口——此前两次报告间提交 >=2 个时，中间提交会随 lastReportedHead 跳到 HEAD 而永久漏记
- **按需归档**：报告按时间戳归档到 `tmp-opencode/knowledge-candidate-history/`（保留最近 50 份），但空报告（无 signals 且无 process notes）不再归档，避免逐渐填满历史配额
- 报告新增 Scanned commit 列表便于核对检测范围
- 移除上一版遗留的死变量 `hasCurrentChanges`

### 过程信息记录触发点前移

候选报告只扫描 diff，任务过程中发现的信息（死路、根因、约束）不会出现在任何文件改动里：

- Stop hook 输出新增提醒：有 diff 看不到的过程发现时，先用 `add-knowledge-note.ps1` 记临时 note 并重跑报告；已有 notes 时不再重复提醒
- 根 `AGENTS.md` NOTES 新增常驻指针，让该要求在任务开始时可见
- `dev-knowledge` skill 新增"任务中随手记录"一节，说明 note 机制与 `resolve-knowledge-candidate.ps1` 清理动作
- 同步更新 `knowledge-check` SKILL.md 对报告覆盖范围与 note 触发时机的描述

## 验证

- `scripts/validate-knowledge-base.ps1` 通过
- 临时 state 模拟五个场景：基线为 HEAD~3 时扫描 3 个提交、垃圾基线时只扫 HEAD、基线为 HEAD 时扫描 0 个、有 notes 时归档且提醒抑制、干净空仓库无 signals 时跳过归档
