### PR TITLE
[fix] 回移出售箱结算修复至 release-v050x

### DIFF
--- a/kubejs/server_scripts/mbd2/sell_bin.js
+++ b/kubejs/server_scripts/mbd2/sell_bin.js
@@ -46,6 +46,7 @@ ServerEvents.tick(e => {
 MBDMachineEvents.onTick("createdelight:sell_bin", e => {
     const {machine} = e.event
     if ((machine.level.dayTime() % 24000) != 20) return
+    if (!machine.customData.hasUUID("owner")) return
     let player = machine.level.getPlayerByUUID(machine.customData.getUUID("owner"))
     if (player == null) return
     let itemSlots = machine.getCapability(ForgeCapabilities.ITEM_HANDLER).orElse(null)
@@ -76,8 +77,8 @@ MBDMachineEvents.onTick("createdelight:sell_bin", e => {
                     break
             }
         }
-        values = values + slotValue
-        if(slotValue > 1 && slotValue != 0) {
+        if (slotValue >= 1) {
+            values += slotValue
             trade.append(global.MoneyUtil.convertBaseValueToString(slotValue))
             tradeList.push(trade)
             itemSlot.shrink(itemSlot.count)


### PR DESCRIPTION
## 修改说明

将主线 PR #2257 的出售箱每日结算修复回移至 release-v050x。

## 修复内容

- 仅在槽位价值至少为 1 时累计收入并清空物品，避免低价值物品重复出售。
- 无 owner 的出售箱直接跳过结算，避免自动化放置时读取缺失 UUID。

## 验证

- node --check kubejs/server_scripts/mbd2/sell_bin.js
- git diff --check