### PR TITLE
[fix] 移除制作成本5铁粒的罐头熔炼成铁锭的配方，避免刷铁

### DIFF
--- a/kubejs/server_scripts/Youkai's Homecoming/recipe.js
+++ b/kubejs/server_scripts/Youkai's Homecoming/recipe.js
@@ -17,6 +17,7 @@ ServerEvents.recipes(e => {
         'youkaishomecoming:oily_bean_curd_from_tofu_campfire',
         'youkaishomecoming:oily_bean_curd_from_tofu_smelting',
         'youkaishomecoming:oily_bean_curd_from_tofu_smoking',
+        'youkaishomecoming:iron_ingot_from_can_smelting',
         'youkaishomecoming:pods_cutting',
         'youkaishomecoming:red_velvet_cake',
         "youkaishomecoming:emptying/blood_bottle_emptying",


### PR DESCRIPTION
移除 youkaishomecoming:iron_ingot_from_can_smelting 配方，避免通过罐头熔炼获得铁锭。验证：node --check；git diff --check。