### PR TITLE
[dev] 正式发布时，增加对按本体分发的模组是否在cf允许清单中的校验

### DIFF
--- a/.agents/skills/packwiz-assets/SKILL.md
+++ b/.agents/skills/packwiz-assets/SKILL.md
@@ -38,6 +38,11 @@ Use this workflow for modpack asset operations that touch `mods/`, `resourcepack
 
 Packwiz's side pruning, local sync, release patch builder, server export, and CurseForge export all include `tacz/`. Keep that root in sync when changing the asset workflow; otherwise TACZ metadata may refresh locally but be omitted from CI artifacts.
 
+### CurseForge 允许列表审计
+
+- 最新的 “Approved Non-CurseForge Mods” 列表应通过 Google Sheet 的 XLSX 导出获取：`https://docs.google.com/spreadsheets/d/176Wv-PZUo9hFxy6oC6N8tWdquBLPRtSuLbNK-r0_byM/export?format=xlsx`。XLSX 导出包含全部标签页；带 `gid` 的 CSV 导出只包含单个标签页，不能作为完整核对来源。
+- 正式 tag 的 `release-assets` job 会下载 Client artifact 后运行 `.github/workflows/scripts/audit_client_bundled_mods.py`，扫描 `overrides/mods/*.jar` 并按 JAR 的 `META-INF/mods.toml` 显示名比对允许列表。未找到的项目会产生 Actions warning；列表下载或解析失败也不得阻断发布。
+
 When old and new runtime JARs coexist, `update-packwiz-meta.ps1` selects the preferred newer filename and updates the existing metadata entry instead of creating a duplicate. Missing runtime JARs do not remove metadata by default; remove the `.pw.toml` explicitly, or use `-AllowRemovals` only when bulk removal is intentional and the runtime directory is complete.
 
 ### 短期 PR 分支上的 CurseForge 定向更新

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,11 +361,23 @@ jobs:
             prerelease_args=(--prerelease)
           fi
           gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --title "$title" --draft "${prerelease_args[@]}"
+      - name: 检出发布检查脚本
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          submodules: false
       - name: 下载客户端包 artifact
         uses: actions/download-artifact@v4
         with:
           name: "[Client]${{ env.MODPACK_NAME }}-${{ env.MODPACK_VERSION }}"
           path: release-artifacts/client
+      - name: 审计本体分发 mod 的 CurseForge 允许列表
+        if: env.IS_STABLE_RELEASE == 'true'
+        continue-on-error: true
+        run: >
+          python3 .github/workflows/scripts/audit_client_bundled_mods.py
+          --client-dir release-artifacts/client
       - name: 下载服务端包 artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/scripts/audit_client_bundled_mods.py
