### PR TITLE
[fix] 调整月球与金星 Alex 洞穴生成参数

### DIFF
--- a/kubejs/data/northstar/dimension/moon.json
+++ b/kubejs/data/northstar/dimension/moon.json
@@ -211,24 +211,24 @@
           "biome": "alexscaves:magnetic_caves",
           "parameters": {
             "temperature": [
-              -2,
-              2
+              -1.15,
+              0.15
             ],
             "humidity": [
-              -2,
-              2
+              -1.15,
+              0.15
             ],
             "continentalness": [
-              0.76,
-              0.78
+              2,
+              2
             ],
             "erosion": [
-              -2,
+              0,
               2
             ],
             "weirdness": [
-              -2,
-              2
+              -1,
+              1
             ],
             "depth": [
               1.5,

--- a/kubejs/data/northstar/dimension/venus.json
+++ b/kubejs/data/northstar/dimension/venus.json
@@ -151,27 +151,27 @@
           "biome": "alexscaves:toxic_caves",
           "parameters": {
             "temperature": [
-              -2,
-              2
+              -1.1,
+              1.4
             ],
             "humidity": [
-              -2,
-              2
+              -0.1,
+              0.1
             ],
             "continentalness": [
-              1.18,
-              1.25
+              1.15,
+              1.5
             ],
             "erosion": [
-              -2,
+              -0.25,
               2
             ],
             "weirdness": [
-              -2,
-              2
+              -1.5,
+              1.5
             ],
             "depth": [
-              1.5,
+              1.7,
               2
             ],
             "offset": 0

--- a/kubejs/data/northstar/worldgen/noise_settings/venus.json
+++ b/kubejs/data/northstar/worldgen/noise_settings/venus.json
@@ -1,0 +1,402 @@
+{
+  "sea_level": -80,
+  "disable_mob_generation": false,
+  "aquifers_enabled": false,
+  "ore_veins_enabled": false,
+  "legacy_random_source": false,
+  "default_block": {
+    "Name": "northstar:venus_stone"
+  },
+  "default_fluid": {
+    "Name": "minecraft:lava",
+    "Properties": {
+      "level": "0"
+    }
+  },
+  "noise": {
+    "min_y": -64,
+    "height": 384,
+    "size_horizontal": 1,
+    "size_vertical": 2
+  },
+  "noise_router": {
+    "barrier": {
+      "type": "minecraft:noise",
+      "noise": "minecraft:aquifer_barrier",
+      "xz_scale": 1,
+      "y_scale": 0.75
+    },
+    "fluid_level_floodedness": 0,
+    "fluid_level_spread": 0,
+    "lava": {
+      "type": "minecraft:noise",
+      "noise": "minecraft:aquifer_lava",
+      "xz_scale": 1,
+      "y_scale": 1
+    },
+    "temperature": {
+      "type": "minecraft:shifted_noise",
+      "noise": "minecraft:temperature",
+      "xz_scale": 0.25,
+      "y_scale": 0,
+      "shift_x": "minecraft:shift_x",
+      "shift_y": -15,
+      "shift_z": "minecraft:shift_z"
+    },
+    "vegetation": 0,
+    "continents": "minecraft:overworld/continents",
+    "erosion": "minecraft:overworld/erosion",
+    "depth": "minecraft:overworld/depth",
+    "ridges": "minecraft:overworld/ridges",
+    "initial_density_without_jaggedness": {
+      "type": "minecraft:add",
+      "argument1": 0.1171875,
+      "argument2": {
+        "type": "minecraft:mul",
+        "argument1": {
+          "type": "minecraft:y_clamped_gradient",
+          "from_y": -64,
+          "to_y": -40,
+          "from_value": 0,
+          "to_value": 1
+        },
+        "argument2": {
+          "type": "minecraft:add",
+          "argument1": -0.1171875,
+          "argument2": {
+            "type": "minecraft:add",
+            "argument1": -0.078125,
+            "argument2": {
+              "type": "minecraft:mul",
+              "argument1": {
+                "type": "minecraft:y_clamped_gradient",
+                "from_y": 240,
+                "to_y": 256,
+                "from_value": 1,
+                "to_value": 0
+              },
+              "argument2": {
+                "type": "minecraft:add",
+                "argument1": 0.078125,
+                "argument2": {
+                  "type": "minecraft:clamp",
+                  "input": {
+                    "type": "minecraft:add",
+                    "argument1": -0.703125,
+                    "argument2": {
+                      "type": "minecraft:mul",
+                      "argument1": 4,
+                      "argument2": {
+                        "type": "minecraft:quarter_negative",
+                        "argument": {
+                          "type": "minecraft:mul",
+                          "argument1": "minecraft:overworld/depth",
+                          "argument2": {
+                            "type": "minecraft:cache_2d",
+                            "argument": "minecraft:overworld/factor"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "min": -64,
+                  "max": 150
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "final_density": {
+      "type": "minecraft:min",
+      "argument1": {
+        "type": "minecraft:squeeze",
+        "argument": {
+          "type": "minecraft:mul",
+          "argument1": 0.64,
+          "argument2": {
+            "type": "minecraft:interpolated",
+            "argument": {
+              "type": "minecraft:blend_density",
+              "argument": {
+                "type": "minecraft:add",
+                "argument1": 0.1171875,
+                "argument2": {
+                  "type": "minecraft:mul",
+                  "argument1": {
+                    "type": "minecraft:y_clamped_gradient",
+                    "from_y": -64,
+                    "to_y": -40,
+                    "from_value": 0,
+                    "to_value": 1
+                  },
+                  "argument2": {
+                    "type": "minecraft:add",
+                    "argument1": -0.1171875,
+                    "argument2": {
+                      "type": "minecraft:add",
+                      "argument1": -0.078125,
+                      "argument2": {
+                        "type": "minecraft:mul",
+                        "argument1": {
+                          "type": "minecraft:y_clamped_gradient",
+                          "from_y": 240,
+                          "to_y": 256,
+                          "from_value": 1,
+                          "to_value": 0
+                        },
+                        "argument2": {
+                          "type": "minecraft:add",
+                          "argument1": 0.078125,
+                          "argument2": {
+                            "type": "minecraft:range_choice",
+                            "input": "minecraft:overworld/sloped_cheese",
+                            "min_inclusive": -1000000,
+                            "max_exclusive": 1.5625,
+                            "when_in_range": {
+                              "type": "minecraft:min",
+                              "argument1": "minecraft:overworld/sloped_cheese",
+                              "argument2": {
+                                "type": "minecraft:mul",
+                                "argument1": 5,
+                                "argument2": "minecraft:overworld/caves/entrances"
+                              }
+                            },
+                            "when_out_of_range": {
+                              "type": "minecraft:max",
+                              "argument1": {
+                                "type": "minecraft:min",
+                                "argument1": {
+                                  "type": "minecraft:min",
+                                  "argument1": {
+                                    "type": "minecraft:add",
+                                    "argument1": {
+                                      "type": "minecraft:mul",
+                                      "argument1": 4,
+                                      "argument2": {
+                                        "type": "minecraft:square",
+                                        "argument": {
+                                          "type": "minecraft:noise",
+                                          "noise": "minecraft:cave_layer",
+                                          "xz_scale": 1,
+                                          "y_scale": 8
+                                        }
+                                      }
+                                    },
+                                    "argument2": {
+                                      "type": "minecraft:add",
+                                      "argument1": {
+                                        "type": "minecraft:clamp",
+                                        "input": {
+                                          "type": "minecraft:add",
+                                          "argument1": 0.27,
+                                          "argument2": {
+                                            "type": "minecraft:noise",
+                                            "noise": "minecraft:cave_cheese",
+                                            "xz_scale": 1,
+                                            "y_scale": 0.6666666666666666
+                                          }
+                                        },
+                                        "min": -1,
+                                        "max": 1
+                                      },
+                                      "argument2": {
+                                        "type": "minecraft:clamp",
+                                        "input": {
+                                          "type": "minecraft:add",
+                                          "argument1": 1.5,
+                                          "argument2": {
+                                            "type": "minecraft:mul",
+                                            "argument1": -0.64,
+                                            "argument2": "minecraft:overworld/sloped_cheese"
+                                          }
+                                        },
+                                        "min": 0,
+                                        "max": 0.5
+                                      }
+                                    }
+                                  },
+                                  "argument2": "minecraft:overworld/caves/entrances"
+                                },
+                                "argument2": {
+                                  "type": "minecraft:add",
+                                  "argument1": "minecraft:overworld/caves/spaghetti_2d",
+                                  "argument2": "minecraft:overworld/caves/spaghetti_roughness_function"
+                                }
+                              },
+                              "argument2": {
+                                "type": "minecraft:range_choice",
+                                "input": "minecraft:overworld/caves/pillars",
+                                "min_inclusive": -1000000,
+                                "max_exclusive": 0.25,
+                                "when_in_range": -1000000,
+                                "when_out_of_range": "minecraft:overworld/caves/pillars"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "argument2": "minecraft:overworld/caves/noodle"
+    },
+    "vein_toggle": 0,
+    "vein_ridged": 0,
+    "vein_gap": 0
+  },
+  "spawn_target": [ ],
+  "surface_rule": {
+    "type": "minecraft:sequence",
+    "sequence": [
+      {
+        "type": "minecraft:sequence",
+        "sequence": [
+          {
+            "type": "minecraft:condition",
+            "if_true": {
+              "type": "minecraft:vertical_gradient",
+              "random_name": "minecraft:bedrock_floor",
+              "true_at_and_below": {
+                "above_bottom": 0
+              },
+              "false_at_and_above": {
+                "above_bottom": 5
+              }
+            },
+            "then_run": {
+              "type": "minecraft:block",
+              "result_state": {
+                "Name": "minecraft:bedrock"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "minecraft:condition",
+        "if_true": {
+          "type": "minecraft:biome",
+          "biome_is": [
+            "alexscaves:toxic_caves"
+          ]
+        },
+        "then_run": {
+          "type": "minecraft:block",
+          "result_state": {
+            "Name": "alexscaves:radrock"
+          }
+        }
+      },
+      {
+        "type": "minecraft:condition",
+        "if_true": {
+          "type": "minecraft:vertical_gradient",
+          "random_name": "northstar:venus_deep_stone",
+          "true_at_and_below": {
+            "above_bottom": 52
+          },
+          "false_at_and_above": {
+            "above_bottom": 64
+          }
+        },
+        "then_run": {
+          "type": "minecraft:block",
+          "result_state": {
+            "Name": "northstar:venus_deep_stone"
+          }
+        }
+      },
+      {
+        "type": "minecraft:sequence",
+        "sequence": [
+          {
+            "type": "minecraft:condition",
+            "if_true": {
+              "type": "minecraft:above_preliminary_surface"
+            },
+            "then_run": {
+              "type": "minecraft:sequence",
+              "sequence": [
+                {
+                  "type": "minecraft:condition",
+                  "if_true": {
+                    "type": "minecraft:biome",
+                    "biome_is": [
+                      "northstar:venusian_plains"
+                    ]
+                  },
+                  "then_run": {
+                    "type": "minecraft:condition",
+                    "if_true": {
+                      "type": "minecraft:stone_depth",
+                      "offset": 4,
+                      "surface_type": "floor",
+                      "add_surface_depth": false,
+                      "secondary_depth_range": 0
+                    },
+                    "then_run": {
+                      "type": "minecraft:condition",
+                      "if_true": {
+                        "type": "minecraft:water",
+                        "offset": 0,
+                        "surface_depth_multiplier": 0,
+                        "add_stone_depth": false
+                      },
+                      "then_run": {
+                        "type": "minecraft:block",
+                        "result_state": {
+                          "Name": "northstar:venus_stone"
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "minecraft:condition",
+                  "if_true": {
+                    "type": "minecraft:biome",
+                    "biome_is": [
+                      "northstar:venusian_wastes"
+                    ]
+                  },
+                  "then_run": {
+                    "type": "minecraft:condition",
+                    "if_true": {
+                      "type": "minecraft:stone_depth",
+                      "offset": 4,
+                      "surface_type": "floor",
+                      "add_surface_depth": false,
+                      "secondary_depth_range": 0
+                    },
+                    "then_run": {
+                      "type": "minecraft:condition",
+                      "if_true": {
+                        "type": "minecraft:water",
+                        "offset": 0,
+                        "surface_depth_multiplier": 0,
+                        "add_stone_depth": false
+                      },
+                      "then_run": {
+                        "type": "minecraft:block",
+                        "result_state": {
+                          "Name": "northstar:volcanic_ash"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
调整月球磁场洞穴和金星毒化洞穴的多噪声参数，使洞穴保持足够规模、连通性与合适的出现频率。金星额外补充独立噪声设置中的 Radrock 表面规则，确保毒化洞穴洞壁正确生成。验证：JSON 解析、git diff --check 与游戏内回归均已通过。