### PR TITLE
[mod] 更新黑骑士铠甲至 1.0.9

### DIFF
--- a/config/modpack_defaults/config/crash_assistant/modlist.json
+++ b/config/modpack_defaults/config/crash_assistant/modlist.json
@@ -169,10 +169,10 @@
     "name": "Create: Bits 'n' Bobs",
     "version": "0.0.41"
   },
-  "blackknightarmor-1.0.3-20260321-2102-reobf.jar": {
+  "blackknightarmor-1.0.9.jar": {
     "modId": "blackknightarmor",
     "name": "Ice and Fire: Black Knight Expansion",
-    "version": "1.0.3-20260321-2102-reobf"
+    "version": "1.0.9"
   },
   "blueprint-1.20.1-7.1.3.jar": {
     "modId": "blueprint",

--- a/mods/black-knight-armor-and-food.pw.toml
+++ b/mods/black-knight-armor-and-food.pw.toml
@@ -1,13 +1,13 @@
 name = "Ice and Fire: Black Knight Expansion"
-filename = "blackknightarmor-1.0.3-20260321-2102-reobf.jar"
+filename = "blackknightarmor-1.0.9.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "3fa31fdcc90f94c7ea1582e72d4fb8b1420f1e83"
+hash = "7aaa774a535e2b5ab14d4c8de72baaf0e26ccca0"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7793529
+file-id = 8653476
 project-id = 1488468


### PR DESCRIPTION
## 内容

- 将 Ice and Fire: Black Knight Expansion 更新至 CurseForge 最新 1.0.9。
- 元数据锁定项目 1488468、文件 8653476。
- 同步更新 Crash Assistant 客户端模组基线。

## 验证

- update-packwiz-target.ps1 定向更新成功。
- 完整本地 Packwiz 同步成功，客户端下载并通过 SHA-1 7aaa774a535e2b5ab14d4c8de72baaf0e26ccca0 校验。
- Crash Assistant 基线生成及 Git diff 检查通过。