+++ b/.github/workflows/scripts/audit_client_bundled_mods.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Warn when CurseForge client overrides bundle mods outside the approved list."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import re
+import sys
+import tomllib
+import urllib.request
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+
+ALLOWLIST_XLSX_URL = (
+    "https://docs.google.com/spreadsheets/d/"
+    "176Wv-PZUo9hFxy6oC6N8tWdquBLPRtSuLbNK-r0_byM/export?format=xlsx"
+)
+MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+
+def normalize(value: str) -> str:
+    """Normalize display names without conflating different words."""
+    return re.sub(r"\s+", " ", value.strip()).casefold()
+
+
+def text_from_shared_string(element: ET.Element) -> str:
+    return "".join(node.text or "" for node in element.iter(f"{{{MAIN_NS}}}t"))
+
+
+def xlsx_cell_texts(data: bytes) -> tuple[set[str], int]:
+    """Return every non-empty cell value from every worksheet in an XLSX export."""
+    with zipfile.ZipFile(io.BytesIO(data)) as workbook:
+        shared_strings: list[str] = []
+        if "xl/sharedStrings.xml" in workbook.namelist():
+            root = ET.fromstring(workbook.read("xl/sharedStrings.xml"))
+            shared_strings = [text_from_shared_string(item) for item in root]
+
+        relationships = ET.fromstring(workbook.read("xl/_rels/workbook.xml.rels"))
+        targets = {relation.attrib["Id"]: relation.attrib["Target"] for relation in relationships}
+        sheets = ET.fromstring(workbook.read("xl/workbook.xml")).findall(
+            f".//{{{MAIN_NS}}}sheet"
+        )
+        values: set[str] = set()
+        for sheet in sheets:
+            relationship_id = sheet.attrib[f"{{{REL_NS}}}id"]
+            target = targets[relationship_id].lstrip("/")
+            path = target if target.startswith("xl/") else f"xl/{target}"
+            root = ET.fromstring(workbook.read(path))
+            for cell in root.findall(f".//{{{MAIN_NS}}}c"):
+                value = cell.find(f"{{{MAIN_NS}}}v")
+                if value is None or not value.text:
+                    continue
+                text = value.text
+                if cell.attrib.get("t") == "s":
+                    text = shared_strings[int(text)]
+                if normalized := normalize(text):
+                    values.add(normalized)
+        return values, len(sheets)
+
+
+def read_allowlist(url: str, local_path: Path | None) -> tuple[set[str], int]:
+    if local_path:
+        return xlsx_cell_texts(local_path.read_bytes())
+
+    request = urllib.request.Request(url, headers={"User-Agent": "CreateDelightRemake-release-audit"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return xlsx_cell_texts(response.read())
+
+
+def jar_mod_details(path: Path) -> tuple[str, str]:
+    """Return a human-readable display name and mod id, falling back to the filename."""
+    try:
+        with zipfile.ZipFile(path) as archive:
+            with archive.open("META-INF/mods.toml") as metadata_file:
+                metadata = tomllib.load(metadata_file)
+        mods = metadata.get("mods", [])
+        if mods:
+            mod = mods[0]
+            return str(mod.get("displayName") or mod.get("modId") or path.stem), str(
+                mod.get("modId") or "unknown"
+            )
+    except (KeyError, OSError, tomllib.TOMLDecodeError, zipfile.BadZipFile):
+        pass
+    return path.stem, "unknown"
+
+
+def bundled_mod_jars(client_dir: Path) -> list[Path]:
+    """Find JARs physically included in the exported CurseForge client package."""
+    candidates = (client_dir / "overrides" / "mods", client_dir / "mods")
+    return sorted({jar.resolve() for directory in candidates if directory.is_dir() for jar in directory.glob("*.jar")})
+
+
+def audit(client_dir: Path, allowlist: set[str]) -> list[tuple[Path, str, str]]:
+    findings = []
+    for jar in bundled_mod_jars(client_dir):
+        display_name, mod_id = jar_mod_details(jar)
+        if normalize(display_name) not in allowlist:
+            findings.append((jar, display_name, mod_id))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--client-dir", required=True, type=Path)
+    parser.add_argument("--allowlist-url", default=ALLOWLIST_XLSX_URL)
+    parser.add_argument("--allowlist-xlsx", type=Path)
+    args = parser.parse_args()
+
+    if not args.client_dir.is_dir():
+        print(f"Client artifact directory not found: {args.client_dir}", file=sys.stderr)
+        return 2
+
+    try:
+        allowlist, sheet_count = read_allowlist(args.allowlist_url, args.allowlist_xlsx)
+    except Exception as error:  # A workflow-level continue-on-error keeps release publishing unblocked.
+        print(f"Unable to load CurseForge approved-mod list: {error}", file=sys.stderr)
+        return 2
+
+    jars = bundled_mod_jars(args.client_dir)
+    print(
+        f"::notice::Loaded {len(allowlist)} values from {sheet_count} CurseForge allowlist worksheet(s); "
+        f"auditing {len(jars)} bundled mod JAR(s)."
+    )
+    for jar, display_name, mod_id in audit(args.client_dir, allowlist):
+        relative = jar.relative_to(args.client_dir.resolve())
+        print(
+            f"::warning file={relative.as_posix()}::Bundled mod is not in the CurseForge approved "
+            f"non-CurseForge list: {display_name} (mod id: {mod_id})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/scripts/test_audit_client_bundled_mods.py
+++ b/.github/workflows/scripts/test_audit_client_bundled_mods.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import importlib.util
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("audit_client_bundled_mods.py")
+SPEC = importlib.util.spec_from_file_location("audit_client_bundled_mods", SCRIPT)
+AUDIT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AUDIT)
+
+
+class ClientBundledModAuditTests(unittest.TestCase):
+    def write_mod_jar(self, root, filename, display_name, mod_id):
+        jar = root / "overrides" / "mods" / filename
+        jar.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(jar, "w") as archive:
+            archive.writestr(
+                "META-INF/mods.toml",
+                f'[[mods]]\nmodId = "{mod_id}"\ndisplayName = "{display_name}"\n',
+            )
+        return jar
+
+    def test_audit_uses_mod_display_name_from_client_overrides(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            allowed = self.write_mod_jar(root, "allowed.jar", "Allowed Mod", "allowed")
+            blocked = self.write_mod_jar(root, "blocked.jar", "Blocked Mod", "blocked")
+
+            findings = AUDIT.audit(root, {AUDIT.normalize("Allowed Mod")})
+
+            self.assertEqual(findings, [(blocked.resolve(), "Blocked Mod", "blocked")])
+            self.assertEqual(AUDIT.bundled_mod_jars(root), [allowed.resolve(), blocked.resolve()])
+
+    def test_xlsx_reader_combines_all_worksheets(self):
+        # XLSX files use shared strings; construct the smallest valid two-sheet export.
+        with tempfile.TemporaryDirectory() as directory:
+            workbook = Path(directory) / "allowlist.xlsx"
+            with zipfile.ZipFile(workbook, "w") as archive:
+                archive.writestr(
+                    "xl/workbook.xml",
+                    '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" '
+                    'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+                    '<sheets><sheet name="A-E" sheetId="1" r:id="rId1"/>'
+                    '<sheet name="U-Z" sheetId="2" r:id="rId2"/></sheets></workbook>',
+                )
+                archive.writestr(
+                    "xl/_rels/workbook.xml.rels",
+                    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+                    '<Relationship Id="rId1" Target="worksheets/sheet1.xml" Type="x"/>'
+                    '<Relationship Id="rId2" Target="worksheets/sheet2.xml" Type="x"/>'
+                    '</Relationships>',
+                )
+                archive.writestr(
+                    "xl/sharedStrings.xml",
+                    '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+                    '<si><t>First Mod</t></si><si><t>VVAddon</t></si></sst>',
+                )
+                for number, string_index in ((1, 0), (2, 1)):
+                    archive.writestr(
+                        f"xl/worksheets/sheet{number}.xml",
+                        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+                        f'<sheetData><row r="1"><c r="A1" t="s"><v>{string_index}</v></c></row>'
+                        '</sheetData></worksheet>',
+                    )
+
+            values, sheet_count = AUDIT.xlsx_cell_texts(workbook.read_bytes())
+
+            self.assertEqual(sheet_count, 2)
+            self.assertEqual(values, {"first mod", "vvaddon"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 内容

- 正式 tag 的 elease-assets 在下载 Client artifact 后，审计 overrides/mods 中本体分发的 JAR。
- 允许列表直接下载 Google Sheet XLSX 导出，覆盖全部工作表标签；未列入模组输出 Actions warning。
- 允许列表下载或解析异常设置为 continue-on-error，不阻断正式发布。
- 在 Packwiz skill 记录完整允许列表的获取方法。

## 验证

- python .github/workflows/scripts/test_audit_client_bundled_mods.py`n- python scripts/test-packwiz-distribution-filter.py`n- 实际下载 Google Sheet：7 个标签页、3209 个非空值
- 知识库校验与 Git diff 检查