### PR TITLE
[fix] 修复任务书失效图标并隐藏未开放锻造节点

### DIFF
--- a/config/ftbquests/quests/chapters/Freedom_of_Movement.snbt
+++ b/config/ftbquests/quests/chapters/Freedom_of_Movement.snbt
@@ -725,7 +725,7 @@
 			subtitle: "什么叫做机械飞升啊（&e后仰&r）"
 			tasks: [{
 				id: "121589E89F15DAA9"
-				item: "create_enchantment_industry:enchanting_guide"
+				item: "create_enchantment_industry:enchanting_template"
 				type: "item"
 			}]
 			title: "&1附魔工业！！！"
@@ -809,7 +809,7 @@
 			subtitle: "烈焰人使用超越经验可增加一级附魔，&e突破极限！"
 			tasks: [{
 				id: "360698F9348E1A09"
-				item: "create_enchantment_industry:hyper_experience_bottle"
+				item: "create_enchantment_industry:super_experience_nugget"
 				type: "item"
 			}]
 			title: "这是...&1超越附魔？"

--- a/config/ftbquests/quests/chapters/Legendary_Creatures.snbt
+++ b/config/ftbquests/quests/chapters/Legendary_Creatures.snbt
@@ -153,7 +153,7 @@
 				Count: 1
 				id: "ftbquests:custom_icon"
 				tag: {
-					Icon: "northstar:textures/environment/mars_far_sky.png"
+					Icon: "northstar:textures/planet/solar_system/mars_sky.png"
 				}
 			}
 			id: "1BEE7AD2537F2428"

--- a/config/ftbquests/quests/chapters/Tetra_Ranged_Defense.snbt
+++ b/config/ftbquests/quests/chapters/Tetra_Ranged_Defense.snbt
@@ -474,6 +474,7 @@
 				}
 			}
 			id: "39B89423DB035787"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -1039,6 +1040,7 @@
 				}
 			}
 			id: "6C66E2F46BDE988C"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{

--- a/config/ftbquests/quests/chapters/Tetra_Weapons.snbt
+++ b/config/ftbquests/quests/chapters/Tetra_Weapons.snbt
@@ -2739,6 +2739,7 @@
 				}
 			}
 			id: "614F0E01A8C91444"
+			invisible: true
 			shape: "square"
 			size: 2.5d
 			tasks: [{
@@ -2771,6 +2772,7 @@
 				}
 			}
 			id: "3244AEB824727F64"
+			invisible: true
 			shape: "diamond"
 			size: 2.0d
 			tasks: [{
@@ -2807,6 +2809,7 @@
 				}
 			}
 			id: "414735ED0517B45E"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -2841,6 +2844,7 @@
 				}
 			}
 			id: "3434D0C066A01FFF"
+			invisible: true
 			shape: "diamond"
 			size: 2.0d
 			tasks: [{
@@ -2878,6 +2882,7 @@
 				}
 			}
 			id: "478E54ABFCD65A6B"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -2911,6 +2916,7 @@
 				}
 			}
 			id: "610741598ABB0016"
+			invisible: true
 			shape: "diamond"
 			size: 2.0d
 			tasks: [{
@@ -2948,6 +2954,7 @@
 				}
 			}
 			id: "1B75B62CA671A1FC"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -2984,6 +2991,7 @@
 				}
 			}
 			id: "5FB6743F20736C8B"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -3021,6 +3029,7 @@
 				}
 			}
 			id: "00951F65B81F623B"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -3054,6 +3063,7 @@
 				}
 			}
 			id: "04CB876F2F392D4E"
+			invisible: true
 			shape: "diamond"
 			size: 2.0d
 			tasks: [{
@@ -3091,6 +3101,7 @@
 				}
 			}
 			id: "3D43068462F0B430"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -3128,6 +3139,7 @@
 				}
 			}
 			id: "5774CF914D62E9B0"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -3164,6 +3176,7 @@
 				}
 			}
 			id: "27DE94ADDA67C5DE"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -3198,6 +3211,7 @@
 				}
 			}
 			id: "038E933716D9DB8B"
+			invisible: true
 			shape: "diamond"
 			size: 2.0d
 			tasks: [{
@@ -3235,6 +3249,7 @@
 				}
 			}
 			id: "3C5C95196FC73CE1"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -3272,6 +3287,7 @@
 				}
 			}
 			id: "3644E71B1250AE65"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{
@@ -3306,6 +3322,7 @@
 				}
 			}
 			id: "6A427B480484384E"
