### PR TITLE
[fix] 修正 Gateways 惩罚提示和默认值翻译（050x）

### DIFF
--- a/kubejs/assets/gateways/lang/zh_cn.json
+++ b/kubejs/assets/gateways/lang/zh_cn.json
@@ -13,7 +13,7 @@
 
 	"tooltip.gateways.scroll": "[滚轮翻页]",
 	"tooltip.gateways.shift": "[按住Shift以查看波次信息]",
-    "tooltip.gateways.ctrl": "[按住Ctrl以查看最终奖励]",
+    "tooltip.gateways.ctrl": "[按住Ctrl以查看惩罚]",
     "tooltip.gateways.alt": "[按住Alt以查看规则变更]",
     "tooltip.gateways.true": "已启用",
     "tooltip.gateways.false": "禁用",
@@ -61,7 +61,7 @@
 	"failure.gateways.summon": "生成 %s",
 	"failure.gateways.chance": "%s 几率 %s",
 
-	"rule.gateways.default": "[是 %s]",
+	"rule.gateways.default": "[默认是 %s]",
 	"rule.gateways.spawn_range": "生成范围: %s",
 	"rule.gateways.leash_range": "拴绳范围: %s",
 	"rule.gateways.allow_discarding": "允许丢弃: %s",


### PR DESCRIPTION
修正 Gateways 的两处中文提示：

- Ctrl 展开提示由「最终奖励」改为「惩罚」。
- 规则默认值提示由「[是 %s]」改为「[默认是 %s]」，保留占位符。

验证：JSON 解析、两处语言键取值校验、git diff --check 均通过。
