### PR TITLE
[fix] 避免 TaCZ addon 模组被重复下载

### DIFF
--- a/.github/workflows/scripts/normalize_packwiz_files_for_curseforge.sh
+++ b/.github/workflows/scripts/normalize_packwiz_files_for_curseforge.sh
@@ -174,49 +174,13 @@ resolve_curseforge_metadata_for_asset() {
   return 1
 }
 
+# 禁用mod文件复制用于自动detect，无release.curseforge模组不再参与探测
 copy_packwiz_file_mods_for_detection() {
-  [ -d "mods" ] || return 0
-  [ -d "packwiz-files/mods" ] || return 0
-
-  while IFS= read -r -d '' meta; do
-    grep -Fq 'packwiz-files/mods/' "$meta" || continue
-
-    local filename
-    filename="$(read_filename "$meta")"
-    if [ -z "$filename" ]; then
-      echo "::warning::Cannot read filename from $meta"
-      continue
-    fi
-
-    local src="packwiz-files/mods/$filename"
-    local dest="mods/$filename"
-    if [ ! -f "$src" ]; then
-      echo "::warning::Missing packwiz-files payload for $meta: $src"
-      continue
-    fi
-
-    if [ ! -f "$dest" ]; then
-      cp "$src" "$dest"
-      printf '%s\n' "$dest" >> "$copied_list"
-    fi
-  done < <(find mods -name '*.pw.toml' -print0)
+  return 0
 }
 
 remove_shadowed_direct_metadata() {
-  [ -d "mods" ] || return 0
-
-  while IFS= read -r -d '' meta; do
-    grep -Fq 'packwiz-files/mods/' "$meta" || continue
-
-    local filename
-    filename="$(read_filename "$meta")"
-    [ -n "$filename" ] || continue
-
-    if has_curseforge_metadata "mods" "$filename" "$meta"; then
-      echo "Removing direct packwiz-files metadata shadowed by CurseForge metadata: $meta"
-      rm -f "$meta"
-    fi
-  done < <(find mods -name '*.pw.toml' -print0)
+  return 0
 }
 
 normalize_packwiz_files_for_category() {
@@ -285,16 +249,6 @@ normalize_release_hinted_mods() {
 
 normalize_release_hinted_mods
 copy_packwiz_file_mods_for_detection
-
-if [ -s "$copied_list" ]; then
-  echo "Detecting CurseForge metadata for packwiz-files-backed mods..."
-  if ! ./packwiz -y curseforge detect; then
-    echo "::warning::CurseForge detection failed or found no usable matches; leaving unmatched packwiz-files entries as direct payloads."
-  fi
-  remove_shadowed_direct_metadata
-else
-  echo "No packwiz-files-backed mod JARs found for CurseForge detection."
-fi
 
 normalize_packwiz_files_for_category resourcepacks
 normalize_packwiz_files_for_category shaderpacks


### PR DESCRIPTION
- 问题：整合包客户端 `overrides/mods` 中包含 `taczaddon-1.20.1-1.1.8-hotfix2-for-new-soph.jar`，`manifest.json` 中也包含该 mod，导致 mod 被重复下载
- 原因：`normalize_packwiz_files_for_curseforge.sh` 文件自动识别匹配模组，写入 `manifest.json`
- 修改：关闭 mod 分类全局自动探测逻辑
- 验证：带有 release 标记的模组正常输出到 `manifest.json`；taczaddon 模组只存在于 `overrides/mods` 中