### PR TITLE
[mod] 更新 Tetra Compat 与 Quality Food Fluids

### DIFF
--- a/config/modpack_defaults/config/crash_assistant/modlist.json
+++ b/config/modpack_defaults/config/crash_assistant/modlist.json
@@ -1509,10 +1509,10 @@
     "name": "Quality Food",
     "version": "1.20.1-2.4.3-all"
   },
-  "quality_food_fluids-1.20.1-0.1.3.jar": {
+  "quality_food_fluids-1.20.1-0.1.4.jar": {
     "modId": "quality_food_fluids",
     "name": "Quality Food Fluids",
-    "version": "1.20.1-0.1.3"
+    "version": "1.20.1-0.1.4"
   },
   "Quark-4.0-462.jar": {
     "modId": "quark",
@@ -1769,10 +1769,10 @@
     "name": "tetracelium",
     "version": "1.20.1-1.3.2"
   },
-  "tetracompat-1.0.0-all.jar": {
+  "tetracompat-1.0.1-all.jar": {
     "modId": "tetracompat",
     "name": "Tetra Compat",
-    "version": "1.0.0-all"
+    "version": "1.0.1-all"
   },
   "tetratic-combat-expanded-1.20-2.8.3.jar": {
     "modId": "tetratic-combat-expanded",

--- a/mods/quality-food-fluids.pw.toml
+++ b/mods/quality-food-fluids.pw.toml
@@ -1,13 +1,13 @@
 name = "Quality Food Fluids"
-filename = "quality_food_fluids-1.20.1-0.1.3.jar"
+filename = "quality_food_fluids-1.20.1-0.1.4.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "f36b1c59ec1fcb06f814ec00b70a8e148906d43c"
+hash = "1937d8f520be03162789fbc6a1b2d9261c97af61"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8417695
+file-id = 8812069
 project-id = 1601403

--- a/mods/tetracompat.pw.toml
+++ b/mods/tetracompat.pw.toml
@@ -1,13 +1,13 @@
 name = "Tetra Compat"
-filename = "tetracompat-1.0.0-all.jar"
+filename = "tetracompat-1.0.1-all.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "52d2edc0b12c6f27f22f364ada866ae2cd36db29"
+hash = "fdb6df44b5ab9886c4d6afbb484954961d35be4d"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 6635564
+file-id = 8808131
 project-id = 1248348


### PR DESCRIPTION
## 变更内容

- 更新 Tetra Compat 至 1.0.1（CurseForge 文件 8808131）。
- 更新 Quality Food Fluids 至 0.1.4（CurseForge 文件 8812069）。
- 同步更新 Crash Assistant mod 文件基线。

## 验证

- 本地运行时 JAR 已同步，SHA-1 与 Packwiz 元数据一致。
- 旧版本 JAR 已移除。
- Crash Assistant JSON 校验和 `git diff --check` 通过。
- 未进行 Minecraft 完整启动或游戏内回归测试。
