### PR TITLE
[fix] 补齐渊海水生生物缺氧免疫

### DIFF
--- a/docs/dev-knowledge/content-map.md
+++ b/docs/dev-knowledge/content-map.md
@@ -4,6 +4,7 @@
 
 | 领域 | 玩家可见变化 | 实现概览 | 主要位置 | 相关文档 | 状态 |
 |---|---|---|---|---|---|
+| 渊海生物缺氧适应 | 渊海陷窟迁入木卫二后，原生与模组追加的渊海水生生物免疫 Northstar 缺氧伤害，普通怪物不新增豁免。 | 沿用已有实体标签组，并以独立的 `europanAbyssalOxygenEntities` 补齐遗漏物种；仅补缺氧免疫，不额外改变温度抗性。 | `kubejs/server_scripts/Create Northstar/tag.js`、`kubejs/data/alexscaves/worldgen/biome/abyssal_chasm.json` | 无 | 原生刷怪表与生成势能表的水生实体标签覆盖已静态核对；需 `/reload` 或重启后在游戏内验证。 |
 | 结构稀疏化 | 新生成区块中的结构间距统一提高至 1.5 倍，降低高结构模组数量带来的重复探索；Alex's Caves 结构保持原频率以避免上游已知的生成兼容问题。 | `Sparse Structures` 全局修改结构集间距，以结构 ID 派生盐值减少重叠；配置对 14 个 Alex's Caves 结构集进行单独覆盖。 | `mods/sparse-structures.pw.toml`、`config/sparsestructures.json5` | Issue #2045 | 已核验 Forge 1.20.1 JAR 的默认配置字段并生成完整性清单；需重启，并在新生成区块验证结构分布。 |
 | 荷花世界生成 | 荷花可在所有标记为 Forge 沼泽的群系生成，覆盖原版沼泽、红树林沼泽及 Terralith 的冰沼、兰花沼泽；每个新生成区块都会尝试生成，仍仅适用于 1-3 格水深且水底为泥土标签或黏土的位置。 | KubeJS 数据包覆盖 Festival Delicacies 的荷花 biome modifier 和 placed feature，改用 `#forge:is_swamp` 并将稀有度筛选设为 `chance: 1`。 | `kubejs/data/festival_delicacies/{forge/biome_modifier/lotus,worldgen/placed_feature/patch_lotus}.json` | 无 | JSON 静态校验通过；已在游戏重新进入世界时完成数据包加载，需在新生成区块验证。 |
 | 节气骨粉催熟 | 骨粉不再因作物所处季节或湿度不适宜而催熟失败；自然生长仍受节气与湿度限制。 | 保持节气作物和湿度控制开启，仅关闭 `RestrictBoneMeal`。 | `config/eclipticseasons-common.toml` | 无 | 配置已修改并完成静态核对；需重启或重新加载配置后游戏内验证。 |

--- a/kubejs/server_scripts/Create Northstar/tag.js
+++ b/kubejs/server_scripts/Create Northstar/tag.js
@@ -53,6 +53,7 @@ const europanAbyssalEntities = [
     "alexscaves:mine_guardian",
     "alexscaves:sea_pig",
     "alexscaves:tripodfish",
+    "alexsmobs:giant_squid",
     "minecraft:dolphin",
     "minecraft:squid"
 ]
@@ -69,6 +70,16 @@ const cataclysmEuropanAquaticEntities = [
     "cataclysm:amethyst_crab",
     "cataclysm:the_leviathan",
     "cataclysm:the_baby_leviathan"
+]
+
+// 补齐模组追加的渊海水生生物；不包括普通怪物，不额外赋予温度抗性。
+const europanAbyssalOxygenEntities = [
+    "alexsmobs:blobfish",
+    "alexsmobs:cachalot_whale",
+    "alexsmobs:comb_jelly",
+    "alexsmobs:frilled_shark",
+    "iceandfire:siren",
+    "iceandfire:sea_serpent"
 ]
 
 const lunarFarsideEntities = [
@@ -146,6 +157,7 @@ ServerEvents.tags("entity_type", e => {
         "#createdelight:can_survive_northstar"
     )
     e.add("northstar:doesnt_require_oxygen", europanAbyssalEntities)
+    e.add("northstar:doesnt_require_oxygen", europanAbyssalOxygenEntities)
     e.add("northstar:doesnt_require_oxygen", cataclysmEuropanAquaticEntities)
     e.add("northstar:doesnt_require_oxygen", lunarFarsideEntities)
     e.add("northstar:doesnt_require_oxygen", cataclysmLunarFactoryEntities)


### PR DESCRIPTION
渊海陷窟迁至木卫二后，部分追加的水生生物缺少 Northstar 缺氧免疫，生成后会受到星球环境伤害。

- 为大王乌贼、水滴鱼、抹香鲸、栉水母、皱鳃鲨、海妖和海蛇补齐缺氧免疫。
- 大王乌贼沿用现有渊海实体组，同时获得低温免疫；其余六种仅新增缺氧免疫。
- 苦力怕、蜘蛛、女巫等普通怪物不新增豁免，保留已有环境标签。
- 同步记录渊海水生生物的环境适应规则。

验证：JavaScript 语法、25 种渊海水生实体的标签覆盖、普通怪物排除及知识库检查通过，`git diff --check` 通过。改动已保留在当前整合包测试目录，需 `/reload` 或重启后测试；尚未进行游戏内回归。
