### PR TITLE
[fix] 补充龙血任务的百合采集提示

### DIFF
--- a/config/ftbquests/quests/chapters/Legendary_Creatures.snbt
+++ b/config/ftbquests/quests/chapters/Legendary_Creatures.snbt
@@ -110,6 +110,7 @@
 		}
 		{
 			dependencies: ["17D9DB61D8A8DC98"]
+			description: ["制作龙血所需的对应百合，可以使用剪刀右键百合簇采集。采收后可用骨粉催熟百合簇，再次采收。"]
 			id: "556B30C5A2ED0D94"
 			tasks: [{
 				id: "67FA75267D4F62AF"
@@ -682,6 +683,7 @@
 		}
 		{
 			dependencies: ["7C9857F0DAD1E04E"]
+			description: ["制作龙血所需的对应百合，可以使用剪刀右键百合簇采集。采收后可用骨粉催熟百合簇，再次采收。"]
 			id: "34E1D8B005ACD4CF"
 			tasks: [{
 				id: "0C7FB94BA4DD0E01"
@@ -744,6 +746,7 @@
 		}
 		{
 			dependencies: ["1D34EBFF1D60EA85"]
+			description: ["制作龙血所需的对应百合，可以使用剪刀右键百合簇采集。采收后可用骨粉催熟百合簇，再次采收。"]
 			id: "0961AD88179B18C4"
 			tasks: [{
 				id: "3FC907D6EA3DAE91"


### PR DESCRIPTION
火龙血、冰龙血和雷龙血任务缺少百合原料的采集提示。本次在三个任务节点中补充：使用剪刀右键百合簇采集百合，采收后可使用骨粉催熟并再次采收。

仅新增三条任务描述，不调整配方、依赖或任务目标。

验证：核对三个节点的描述与变更范围，`git diff --check` 通过。未进行游戏内显示验证。