+			invisible: true
 			shape: "diamond"
 			size: 2.0d
 			tasks: [{
@@ -3343,6 +3360,7 @@
 				}
 			}
 			id: "355F268A3037A14B"
+			invisible: true
 			shape: "circle"
 			size: 1.75d
 			tasks: [{

--- a/config/ftbquests/quests/chapters/Youkais_Homecoming.snbt
+++ b/config/ftbquests/quests/chapters/Youkais_Homecoming.snbt
@@ -529,7 +529,7 @@
 		}
 		{
 			height: 2.0d
-			image: "farmersdelight:block/basket_side"
+			image: "farmersdelight:block/bamboo_basket_side"
 			rotation: 0.0d
 			width: 2.0d
 			x: 13.5d

--- a/scripts/generate-tetra-compendium.py
+++ b/scripts/generate-tetra-compendium.py
@@ -41,6 +41,13 @@ OUTPUTS = {
     "scrolls": "Tetra_Scrolls.snbt",
 }
 
+# Keep these unfinished entries and their dependents in place, but hidden.
+HIDDEN_QUEST_SEEDS = {
+    "melee:item:mmt_iron_staff",
+    "ranged:module:bow/laminated_stave",
+    "ranged:module:modular_mmt_bow/laminated_stave",
+}
+
 REMOVED_CHAPTERS = (
     "Tetra_Compendium.snbt",
     "Tetra_Armor.snbt",
@@ -689,6 +696,7 @@ class QuestNode:
     description: list[str]
     dependencies: list[str] = field(default_factory=list)
     hide_dependency_lines: bool = False
+    invisible: bool = False
 
     @property
     def id(self) -> str:
@@ -1250,6 +1258,8 @@ class CompendiumGenerator:
             lines.extend(self._stack_snbt(node.icon, 2)[1:-1])
             lines.append("\t}")
         lines.append(f"\tid: {quote(node.id)}")
+        if node.invisible:
+            lines.append("\tinvisible: true")
         lines.append(f"\tshape: {quote(node.shape)}")
         lines.append(f"\tsize: {node.size:.2f}d")
         lines.append("\ttasks: [{")
@@ -1272,6 +1282,15 @@ class CompendiumGenerator:
         root_node: QuestNode,
         nodes: list[QuestNode],
     ) -> str:
+        hidden_ids = {node.id for node in nodes if node.seed in HIDDEN_QUEST_SEEDS}
+        while True:
+            dependent_ids = {node.id for node in nodes if hidden_ids.intersection(node.dependencies)}
+            if dependent_ids.issubset(hidden_ids):
+                break
+            hidden_ids.update(dependent_ids)
+        for node in nodes:
+            if node.id in hidden_ids:
+                node.invisible = True
         chapter_id = stable_id(f"chapter:{key}")
         lines = [
             "{",


### PR DESCRIPTION
修复任务书引用旧贴图、旧物品 ID 导致的紫黑图标，并原地隐藏当前不开放的法杖和层压臂节点。

- 篮子装饰图改为 Farmer's Delight 1.3.2 中存在的 `farmersdelight:block/bamboo_basket_side`。
- 模块化法杖及其全部依赖节点（18 个）、两个层压臂节点增加 `invisible: true`。不移动章节，不更换任务 ID、依赖或坐标；生成器同步保留隐藏规则。
- 火星山峰图标改用 Northstar 0.6.4 的 `northstar:textures/planet/solar_system/mars_sky.png`。
- “&1附魔工业！！！”与“这是...&1超越附魔？”分别检测当前的附魔模板、超越经验颗粒，替换失效的 `enchanting_guide`、`hyper_experience_bottle`。改名后的附魔手册配方依赖已关闭的旧版附魔器功能，因此没有作为替代目标。

验证：41 个章节 SNBT 均解析通过，2509 个任务 ID 保持不变；20 个隐藏节点的依赖闭包和生成器输出核对通过；替代图标的模型、贴图及物品注册已核对运行 JAR，`git diff --check` 通过。尚未进行游戏内任务书视觉回归。

本 PR 独立基于 `release-v050x`，不包含 #2271 的神化移除改动。
