### PR TITLE
[fix] 临时禁用杠杆锤扳手旋转菜单以规避崩溃

### DIFF
--- a/kubejs/startup_scripts/disable_helve_wrench_menu.js
+++ b/kubejs/startup_scripts/disable_helve_wrench_menu.js
@@ -1,0 +1,18 @@
+StartupEvents.init(event => {
+    const RadialWrenchMenu = Java.loadClass(
+        'com.simibubi.create.content.contraptions.wrench.RadialWrenchMenu'
+    )
+    const ResourceLocation = Java.loadClass(
+        'net.minecraft.resources.ResourceLocation'
+    )
+
+    RadialWrenchMenu.BLOCK_BLACKLIST.add(
+        new ResourceLocation('vintageimprovements:helve_hammer')
+    )
+    RadialWrenchMenu.BLOCK_BLACKLIST.add(
+        new ResourceLocation('vintageimprovements:helve_structure')
+    )
+    RadialWrenchMenu.BLOCK_BLACKLIST.add(
+        new ResourceLocation('vintageimprovements:helve_kinetic')
+    )
+})


### PR DESCRIPTION
## 修改说明

临时禁用 Create 扳手对 Vintage Improvements 杠杆锤相关方块的旋转菜单。

## 问题原因

当前 Vintage Improvements 的杠杆锤结构在使用 Create 扳手旋转面板时，可能生成垂直方向的临时方块状态，导致客户端渲染崩溃：

```text
java.lang.IllegalStateException: Unable to get CCW facing of down
```

该问题可能发生在玩家手持 Create 扳手，使用快捷键对杠杆锤结构延伸部分打开旋转菜单时。

杠杆锤主体可以正常旋转，但可能出现旧方向的结构模型残留。

## 临时处理方案

新增 KubeJS 客户端脚本，将以下方块加入 Create 扳手旋转菜单黑名单：

```text
vintageimprovements:helve_hammer
vintageimprovements:helve_structure
vintageimprovements:helve_kinetic
```

脚本位置：

```text
kubejs/startup_scripts/disable_helve_wrench_menu.js
```

该方案只会禁用杠杆锤相关方块的扳手旋转菜单，不会移除杠杆锤，也不会影响其正常工作。

## 后续处理

这只是临时解决方案，目前已经向 Mod 作者提交了正式修复 PR。

等待 Mod 作者发布包含正式修复的新版本后，应删除本次 KubeJS 临时脚本，并恢复使用官方 Mod 版本。

如果暂时无法等待官方更新，也可以提供修复版 JAR 替代当前版本。
