### PR TITLE
[feat] v0.5.0.10-test 版本更新

### DIFF
--- a/modpack.toml
+++ b/modpack.toml
@@ -1,6 +1,6 @@
 name = "Create-Delight-Remake"
 author = "JSI"
-version = "v0.5.0.9-test"
+version = "v0.5.0.10-test"
 pack-format = "packwiz:1.1.0"
 
 [versions]


### PR DESCRIPTION
版本号更新: → v0.5.0.10-test

**更新内容**:
- [fix] 回滚 #2180 方纹更新，因为新版本画风和机械动力不贴合，且和整合包的部分材质不一致 (#2265)