### PR TITLE
[fix] 修正发布基准版本解析

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -21,7 +21,7 @@ description: 管理 Create-Delight Remake 整合包的正式版或测试版发�
 .\.agents\skills\release\release-plan.ps1 -Version 'v0.5.0.6-test' -ReleaseType '测试' -AsJson
 ```
 
-计划会推导版本、目标分支、上一稳定版本和首个正式版候选。用户明确指定版本、分支或发布类型时，以用户指定为准。
+计划会推导版本、目标分支、上一发布版本和首个正式版候选。上一发布版本按发布类型读取 GitHub Release 元数据：测试版使用最近发布的 Release（包含 prerelease），正式版使用 GitHub 的 `latest release` tag；不要根据 tag 是否带 `-test` 推断正式性。用户明确指定版本、分支或发布类型时，以用户指定为准。
 
 ## Agent 必须完成的判断
 
@@ -60,7 +60,7 @@ description: 管理 Create-Delight Remake 整合包的正式版或测试版发�
     -WhatIf
 ```
 
-`PreviousVersion` 默认自动推导；只有推导错误时才传入覆盖值。确认 dry run 后移除 `-WhatIf`。脚本会发布 4 个正式版产物或 2 个测试版产物，并在正式版时创建公告更新 PR；只报告该 PR，不要合并它。
+`PreviousVersion` 默认按上述 GitHub Release 规则自动推导；只有推导错误时才传入覆盖值。确认 dry run 后移除 `-WhatIf`。脚本会发布 4 个正式版产物或 2 个测试版产物，并在正式版时创建公告更新 PR；只报告该 PR，不要合并它。
 
 ## 不可违反的约束
 

--- a/.agents/skills/release/release-plan.ps1
+++ b/.agents/skills/release/release-plan.ps1
@@ -3,7 +3,7 @@
     Resolve a read-only Create-Delight Remake release plan.
 
 .DESCRIPTION
-    Derives the release version, target branch, previous stable version, and
+    Derives the release version, target branch, previous release tag, and
     first-stable candidate without changing Git state or remote state.
 #>
 [CmdletBinding()]
@@ -18,8 +18,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+$GitHubRepo = "Jasons-impart/Create-Delight-Remake"
 $VersionPattern = '^v(\d+)\.(\d+)\.(\d+)\.(\d+)(-test)?$'
-$StableVersionPattern = '^v\d+\.\d+\.\d+\.\d+$'
 
 function Invoke-GitReadOnly {
     param([string[]]$Arguments)
@@ -29,6 +29,25 @@ function Invoke-GitReadOnly {
         return @()
     }
     return @($output | Where-Object { $_ })
+}
+
+function Invoke-GhJson {
+    param([string[]]$Arguments)
+
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        throw "gh CLI is required to resolve the latest GitHub release"
+    }
+
+    $output = & gh @Arguments 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $output) {
+        throw "Could not query GitHub releases"
+    }
+
+    try {
+        return $output | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        throw "GitHub release query returned invalid JSON"
+    }
 }
 
 function Get-ModpackVersion {
@@ -50,24 +69,45 @@ function Test-HeadChangedModpack {
     return $changedPaths -contains "modpack.toml"
 }
 
-function Get-LatestTag {
-    $tags = Invoke-GitReadOnly -Arguments @("tag", "-l", "v*", "--sort=-version:refname")
-    foreach ($tag in $tags) {
-        if ($tag -match $VersionPattern) {
-            return $tag
-        }
+function Get-LatestPublishedRelease {
+    $releases = @(Invoke-GhJson -Arguments @(
+        "release", "list", "--repo", $GitHubRepo, "--limit", "1",
+        "--exclude-drafts", "--json", "tagName,publishedAt,isPrerelease"
+    ))
+    if ($releases.Count -eq 0 -or -not $releases[0].tagName) {
+        throw "No published GitHub release was found"
     }
-    throw "No release tag matching $VersionPattern was found"
+    return $releases[0]
 }
 
-function Get-LatestStableTag {
-    $tags = Invoke-GitReadOnly -Arguments @("tag", "-l", "v*", "--sort=-version:refname")
-    foreach ($tag in $tags) {
-        if ($tag -match $StableVersionPattern) {
-            return $tag
-        }
+function Get-LatestPublishedReleaseTag {
+    $release = Get-LatestPublishedRelease
+    if ($release.tagName -notmatch $VersionPattern) {
+        throw "Latest published GitHub release has invalid tag: $($release.tagName)"
     }
-    throw "No stable release tag was found"
+    return $release.tagName
+}
+
+function Get-LatestReleaseTag {
+    # gh release view without a tag follows GitHub's latest release semantics:
+    # the latest published non-prerelease release.
+    $release = Invoke-GhJson -Arguments @(
+        "release", "view", "--repo", $GitHubRepo, "--json", "tagName,publishedAt,isPrerelease"
+    )
+    if (-not $release.tagName -or $release.isPrerelease) {
+        throw "GitHub latest release is missing or marked as a prerelease"
+    }
+    if ($release.tagName -notmatch $VersionPattern) {
+        throw "GitHub latest release has invalid tag: $($release.tagName)"
+    }
+    return $release.tagName
+}
+
+function Get-PublishedReleases {
+    return @(Invoke-GhJson -Arguments @(
+        "release", "list", "--repo", $GitHubRepo, "--limit", "100",
+        "--exclude-drafts", "--json", "tagName,publishedAt,isPrerelease"
+    ))
 }
 
 function Get-IncrementedVersion {
@@ -109,7 +149,7 @@ if ($Version) {
     $Version = $currentModpackVersion
 } else {
     $effectiveType = if ($ReleaseType) { $ReleaseType } else { "正式" }
-    $Version = Get-IncrementedVersion -BaseVersion (Get-LatestTag) -Type $effectiveType
+    $Version = Get-IncrementedVersion -BaseVersion (Get-LatestPublishedReleaseTag) -Type $effectiveType
 }
 
 $inferredType = if ($Version.EndsWith("-test")) { "测试" } else { "正式" }
@@ -131,9 +171,18 @@ if (-not $TargetBranch) {
     $TargetBranch = if (Test-BranchExists -Branch $releaseBranch) { $releaseBranch } else { "main" }
 }
 
-$previousVersion = Get-LatestStableTag
-$matchingStableTags = Invoke-GitReadOnly -Arguments @("tag", "-l", "v$subVersion.*") |
-    Where-Object { $_ -match "^v$([regex]::Escape($subVersion))\.\d+$" -and $_ -ne $Version }
+$previousVersion = if ($ReleaseType -eq "测试") {
+    Get-LatestPublishedReleaseTag
+} else {
+    Get-LatestReleaseTag
+}
+$matchingStableTags = @(Get-PublishedReleases |
+    Where-Object {
+        (-not $_.isPrerelease) -and
+        ($_.tagName -match "^v$([regex]::Escape($subVersion))\.\d+$") -and
+        ($_.tagName -ne $Version)
+    } |
+    Select-Object -ExpandProperty tagName)
 $firstStableCandidate = $ReleaseType -eq "正式" -and @($matchingStableTags).Count -eq 0
 
 $commitRange = "$previousVersion..HEAD"

--- a/.agents/skills/release/release-publish.ps1
+++ b/.agents/skills/release/release-publish.ps1
@@ -17,7 +17,7 @@
     The branch to tag on (e.g. "release-v047x").
 
 .PARAMETER PreviousVersion
-    The previous version for release notes and patch artifact names (e.g. "v0.4.7.14").
+    The previous release tag for release notes and patch artifact names (e.g. "v0.4.7.14").
 
 .PARAMETER ReleaseType
     "正式" for full release, "测试" for prerelease. Default: "正式".
@@ -50,6 +50,7 @@ param(
 )
 
 $ErrorActionPreference = "Continue"
+$GitHubRepo = "Jasons-impart/Create-Delight-Remake"
 
 # --- State for cleanup ---
 $script:OriginalBranch = $null
@@ -73,6 +74,40 @@ function Fail {
     Restore-State
     Write-Error $Message
     exit 1
+}
+
+function Get-LatestPublishedReleaseTag {
+    $releasesJson = gh release list --repo $GitHubRepo --limit 1 --exclude-drafts --json tagName,publishedAt,isPrerelease 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $releasesJson) {
+        Fail "Cannot query the latest published GitHub release"
+    }
+    try {
+        $releases = @($releasesJson | ConvertFrom-Json -ErrorAction Stop)
+    } catch {
+        Fail "GitHub release list returned invalid JSON"
+    }
+    if ($releases.Count -eq 0 -or -not $releases[0].tagName) {
+        Fail "No published GitHub release was found"
+    }
+    return $releases[0].tagName
+}
+
+function Get-LatestReleaseTag {
+    # gh release view without a tag follows GitHub's latest release semantics:
+    # the latest published non-prerelease release.
+    $releaseJson = gh release view --repo $GitHubRepo --json tagName,publishedAt,isPrerelease 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $releaseJson) {
+        Fail "Cannot query GitHub's latest release"
+    }
+    try {
+        $release = $releaseJson | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Fail "GitHub latest release returned invalid JSON"
+    }
+    if (-not $release.tagName -or $release.isPrerelease) {
+        Fail "GitHub latest release is missing or marked as a prerelease"
+    }
+    return $release.tagName
 }
 
 function Test-Prerequisites {
@@ -169,33 +204,15 @@ if (-not (Test-Prerequisites)) {
     exit 1
 }
 
-# Auto-detect PreviousVersion if not provided (matches CI's patch-tasks logic)
+# Auto-detect PreviousVersion from GitHub release metadata if not provided.
 if (-not $PreviousVersion) {
     Write-Host "🔍 Auto-detecting PreviousVersion..."
-    # After checkout & pull in Phase A, HEAD will have the tag.
-    # Use same logic as CI: if HEAD has exact tag, look at HEAD^; otherwise HEAD.
-    # But we're running before Phase A checkout, so use remote tags.
-    $autoPrev = git describe --tags --abbrev=0 "$Version^" 2>$null
-    if ($LASTEXITCODE -eq 0 -and $autoPrev) {
-        $PreviousVersion = $autoPrev
-        Write-Host "   ✅ Auto-detected PreviousVersion: $PreviousVersion"
+    if ($ReleaseType -eq "测试") {
+        $PreviousVersion = Get-LatestPublishedReleaseTag
     } else {
-        # Fallback: list tags and find the one before $Version
-        $allTags = git tag -l 'v*' --sort=-version:refname 2>$null
-        $found = $false
-        foreach ($tag in $allTags) {
-            if ($tag -eq $Version) { continue }
-            if ($tag -match '^v\d+\.\d+\.\d+\.\d+$') {
-                $PreviousVersion = $tag
-                $found = $true
-                Write-Host "   ✅ Auto-detected PreviousVersion from tag list: $PreviousVersion"
-                break
-            }
-        }
-        if (-not $found) {
-            Fail "Cannot auto-detect PreviousVersion. Please provide -PreviousVersion parameter."
-        }
+        $PreviousVersion = Get-LatestReleaseTag
     }
+    Write-Host "   ✅ Auto-detected PreviousVersion: $PreviousVersion"
 }
 
 # Validate PreviousVersion format (now that it may be auto-detected)


### PR DESCRIPTION
修正发布流程中的 PreviousVersion 自动推导：测试版读取最近发布的 GitHub Release（包含 prerelease），正式版读取 GitHub latest release；不再依据 tag 后缀判断正式性，并同步修正首个正式版候选判断。验证：PowerShell 语法检查、git diff --check、release-plan 两类计划、release-publish 两类 dry-run 均通过。